### PR TITLE
Fix issue with using the translation script for English

### DIFF
--- a/translation_helper/phrase_translations.json
+++ b/translation_helper/phrase_translations.json
@@ -16,6 +16,21 @@
       "contains": "Staffel, die %s enthält"
     },
     {
+      "language": "en",
+      "requires": "CHANGE ME %s",
+      "adds": "CHANGE ME%s",
+      "only": "CHANGE ME%s",
+      "variable_cost": "CHANGE ME",
+      "or": "CHANGE ME",
+      "SMALL": "CHANGE ME",
+      "MEDIUM": "CHANGE ME",
+      "LARGE": "CHANGE ME",
+      "Rebel Alliance": "CHANGE ME",
+      "Scum and Villainy": "CHANGE ME",
+      "Galactic Empire": "CHANGE ME",
+      "contains": "CHANGE ME%s"
+    },
+    {
       "language": "es",
       "requires": "CHANGE ME %s",
       "adds": "CHANGE ME%s",

--- a/translation_helper/ship_translations.json
+++ b/translation_helper/ship_translations.json
@@ -2,6 +2,7 @@
   "1": {
     "name_yasb": "YT-1300",
     "name_de": "Modifizierter leichter YT-1300-Frachter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -11,6 +12,7 @@
   "3": {
     "name_yasb": "StarViper",
     "name_de": "Angriffsplattform der Sternenviper-Klasse",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -20,6 +22,7 @@
   "4": {
     "name_yasb": "Scurrg H-6 Bomber",
     "name_de": "Scurrg-H-6-Bomber",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -29,6 +32,7 @@
   "5": {
     "name_yasb": "YT-2400",
     "name_de": "Leichter YT-2400-Frachter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -38,6 +42,7 @@
   "6": {
     "name_yasb": "Auzituck Gunship",
     "name_de": "Auzituck-Kanonenboot",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -47,6 +52,7 @@
   "7": {
     "name_yasb": "Kihraxz Fighter",
     "name_de": "Kihraxz-Jäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -56,6 +62,7 @@
   "8": {
     "name_yasb": "Sheathipede-Class Shuttle",
     "name_de": "Raumfähre der Sheathipede-Klasse",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -65,6 +72,7 @@
   "9": {
     "name_yasb": "Quadjumper",
     "name_de": "Quadrijet-Transferschlepper",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -74,6 +82,7 @@
   "10": {
     "name_yasb": "Firespray-31",
     "name_de": "Patrouillenboot der Firespray-Klasse",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -83,6 +92,7 @@
   "11": {
     "name_yasb": "TIE Fighter",
     "name_de": "TIE/ln-Jäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -92,6 +102,7 @@
   "12": {
     "name_yasb": "Y-Wing",
     "name_de": "BTL-A4-Y-Flügler",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -101,6 +112,7 @@
   "13": {
     "name_yasb": "TIE Advanced",
     "name_de": "TIE-x1-Turbojäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -110,6 +122,7 @@
   "14": {
     "name_yasb": "Alpha-Class Star Wing",
     "name_de": "Sternflügler der Alpha-Klasse",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -119,6 +132,7 @@
   "15": {
     "name_yasb": "U-Wing",
     "name_de": "UT-60D-U-Flügler",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -128,6 +142,7 @@
   "16": {
     "name_yasb": "TIE Striker",
     "name_de": "TIE/sk-Stürmer",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -137,6 +152,7 @@
   "17": {
     "name_yasb": "B-Wing",
     "name_de": "A/SF-01-B-Flügler",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -146,6 +162,7 @@
   "18": {
     "name_yasb": "TIE Defender",
     "name_de": "TIE/D-Abwehrjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -155,6 +172,7 @@
   "19": {
     "name_yasb": "TIE Bomber",
     "name_de": "TIE/sa-Bomber",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -164,6 +182,7 @@
   "20": {
     "name_yasb": "TIE Punisher",
     "name_de": "TIE/ca-Vergelter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -173,6 +192,7 @@
   "21": {
     "name_yasb": "Aggressor",
     "name_de": "Aggressor-Angriffsjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -182,6 +202,7 @@
   "22": {
     "name_yasb": "G-1A Starfighter",
     "name_de": "G-1A Sternenjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -191,6 +212,7 @@
   "23": {
     "name_yasb": "VCX-100",
     "name_de": "Leichter VCX-100-Frachter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -200,6 +222,7 @@
   "24": {
     "name_yasb": "YV-666",
     "name_de": "Leichter YV-666-Frachter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -209,6 +232,7 @@
   "25": {
     "name_yasb": "TIE Advanced Prototype",
     "name_de": "TIE-v1-Turbojäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -218,6 +242,7 @@
   "26": {
     "name_yasb": "Lambda-Class Shuttle",
     "name_de": "T-4A-Raumfähre der Lambda-Klasse",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -227,6 +252,7 @@
   "27": {
     "name_yasb": "TIE Phantom",
     "name_de": "TIE/ph-Phantom",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -236,6 +262,7 @@
   "28": {
     "name_yasb": "VT-49 Decimator",
     "name_de": "VT-49-Decimator",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -245,6 +272,7 @@
   "29": {
     "name_yasb": "TIE Aggressor",
     "name_de": "TIE/ag-Agressor",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -254,6 +282,7 @@
   "30": {
     "name_yasb": "K-Wing",
     "name_de": "BTL-S8-K-Flügler",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -263,6 +292,7 @@
   "31": {
     "name_yasb": "ARC-170",
     "name_de": "ARC-170-Sternenjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -272,6 +302,7 @@
   "32": {
     "name_yasb": "Attack Shuttle",
     "name_de": "Jagdshuttle",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -281,6 +312,7 @@
   "33": {
     "name_yasb": "X-Wing",
     "name_de": "T-65-X-Flügler",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -290,6 +322,7 @@
   "34": {
     "name_yasb": "HWK-290",
     "name_de": "Leichter HWK-290-Frachter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -299,6 +332,7 @@
   "35": {
     "name_yasb": "A-Wing",
     "name_de": "RZ-1-A-Flügler",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -308,6 +342,7 @@
   "36": {
     "name_yasb": "Fang Fighter",
     "name_de": "Fangjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -317,6 +352,7 @@
   "38": {
     "name_yasb": "Z-95 Headhunter",
     "name_de": "Z-95-AF4-Kopfjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -326,6 +362,7 @@
   "39": {
     "name_yasb": "M12-L Kimogila Fighter",
     "name_de": "M12-L-Kimogila-Jäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -335,6 +372,7 @@
   "40": {
     "name_yasb": "E-Wing",
     "name_de": "E-Flügler",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -344,6 +382,7 @@
   "41": {
     "name_yasb": "TIE Interceptor",
     "name_de": "TIE-Abfangjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -353,6 +392,7 @@
   "42": {
     "name_yasb": "Lancer-Class Pursuit Craft",
     "name_de": "Jagdschiff der Lanzen-Klasse",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -362,6 +402,7 @@
   "43": {
     "name_yasb": "TIE Reaper",
     "name_de": "TIE-Schnitter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -371,6 +412,7 @@
   "45": {
     "name_yasb": "JumpMaster 5000",
     "name_de": "JumpMaster 5000",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -380,6 +422,7 @@
   "44": {
     "name_yasb": "M3-A Interceptor",
     "name_de": "M3-A-Abfangjäger",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -389,6 +432,7 @@
   "47": {
     "name_yasb": "YT-1300 (Scum)",
     "name_de": "Modifizierter YT-1300-Frachter",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",
@@ -398,6 +442,7 @@
   "48": {
     "name_yasb": "Escape Craft",
     "name_de": "Fluchtschiff",
+    "name_en": "CHANGE ME",
     "name_es": "CHANGE ME",
     "name_fr": "CHANGE ME",
     "name_it": "CHANGE ME",


### PR DESCRIPTION
And while we're at it:

I noticed that I gave the translation script the power to handle every language EXCEPT ENGLISH.
This can be fixed easily by adding "en" to the translation supporting JSONs. So I did.
It might not seem logical to use the translation script for English as well, but it can actually be quite useful to mass update card texts.