### PR TITLE
Add list of typos in official API files

### DIFF
--- a/translation_helper/known_typos.json
+++ b/translation_helper/known_typos.json
@@ -1,0 +1,11 @@
+{
+  "de" : [
+    "Kollisionssensor: Multiple spaces missing"
+  ],
+  "en": [],
+  "es": [],
+  "fr": [],
+  "it": [],
+  "pl": [],
+  "pt" : []
+}

--- a/translation_helper/translate.py
+++ b/translation_helper/translate.py
@@ -279,6 +279,13 @@ output_text = output_text.replace('–', "-")
 # Remove unique dots
 output_text = output_text.replace('•', '')
 
+# Add known typos to the ToDo
+known_typos = json.load(open('known_typos.json', encoding = "utf8"))[lang]
+if known_typos :
+    manual_stuff += "Be aware of the following typos! You need to fix them before merging:\n"
+for typo in known_typos:
+    manual_stuff += ('%s\n' % typo)
+
 # write output
 output_file = open("translation.coffee","w",encoding="utf8")
 output_file.write(output_text)


### PR DESCRIPTION
Added a list of typos in the official API. When doing a mass merge I almost re-introduced the one that there is and if we find others later we might want to keep a list (though I understand if this seems overkill).