### PR TITLE
API exoport JSONs now sorted by ID

### DIFF
--- a/translation_helper/api_export_de.json
+++ b/translation_helper/api_export_de.json
@@ -1,6 +1,745 @@
 {
     "cards": [
         {
+            "ability_text": "Solange du einen Angriff durchführst, wirft der Verteidiger 1<nonbreak>Verteidigungswürfel weniger.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5839,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5840,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5841,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_1",
+            "force_side": null,
+            "id": 1,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Wedge Antilles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6671,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6672,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6673,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6674,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rot Zwei",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du zum Verteidiger geworden bist (bevor Würfel geworfen werden), darfst du 1<nonbreak><forcecharge> wiederherstellen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5842,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5843,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5844,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                17,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "62",
+            "faction_id": 1,
+            "ffg_id": "XW_P_2",
+            "force_side": 2,
+            "id": 2,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Luke Skywalker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6675,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6676,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6677,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6678,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 6679,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rot Fünf",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen Angriff durchführst, darfst du 1<nonbreak><focus>-, <hit>- oder <crit>-Ergebnis ausgeben, um dir die verdeckten Schadenskarten des Verteidigers anzusehen, 1 zu wählen und sie offenzulegen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5845,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5846,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5847,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_set_ids": [
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_3",
+            "force_side": null,
+            "id": 3,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Thane Kyrell",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6680,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6681,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6682,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6683,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Corona Vier",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du einen Fokusmarker ausgegeben hast, darfst du 1<nonbreak>befreundetes Schiff in Reichweite 1–3 wählen. Jenes Schiff erhält 1 Fokusmarker.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5848,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5849,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5850,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_4",
+            "force_side": null,
+            "id": 4,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6684,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6685,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6686,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6687,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rot Eins",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du einen Stressmarker bekommen hast, darfst du 1<nonbreak>Angriffswürfel werfen, um ihn zu entfernen. Bei einem <hit>-Ergebnis erleide 1<nonbreak><hit>-Schaden.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5851,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5852,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5853,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_5",
+            "force_side": null,
+            "id": 5,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Jek Porkins",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6688,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6689,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6690,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6691,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rot Sechs",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du eine <barrelroll>- oder <boost>-Aktion durchgeführt hast, darfst du deine ausgerüstete <config>-Aufwertungskarte umdrehen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5854,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5855,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5856,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_6",
+            "force_side": null,
+            "id": 6,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kullbee Sperado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6692,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6693,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6694,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6695,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Geheimnisvoller Revolverheld",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein anderes befreundetes Schiff in Reichweite 0–1 verteidigt, vor dem Schritt „Ergebnisse neutralisieren“, falls du im Angriffswinkel bist, darfst du 1<nonbreak><hit>- oder <crit>-Schaden erleiden, um 1<nonbreak>passendes Ergebnis zu negieren. ",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5857,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5858,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5859,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_7",
+            "force_side": null,
+            "id": 7,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Biggs Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6696,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6697,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6698,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6699,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rot Drei",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du eine <barrelroll>- oder <boost>-Aktion durchgeführt hast, darfst du eine rote <evade>-Aktion durchführen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5860,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5861,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5862,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_8",
+            "force_side": null,
+            "id": 8,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Leevan Tenza",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6700,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6701,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6702,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6703,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Überläufer der Allianz",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor du aktiviert wirst, falls du fokussiert bist, darfst du eine Aktion durchführen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5863,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5864,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5865,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_9",
+            "force_side": null,
+            "id": 9,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Edrio Two Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6704,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6705,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6706,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6707,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Veteran der Sturmengel",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Die rote Staffel wurde als Elite-Jägerverband gegründet und zählt einige der besten Piloten der Allianz zu ihren Mitgliedern.</flavor>",
             "available_actions": [
                 {
@@ -84,164 +823,164 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Solange du einen Angriff durchführst, wirft der Verteidiger 1<nonbreak>Verteidigungswürfel weniger.",
+            "ability_text": "<flavor>Der T-65-X-Flügler aus dem Hause Incom erwies sich schnell als eine der effektivsten und vielseitigsten Jagdmaschinen der Galaxis – und als wahrer Segen für die Rebellion.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 5869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 5870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 5871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
             "card_set_ids": [
+                1,
                 4,
                 7
             ],
             "card_type_id": 1,
-            "cost": "52",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_1",
+            "ffg_id": "XW_P_11",
             "force_side": null,
-            "id": 1,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Wedge Antilles",
+            "id": 11,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Eskorte der blauen Staffel",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 6712,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 6713,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 6714,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 6715,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Rot Zwei",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "Solange du einen Angriff durchführst, darfst du 1<nonbreak><focus>-, <hit>- oder <crit>-Ergebnis ausgeben, um dir die verdeckten Schadenskarten des Verteidigers anzusehen, 1 zu wählen und sie offenzulegen.",
+            "ability_text": "<flavor>Anders als die meisten Widerstandszellen sind Saw Gerreras Partisanen bereit, bis zum Äußersten zu gehen, um die Pläne des Imperiums zu durchkreuzen. Von Geonosis bis Jedha liefern sie sich blutige Auseinandersetzungen mit der imperialen Obrigkeit.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 5872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 5873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 5874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
+                13,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
             "card_set_ids": [
-                7
+                2
             ],
             "card_type_id": 1,
-            "cost": "48",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_3",
+            "ffg_id": "XW_P_12",
             "force_side": null,
-            "id": 3,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Thane Kyrell",
+            "id": 12,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Fanatiker der Sturmengel",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 6716,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 6717,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 6718,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 6719,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Corona Vier",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -332,343 +1071,6 @@
                 }
             ],
             "subtitle": "Gold Neun",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Fokusmarker ausgegeben hast, darfst du 1<nonbreak>befreundetes Schiff in Reichweite 1–3 wählen. Jenes Schiff erhält 1 Fokusmarker.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5848,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5849,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5850,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_4",
-            "force_side": null,
-            "id": 4,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6684,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6685,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6686,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6687,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rot Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der T-65-X-Flügler aus dem Hause Incom erwies sich schnell als eine der effektivsten und vielseitigsten Jagdmaschinen der Galaxis – und als wahrer Segen für die Rebellion.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5869,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5870,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5871,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_11",
-            "force_side": null,
-            "id": 11,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Eskorte der blauen Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6712,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6713,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6714,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6715,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Angriff durchführst, darfst du für jedes andere befreundete Schiff in Reichweite 0–1 des Verteidigers 1 Angriffswürfel neu werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5883,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5884,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5885,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5886,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
-            "card_set_ids": [
-                4,
-                8
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_15",
-            "force_side": null,
-            "id": 15,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Horton Salm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 6728,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6729,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6730,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6731,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Grau Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du eine <barrelroll>- oder <boost>-Aktion durchgeführt hast, darfst du deine ausgerüstete <config>-Aufwertungskarte umdrehen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5854,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5855,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5856,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_6",
-            "force_side": null,
-            "id": 6,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kullbee Sperado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6692,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6693,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6694,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6695,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Geheimnisvoller Revolverheld",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -765,42 +1167,183 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Zu Beginn der Endphase darfst du 1<nonbreak>Fokusmarker ausgeben, um 1<nonbreak>deiner offenen Schadenskarten zu reparieren.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+            "ability_text": "Solange du einen Angriff durchführst, darfst du für jedes andere befreundete Schiff in Reichweite 0–1 des Verteidigers 1 Angriffswürfel neu werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5883,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5884,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5885,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5886,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
             "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_157",
-            "force_side": null,
-            "id": 382,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
+                4,
                 8
             ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_15",
+            "force_side": null,
+            "id": 15,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Horton Salm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6728,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6729,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6730,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6731,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Grau Eins",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase darfst du 1 Fokusmarker ausgeben, um ein befreundetes Schiff in Reichweite 0–1 zu wählen. Falls du das tust, wirft jenes Schiff bis zum Ende der Runde 1<nonbreak>zusätzlichen Verteidigungswürfel, solange es verteidigt.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5887,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5888,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5889,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5890,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_set_ids": [
+                8
+            ],
+            "card_type_id": 1,
+            "cost": "36",
+            "faction_id": 1,
+            "ffg_id": "XW_P_16",
+            "force_side": null,
+            "id": 16,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Evaan Verlaine",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6732,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6733,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6734,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6735,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gold Drei",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -896,39 +1439,38 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Zu Beginn der Kampfphase darfst du 1 Fokusmarker ausgeben, um ein befreundetes Schiff in Reichweite 0–1 zu wählen. Falls du das tust, wirft jenes Schiff bis zum Ende der Runde 1<nonbreak>zusätzlichen Verteidigungswürfel, solange es verteidigt.",
+            "ability_text": "<flavor>Obwohl er beim Imperium schon lange ausgemustert ist, bleibt der Y-Flügler aufgrund seiner Robustheit, Zuverlässigkeit und schweren Bewaffnung weiterhin ein fester Bestandteil der Rebellenflotte.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 5895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 5896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 5897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 5898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 4,
                 5,
                 10,
@@ -936,51 +1478,52 @@
                 14,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
             "card_set_ids": [
+                4,
                 8
             ],
             "card_type_id": 1,
-            "cost": "36",
+            "cost": "32",
             "faction_id": 1,
-            "ffg_id": "XW_P_16",
+            "ffg_id": "XW_P_18",
             "force_side": null,
-            "id": 16,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Evaan Verlaine",
+            "id": 18,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Bomber der grauen Staffel",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 6740,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 6741,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 6742,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 6743,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Gold Drei",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1078,167 +1621,179 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Nachdem du eine <barrelroll>- oder <boost>-Aktion durchgeführt hast, darfst du eine rote <evade>-Aktion durchführen.",
+            "ability_text": "Du kannst Primärangriffe in Reichweite 0 durchführen.<return>Falls du durch Überschneidung mit einem anderen Schiff an einer <boost>-Aktion scheitern würdest, handle sie stattdessen so ab, als würdest du ein Manöver teilweise ausführen.<return><shipability><sabold>Schwenkbare Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <boost>-Aktion durchführen.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 5904,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 5906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 5907,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                5,
-                10,
-                13,
-                14,
-                18
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
             "card_set_ids": [
-                2
+                4
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_8",
+            "ffg_id": "XW_P_20",
             "force_side": null,
-            "id": 8,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "id": 20,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "•Leevan Tenza",
+            "name": "•Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 33,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 6748,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6701,
-                    "recurring": false,
-                    "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 6749,
                     "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
+                    "statistic_id": 1,
+                    "value": "3"
                 },
                 {
-                    "id": 6703,
+                    "id": 6750,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6751,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Überläufer der Allianz",
+            "subtitle": "Grün Eins",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Obwohl er beim Imperium schon lange ausgemustert ist, bleibt der Y-Flügler aufgrund seiner Robustheit, Zuverlässigkeit und schweren Bewaffnung weiterhin ein fester Bestandteil der Rebellenflotte.</flavor>",
+            "ability_text": "<flavor>Aufgrund seiner empfindlichen Steuerung und extremen Wendigkeit war das Cockpit des A-Flüglers nur für besonders begabte Piloten bestimmt.</flavor><return><shipability><sabold>Schwenkbare Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <boost>-Aktion durchführen.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 5909,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 5911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "base_action_side_effect": null,
+                    "id": 5912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
+                1,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
             "card_set_ids": [
-                4,
-                8
+                4
             ],
             "card_type_id": 1,
-            "cost": "32",
+            "cost": "34",
             "faction_id": 1,
-            "ffg_id": "XW_P_18",
+            "ffg_id": "XW_P_21",
             "force_side": null,
-            "id": 18,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-            "initiative": 2,
+            "id": 21,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
+            "initiative": 3,
             "is_unique": false,
-            "name": "Bomber der grauen Staffel",
+            "name": "Pilot der grünen Staffel",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 12,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 6752,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 6753,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "1"
+                    "value": "3"
                 },
                 {
-                    "id": 6742,
+                    "id": 6754,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "6"
+                    "value": "2"
                 },
                 {
-                    "id": 6743,
+                    "id": 6755,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1246,46 +1801,6 @@
             ],
             "subtitle": "",
             "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du genau 1 Entwaffnet-Marker hast, kannst du trotzdem <torpedo>- und <missile>-Angriffe gegen Ziele durchführen, die du als Ziel erfasst hast. Falls du das tust, kannst du während des Angriffs deine Zielerfassung nicht ausgeben.<return>Füge <torpedo>- und <missile>-Slots hinzu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_125",
-            "force_side": null,
-            "id": 350,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Os-1-Waffenarsenal",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 14,
-                            "raw_name": "Alpha-class Star Wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -1381,93 +1896,3985 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Du kannst Primärangriffe in Reichweite 0 durchführen.<return>Falls du durch Überschneidung mit einem anderen Schiff an einer <boost>-Aktion scheitern würdest, handle sie stattdessen so ab, als würdest du ein Manöver teilweise ausführen.<return><shipability><sabold>Schwenkbare Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <boost>-Aktion durchführen.</shipability>",
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du bis zu 2<nonbreak>deiner Würfel neu werfen.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5905,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
+                    "id": 5919,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 5920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 5921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                6
+                2,
+                3,
+                3,
+                5,
+                14
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_23",
+            "force_side": null,
+            "id": 23,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Braylen Stramm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6760,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6761,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6762,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6763,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Klinge Eins",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, darfst du 1<nonbreak>Stressmarker ausgeben, um alle deine <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5922,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5923,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5924,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_24",
+            "force_side": null,
+            "id": 24,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Ten Numb",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6764,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6765,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6766,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6767,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Blau Fünf",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Das Cockpit des B-Flüglers ist in einen einzigartigen Gyrostabilisator eingebunden, der den Piloten während des gesamten Fluges in aufrechter Position hält.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5925,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5926,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5927,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 1,
+            "ffg_id": "XW_P_25",
+            "force_side": null,
+            "id": 25,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Veteran der Klingen-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6768,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6769,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6770,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6771,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Seine schweren Waffensysteme und unverwüstlichen Schilde machen den B-Flügler zu einer der innovativsten Jagdmaschinen der Allianz.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5928,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5929,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5930,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_26",
+            "force_side": null,
+            "id": 26,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot der blauen Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6772,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6773,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6774,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6775,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du einen Angriff durchgeführt hast, darfst du 1 befreundetes Schiff in Reichweite 1 wählen. Jenes Schiff darf eine Aktion durchführen, die es als rot behandelt.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5931,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5932,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5933,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 1,
             "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_20",
+            "ffg_id": "XW_P_27",
             "force_side": null,
-            "id": 20,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-            "initiative": 3,
+            "id": 27,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
+            "initiative": 5,
             "is_unique": true,
-            "name": "•Arvel Crynyd",
+            "name": "•Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 35,
+            "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 6776,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 6777,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "3"
+                    "value": "2"
                 },
                 {
-                    "id": 6750,
+                    "id": 6778,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 6779,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Grün Eins",
+            "subtitle": "Geheimdienstchef",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen Primärangriff durchführst, falls mindestens 1 anderes befreundetes Schiff in Reichweite 0–1 des Verteidigers ist, darfst du 1 zusätzlichen Angriffswürfel werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5934,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5935,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5936,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_28",
+            "force_side": null,
+            "id": 28,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lieutenant Blount",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6780,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6781,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6782,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6783,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Teamspieler",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Die AF4-Serie ist das jüngste Modell der bewährten Kopfjäger-Produktreihe, die mit ihrem günstigen Preis und ihrer robusten Bauweise zu den Favoriten vieler unabhängiger Organisationen wie der Rebellion gehört.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5937,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5938,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5939,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "25",
+            "faction_id": 1,
+            "ffg_id": "XW_P_29",
+            "force_side": null,
+            "id": 29,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot der Tala-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6784,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6785,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6786,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6787,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der Z-95-Kopfjäger ist ein direkter Vorläufer von Incoms Vorzeigemodell, dem T-65-X-Flügler. Obwohl er nach modernen Standards als veraltet gilt, ist er nach wie vor ein vielseitiger und schlagkräftiger Sternjäger.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5940,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5941,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5942,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "23",
+            "faction_id": 1,
+            "ffg_id": "XW_P_30",
+            "force_side": null,
+            "id": 30,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Pilot der Banditen-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6788,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6789,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6790,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6791,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem ein befreundetes Schiff in Reichweite 0–1 zum Verteidiger geworden ist, darfst du 1 Verstärkungsmarker ausgeben. Falls du das tust, erhält jenes Schiff 1 Ausweichmarker.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5943,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5944,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5945,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "56",
+            "faction_id": 1,
+            "ffg_id": "XW_P_31",
+            "force_side": null,
+            "id": 31,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lowhhrick",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6792,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6793,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6794,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6795,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Entflohener Gladiator",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen Primärangriff durchführst, falls du beschädigt bist, darfst du 1 zusätzlichen Angriffswürfel werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5946,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5947,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5948,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_32",
+            "force_side": null,
+            "id": 32,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Wullffwarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6796,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6797,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6798,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6799,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Wookiee-Häuptling",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Mit seinen drei weitreichenden Sureggi-Zwillingslaserkanonen soll das Auzituck-Kanonenboot Sklavenjäger im Kashyyyk-System abschrecken.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5949,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5950,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5951,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_33",
+            "force_side": null,
+            "id": 33,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Verteidiger von Kashyyyk",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6800,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6801,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6802,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6803,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du ein rotes oder blaues Manöver aufgedeckt hast, darfst du dein Rad auf ein anderes Manöver derselben Schwierigkeit einstellen.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5952,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5953,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5954,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "39",
+            "faction_id": 1,
+            "ffg_id": "XW_P_34",
+            "force_side": null,
+            "id": 34,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6804,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6805,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6806,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6807,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor du aktiviert wirst, darfst du eine <barrelroll>- oder <boost>-Aktion durchführen.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5955,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5956,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5957,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_35",
+            "force_side": null,
+            "id": 35,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6808,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6809,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6810,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6811,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du 1<nonbreak><forcecharge> ausgeben, um bis zu 2 deiner <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5958,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5959,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5960,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "41",
+            "faction_id": 1,
+            "ffg_id": "XW_P_36",
+            "force_side": 2,
+            "id": 36,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6812,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6813,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6814,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6815,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6816,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst, werden <crit>-Ergebnisse neutralisiert, bevor <hit>-Ergebnisse neutralisiert werden.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5961,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5962,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5963,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 1,
+            "ffg_id": "XW_P_37",
+            "force_side": null,
+            "id": 37,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Zeb“ Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6817,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6818,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6819,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6820,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem ein feindliches Schiff in deinem Feuerwinkel begonnen hat zu kämpfen, falls du nicht gestresst bist, darfst du 1 Stressmarker erhalten. Falls du das tust, kann jenes Schiff keine Marker ausgeben, um Würfel zu modifizieren, solange es während dieser Phase einen Angriff durchführt.<return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5964,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5965,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_38",
+            "force_side": null,
+            "id": 38,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6821,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6822,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6823,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6824,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6825,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Rebell wider Willen",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du 1<nonbreak><forcecharge> ausgeben, um bis zu 2 deiner <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern. <return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5966,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5967,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                10,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_39",
+            "force_side": 2,
+            "id": 39,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6826,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6827,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6828,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6829,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6830,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6831,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst, werden <crit>-Ergebnisse neutralisiert, bevor <hit>-Ergebnisse neutralisiert werden.<return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5968,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5969,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_40",
+            "force_side": null,
+            "id": 40,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Zeb“ Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6832,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6833,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6834,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6835,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6836,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du koordinierst, falls du ein Schiff mit genau 1 Stressmarker wählst, kann es Aktionen durchführen.<return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5970,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5971,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_41",
+            "force_side": null,
+            "id": 41,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
+            "initiative": 1,
+            "is_unique": true,
+            "name": "•AP-5",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6837,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6838,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6839,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6840,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6841,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Entflohener Inventardroide",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein befreundetes Schiff in deinem Feuerwinkel einen Primärangriff durchführt, falls du nicht gestresst bist, darfst du 1<nonbreak>Stressmarker erhalten. Falls du das tust, darf jenes Schiff 1<nonbreak>zusätzlichen Angriffswürfel werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5972,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5973,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5974,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5975,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5976,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_42",
+            "force_side": null,
+            "id": 42,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Jan Ors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6842,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6843,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6844,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6845,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Spionageexpertin",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase darfst du 1 deiner Fokusmarker auf ein<nonbreak>befreundetes Schiff in deinem Feuerwinkel transferieren.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5977,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5978,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5979,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5980,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5981,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_43",
+            "force_side": null,
+            "id": 43,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kyle Katarn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6846,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6847,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6848,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6849,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Unbeugsamer Agent",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase darfst du 1 Schiff in deinem Feuerwinkel wählen. Falls du das tust, kämpft es in dieser Phase bei Initiative 7 anstatt bei seiner normalen Initiative.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5982,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5983,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5984,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5985,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5986,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_44",
+            "force_side": null,
+            "id": 44,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Roark Garnet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6850,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6851,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6852,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6853,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gutherziger Schmuggler",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Ein Vogel mit ausgebreiteten Schwingen diente der Corellianischen Ingenieursgesellschaft als Vorbild für das Design der „Hawk“-Serie, einer Reihe von erstklassigen Transportschiffen. Der flinke und robuste HWK-290 wird oft von Rebellenagenten als mobile Operationsbasis eingesetzt.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5987,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5988,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5989,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5990,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5991,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_45",
+            "force_side": null,
+            "id": 45,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebellen-Aufklärer",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6854,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6855,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6856,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6857,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du 1<nonbreak><forcecharge> ausgeben, um bis zu 2 deiner <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5992,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5993,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5994,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_46",
+            "force_side": 2,
+            "id": 46,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6858,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6859,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6860,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6861,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor du aktiviert wirst, darfst du eine <barrelroll>- oder <boost>-Aktion durchführen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5995,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5996,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5997,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 1,
+            "ffg_id": "XW_P_47",
+            "force_side": null,
+            "id": 47,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6862,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6863,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6864,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du einen Angriff durchgeführt hast, ordne dem Verteidiger den Zustand <smallcaps>Sperrfeuer</smallcaps> zu.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5998,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5999,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6000,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_48",
+            "force_side": null,
+            "id": 48,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Captain Rex",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6865,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6866,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6867,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Veteran der Klonkriege",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst, werden <crit>-Ergebnisse neutralisiert, bevor <hit>-Ergebnisse neutralisiert werden.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6001,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6002,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6003,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "26",
+            "faction_id": 1,
+            "ffg_id": "XW_P_49",
+            "force_side": null,
+            "id": 49,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Zeb“ Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6868,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6869,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6870,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bei Initiative 0 darfst du einen Bonus-Primärangriff gegen ein feindliches Schiff in deinem <bullseye> durchführen. Falls du das tust, erhalte zu Beginn der nächsten Planungsphase 1 Entwaffnet-Marker.<return><shipability><sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6004,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6005,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6006,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6007,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6008,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 1,
+            "ffg_id": "XW_P_50",
+            "force_side": null,
+            "id": 50,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Corran Horn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6871,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6872,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6873,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6874,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Hartnäckiger Ermittler",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein befreundetes Schiff einen Angriff durchführt, falls der Verteidiger in deinem <frontarc> ist, darf der Angreifer 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis ändern.<return><shipability><sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6009,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6010,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6011,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6012,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6013,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 1,
+            "ffg_id": "XW_P_51",
+            "force_side": null,
+            "id": 51,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Gavin Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6875,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6876,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6877,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6878,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Tapferer Flügelmann",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Die Spitzenpiloten der Renegaten-Staffel gehören zur absoluten Elite der Rebellion. </flavor><return><shipability> <sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6014,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6015,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6016,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6017,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6018,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "63",
+            "faction_id": 1,
+            "ffg_id": "XW_P_52",
+            "force_side": null,
+            "id": 52,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Eskorte der Renegaten-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6879,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6880,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6881,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6882,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der E-Flügler verbindet die besten Eigenschaften von X-Flügler und A-Flügler, und kann mit überlegener Feuerkraft, Geschwindigkeit und Manövrierbarkeit aufwarten.</flavor><return><shipability> <sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6019,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6020,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6021,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6022,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6023,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "61",
+            "faction_id": 1,
+            "ffg_id": "XW_P_53",
+            "force_side": null,
+            "id": 53,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Eskorte der Schurken-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6883,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6884,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6885,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6886,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Befreundete Schiffe können Objekte in Reichweite 0–3 eines beliebigen befreundeten Schiffes als Ziele erfassen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6024,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6025,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6026,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 1,
+            "ffg_id": "XW_P_54",
+            "force_side": null,
+            "id": 54,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Bodhi Rook",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6887,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6888,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6889,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6890,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Imperialer Überläufer",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein beschädigtes befreundetes Schiff in Reichweite 0–3 einen Angriff durchführt, darf es 1<nonbreak>Angriffswürfel neu werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6027,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6028,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6029,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_55",
+            "force_side": null,
+            "id": 55,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Saw Gerrera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6891,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6892,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6893,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6894,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Zwanghafter Gesetzloser",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Aktivierungsphase darfst du 1 befreundetes Schiff in Reichweite 1–3 wählen. Falls du das tust, entfernt jenes Schiff 1 Stressmarker.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6030,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6031,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6032,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_56",
+            "force_side": null,
+            "id": 56,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Cassian Andor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6895,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6896,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6897,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6898,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Aufgewachsen bei der Rebellion",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein befreundetes Schiff in Reichweite 0–2 verteidigt, kann der Angreifer nicht mehr als 1<nonbreak>Angriffswürfel neu werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6033,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6034,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6035,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_57",
+            "force_side": null,
+            "id": 57,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6899,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6900,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6901,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6902,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Aufklärerin der Sturmengel",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du eine <focus>-Aktion durchgeführt hast, darfst du 1 deiner Fokusmarker auf ein befreundetes Schiff in Reichweite 1–2 transferieren.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6036,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6037,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6038,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_58",
+            "force_side": null,
+            "id": 58,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Benthic Two Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6903,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6904,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6905,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6906,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Meisterschütze der Sturmengel",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem ein feindliches Schiff ein Manöver ausgeführt hat, falls es in Reichweite 0 ist, darfst du eine Aktion durchführen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6039,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6040,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6041,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_59",
+            "force_side": null,
+            "id": 59,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Heff Tobber",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6907,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6908,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6909,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6910,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Blau Acht",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der UT-60D-U-Flügler deckt den Bedarf der Rebellion an schnellen, unverwüstlichen Truppentransportern. Meistens wird er eingesetzt, um Soldaten im Schutz der Dunkelheit oder inmitten eines tobenden Gefechts an ihren Einsatzort zu befördern. </flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6042,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6043,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6044,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_60",
+            "force_side": null,
+            "id": 60,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Aufklärer der blauen ",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6911,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6912,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6913,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6914,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Ursprünglich hatten sich Saw Gerreras Partisanen während der Klonkriege formiert, um den Streitkräften der Separatisten auf Onderon die Stirn zu bieten. Als das Imperium die Macht übernahm, setzten sie ihren Kampf gegen die Tyrannei einfach fort.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6045,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6046,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6047,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_61",
+            "force_side": null,
+            "id": 61,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Überzeugter Partisan",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6915,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6916,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6917,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6918,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen Primärangriff durchführst, darfst du entweder 1<nonbreak>Schild ausgeben, um 1 zusätzlichen Angriffswürfel zu werfen, oder, falls du keine Schilde hast, du darfst 1<nonbreak>Angriffswürfel weniger werfen, um 1<nonbreak>Schild wiederherzustellen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6048,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6049,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6050,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6051,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6052,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_62",
+            "force_side": null,
+            "id": 62,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Miranda Doni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6919,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6920,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6921,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6922,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Schweres Geschütz",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein befreundetes Schiff in Reichweite 0–2 verteidigt oder einen Angriff durchführt, darf es deine Fokusmarker ausgeben, als ob jenes Schiff sie hätte.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6053,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6054,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6055,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6056,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6057,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_63",
+            "force_side": null,
+            "id": 63,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Esege Tuketu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6923,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6924,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6925,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6926,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Selbstloser Held",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der K-Flügler von Koensayr zeichnet sich durch einen topmodernen Sublicht-Antriebsmotor (kurz: SLAM) sowie beispiellose achtzehn Waffenaufhängungen aus. Was Geschwindigkeit und Feuerkraft anbelangt, steht er außer Konkurrenz.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6058,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6059,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6060,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6061,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6062,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 1,
+            "ffg_id": "XW_P_64",
+            "force_side": null,
+            "id": 64,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot der Beschützer-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6927,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6928,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6929,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6930,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst, falls ein feindliches Schiff in Reichweite 0–1 ist, füge 1<nonbreak><evade>-Ergebnis zu deinen Würfelergebnissen hinzu.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6063,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6064,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6065,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "55",
+            "faction_id": 1,
+            "ffg_id": "XW_P_65",
+            "force_side": null,
+            "id": 65,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Norra Wexley",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6931,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6932,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6933,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6934,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6935,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Gold Neun",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du einen Fokusmarker ausgegeben hast, darfst du 1<nonbreak>befreundetes Schiff in Reichweite 1–3 wählen. Jenes Schiff erhält 1 Fokusmarker.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6066,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6067,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6068,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "51",
+            "faction_id": 1,
+            "ffg_id": "XW_P_66",
+            "force_side": null,
+            "id": 66,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6936,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6937,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6938,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6939,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6940,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Rot Eins",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst oder einen Primärangriff durchführst, darfst du 1 Zielerfassung, die du auf dem feindlichen Schiff hast, ausgeben, um 1<nonbreak><focus>-Ergebnis zu deinen Würfelergebnissen hinzuzufügen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6069,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6070,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6071,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "53",
+            "faction_id": 1,
+            "ffg_id": "XW_P_67",
+            "force_side": null,
+            "id": 67,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Shara Bey",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6941,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6942,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6943,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6944,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6945,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Grün Vier",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du ein Manöver vollständig ausgeführt hast, falls du gestresst bist, darfst du 1 Angriffswürfel werfen. Bei einem <hit>- oder <crit>-Ergebnis entferne 1<nonbreak>Stressmarker.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6072,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6073,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6074,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_68",
+            "force_side": null,
+            "id": 68,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ibtisam",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6946,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6947,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6948,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6949,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6950,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Überlebende von Endor",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du Würfel geworfen hast, falls du in Reichweite 0–1 eines Hindernisses bist, darfst du alle deine Würfel neu werfen. Dies zählt für alle anderen Effekte nicht als Neuwerfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6075,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6076,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6077,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6078,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "92",
+            "faction_id": 1,
+            "ffg_id": "XW_P_69",
+            "force_side": null,
+            "id": 69,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6951,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6952,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6953,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6954,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Verwegener Söldner",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1559,6 +5966,533 @@
                 }
             ],
             "subtitle": "General der Allianz",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor dir eine offene Schadenskarte zugeteilt werden würde, darfst du 1<nonbreak><standardcharge> ausgeben, um die Karte stattdessen verdeckt zugeteilt zu bekommen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6083,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6084,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6085,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6086,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 1,
+            "ffg_id": "XW_P_71",
+            "force_side": null,
+            "id": 71,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Chewbacca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6959,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6960,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6961,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6962,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                },
+                {
+                    "id": 6963,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Der Mächtige",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Mit seiner robusten Bauweise und modularen Konstruktion gehört der YT-1300 zu den beliebtesten, weitverbreitetsten und am stärksten modifizierten Raumfrachtern der Galaxis. </flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6087,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6088,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6089,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6090,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "78",
+            "faction_id": 1,
+            "ffg_id": "XW_P_72",
+            "force_side": null,
+            "id": 72,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Schmuggler aus dem ",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6964,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6965,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6966,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6967,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du ein rotes oder blaues Manöver aufgedeckt hast, darfst du dein Rad auf ein anderes Manöver derselben Schwierigkeit einstellen.<return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6091,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6092,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6093,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "76",
+            "faction_id": 1,
+            "ffg_id": "XW_P_73",
+            "force_side": null,
+            "id": 73,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6968,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6969,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6970,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6971,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein befreundetes Schiff in deinem Feuerwinkel verteidigt, darfst du 1<nonbreak><forcecharge> ausgeben. Falls du das tust, wirft der Angreifer 1 Angriffswürfel weniger.<return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6094,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6095,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6096,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "90",
+            "faction_id": 1,
+            "ffg_id": "XW_P_74",
+            "force_side": 2,
+            "id": 74,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kanan Jarrus",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6972,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6973,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6974,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6975,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                },
+                {
+                    "id": 6976,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Spectre-1",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase erhält jedes feindliche Schiff in Reichweite 0 2 Störsignalmarker. <return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6097,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6098,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6099,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 1,
+            "ffg_id": "XW_P_75",
+            "force_side": null,
+            "id": 75,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Chopper“",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6977,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6978,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6979,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6980,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-3",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der VCX-100 ist ein weiteres Erfolgsmodell der Corellianischen Ingenieursgesellschaft, geräumiger und mit mehr Ausstattungsoptionen als die beliebte YT-Serie.</flavor><return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6100,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6101,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6102,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 1,
+            "ffg_id": "XW_P_76",
+            "force_side": null,
+            "id": 76,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebell von Lothal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6981,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6982,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6983,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6984,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1973,87 +6907,6 @@
                 }
             ],
             "subtitle": "Obsidian Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Anders als die meisten Widerstandszellen sind Saw Gerreras Partisanen bereit, bis zum Äußersten zu gehen, um die Pläne des Imperiums zu durchkreuzen. Von Geonosis bis Jedha liefern sie sich blutige Auseinandersetzungen mit der imperialen Obrigkeit.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5872,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5873,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5874,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_12",
-            "force_side": null,
-            "id": 12,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Fanatiker der Sturmengel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6716,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6717,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6718,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6719,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -2647,9455 +7500,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Nachdem du eine Aktion durchgeführt hast, darfst du 1<nonbreak><forcecharge> ausgeben, um eine Aktion durchzuführen.<return><shipability><sabold>Verbesserter Zielcomputer:</sabold> Solange du einen Primärangriff gegen einen Verteidiger durchführst, den du als Ziel erfasst hast, wirf 1<nonbreak>zusätzlichen Angriffswürfel und ändere 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6154,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6155,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6156,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 2,
-            "ffg_id": "XW_P_93",
-            "force_side": 1,
-            "id": 93,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Darth Vader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7038,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7039,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7040,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7041,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7042,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Schwarz Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der TIE-x1-Turbojäger wurde nur in geringer Stückzahl produziert, dafür wurden viele seiner Innovationen bei der Entwicklung von Sienars nächstem TIE-Modell, dem TIE-Abfangjäger, übernommen.</flavor><return><shipability><sabold>Verbesserter Zielcomputer:</sabold> Solange du einen Primärangriff gegen einen Verteidiger durchführst, den du als Ziel erfasst hast, wirf 1 zusätzlichen Angriffswürfel und ändere 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6166,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6167,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6168,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 2,
-            "ffg_id": "XW_P_97",
-            "force_side": null,
-            "id": 97,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Fliegerass der Storm-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7055,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7056,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7057,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7058,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Sienars TIE-v1-Turbojäger war eine bahnbrechende Entwicklung auf dem Gebiet der Sternenjäger-Technologie. Er verfügt über stärkere Triebwerke, einen Raketenwerfer sowie klappbare S-Flügel.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6182,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6183,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6184,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6185,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6186,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_101",
-            "force_side": null,
-            "id": 101,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Imperialer Baron",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 25,
-            "statistics": [
-                {
-                    "id": 7073,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7074,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7075,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7076,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du eine <reload>-Aktion durchgeführt hast, darfst du 1<nonbreak><standardcharge> von 1 deiner ausgerüsteten <talent>-Aufwertungskarten wiederherstellen. <return><shipability><sabold>Wendiger Bomber:</sabold> Falls du unter Verwendung einer <straight>-Schablone ein Gerät abwerfen würdest, darfst du stattdessen eine <leftbank>- oder <rightbank>-Schablone derselben Geschwindigkeit verwenden.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6208,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6209,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6210,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6211,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_107",
-            "force_side": null,
-            "id": 107,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Tomax Bren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7094,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7095,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7096,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Ungestümer Einzelkämpfer",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du zerstört worden bist, bevor du entfernt wirst, darfst du einen Angriff durchführen und 1 Gerät abwerfen oder starten.<return><shipability><sabold>Wendiger Bomber:</sabold> Falls du unter Verwendung einer <straight>-Schablone ein Gerät abwerfen würdest, darfst du stattdessen eine <leftbank>- oder <rightbank>-Schablone derselben Geschwindigkeit verwenden.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6220,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6221,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6222,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6223,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_110",
-            "force_side": null,
-            "id": 110,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Todesfeuer“",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7103,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7104,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7105,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Unverwüstlich und unerschrocken",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst, falls der Angreifer keine grünen Marker hat, darfst du 1 deiner Leerseiten- oder <focus>-Ergebnisse in ein <evade>-Ergebnis ändern.<return><sabold>Adaptive Querruder:</sabold> Bevor du dein Rad aufdeckst, falls du nicht gestresst bist, <bold>musst</bold> du ein weißes [1<nonbreak><leftbank>]-, [1<nonbreak><straight>]- oder [1<nonbreak><rightbank>]-Manöver ausführen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6236,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6237,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6238,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6239,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 2,
-            "ffg_id": "XW_P_114",
-            "force_side": null,
-            "id": 114,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Captain Feroph",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 43,
-            "statistics": [
-                {
-                    "id": 7116,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7117,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7118,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7119,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Imperial Kurier",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst, nach dem Schritt „Ergebnisse neutralisieren“, falls du nicht gestresst bist, darfst du 1<nonbreak><hit>-Schaden erleiden und 1<nonbreak>Stressmarker erhalten. Falls du das tust, negiere alle Würfelergebnisse.<return><shipability><sabold>Adaptive Querruder:</sabold> Bevor du dein Rad aufdeckst, falls du nicht gestresst bist, <bold>musst</bold> du ein weißes [1<nonbreak><leftbank>]-, [1<nonbreak><straight>]- oder [1<nonbreak><rightbank>]-Manöver ausführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6251,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6252,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6253,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_118",
-            "force_side": null,
-            "id": 118,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•„Countdown“",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 16,
-            "statistics": [
-                {
-                    "id": 7131,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7132,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7133,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Stärker als der Tod",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Angriff durchgeführt hast, der getroffen hat, falls du ausweichst, lege 1 der Schadenskarten des Verteidigers offen.<return><shipability><sabold>Vollgas:</sabold> Nachdem du ein Manöver mit Geschwindigkeit 3–5 vollständig ausgeführt hast, darfst du eine <evade>-Aktion durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6263,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6264,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6265,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6266,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6267,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_122",
-            "force_side": null,
-            "id": 122,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Rexler Brath",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 18,
-            "statistics": [
-                {
-                    "id": 7143,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7144,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7145,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7146,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Onyx Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Bei der Entwicklung des TIE-Aggressors setzte Sienar Flottensysteme mehr auf Vielseitigkeit und Leistung als auf reine Kosteneffizienz.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6297,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6298,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6299,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 2,
-            "ffg_id": "XW_P_130",
-            "force_side": null,
-            "id": 130,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Experte von Sienar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7175,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7176,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7177,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7178,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>In einem geheimen Forschungsprojekt auf dem Mond Imdaar Alpha wurde entwickelt, was viele für unmöglich gehalten hatten: der TIE-Phantom, ein kleiner Sternenjäger mit Tarnvorrichtung.</flavor><return><shipability><sabold>Stygium-Gitter:</sabold> Nachdem du dich enttarnt hast, darfst du eine <evade>-Aktion durchführen. Zu Beginn der Endphase darfst du 1 Ausweichmarker ausgeben, um 1 Tarnungsmarker zu erhalten.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6312,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6313,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6314,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 7,
-                    "base_action_side_effect": null,
-                    "id": 6315,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_134",
-            "force_side": null,
-            "id": 134,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Testpilot von Imdaar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 27,
-            "statistics": [
-                {
-                    "id": 7191,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7192,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7193,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7194,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Inspiriert von anderen Modellen der Cygnus Raumwerften, ist der Sternflügler der <untalic>Alpha</untalic>-Klasse ein vielseitiges Kanonenboot, das für verschiedene Einsatzgebiete umgerüstet werden kann und somit ideal für die Spezialeinheiten der Imperialen Flotte ist.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6328,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6329,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6330,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6331,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                6,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "35",
-            "faction_id": 2,
-            "ffg_id": "XW_P_138",
-            "force_side": null,
-            "id": 138,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot der Nu-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 14,
-            "statistics": [
-                {
-                    "id": 7207,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7208,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7209,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7210,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase darfst du 1 oder mehrere befreundete Schiffe in Reichweite 0–3 wählen. Falls du das tust, transferiere alle feindlichen Zielerfassungsmarker von den gewählten Schiffen auf dich.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6347,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6348,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 6349,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6350,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                8,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 2,
-            "ffg_id": "XW_P_142",
-            "force_side": null,
-            "id": 142,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Captain Kagi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 26,
-            "statistics": [
-                {
-                    "id": 7223,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7224,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 7225,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7226,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7227,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Shuttlepilot des Imperators",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Angriff durchführst, falls du verstärkt bist und der Verteidiger in dem <fullfront> oder <fullrear> ist, der zu deinem Verstärkungsmarker passt, darfst du 1 deiner <focus>-Ergebnisse in ein <crit>-Ergebnis ändern.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6368,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6369,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6370,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6371,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6372,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "88",
-            "faction_id": 2,
-            "ffg_id": "XW_P_147",
-            "force_side": null,
-            "id": 147,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Konteradmiral Chiraneau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7248,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7249,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7250,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7251,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Berater von Admiral Piett",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Primärangriff durchführst, falls mindestens 1<nonbreak>befreundetes nicht-limitiertes Schiff in Reichweite 0 des Verteidigers ist, wirf 1<nonbreak>zusätzlichen Angriffswürfel.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6386,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6387,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": "stress",
-                    "id": 6388,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6389,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
-            "card_set_ids": [
-                6,
-                11
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 3,
-            "ffg_id": "XW_P_151",
-            "force_side": null,
-            "id": 151,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kath Scarlet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 10,
-            "statistics": [
-                {
-                    "id": 7266,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7267,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "3"
-                },
-                {
-                    "id": 7268,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7269,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7270,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Captain der Binayre-Piraten",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls die Angriffsreichweite 1 ist, darfst du 1<nonbreak>zusätzlichen Würfel werfen.<return><shipability><sabold>Concordianischer Wirbel:</sabold> Solange du verteidigst, falls die Angriffsreichweite 1 ist und du im<frontarc><nonbreak>des Angreifers bist, ändere 1<nonbreak>Ergebnis in ein <evade>-Ergebnis.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6402,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6403,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6404,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6405,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 3,
-            "ffg_id": "XW_P_155",
-            "force_side": null,
-            "id": 155,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7286,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7287,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7288,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Skull Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Aufgrund seiner empfindlichen Steuerung und extremen Wendigkeit war das Cockpit des A-Flüglers nur für besonders begabte Piloten bestimmt.</flavor><return><shipability><sabold>Schwenkbare Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <boost>-Aktion durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5909,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5910,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5911,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5912,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5913,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_21",
-            "force_side": null,
-            "id": 21,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Pilot der grünen Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 35,
-            "statistics": [
-                {
-                    "id": 6752,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6753,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6754,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6755,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Die Fliegerasse der Skull-Staffel bevorzugen eine aggressive Kampftaktik und vertrauen dabei auf die schwenkbaren Tragflächen ihrer Schiffe, um ihre Beute mit unübertroffener Agilität zur Strecke zu bringen. </flavor><return><shipability> <sabold>Concordianischer Wirbel:</sabold> Solange du verteidigst, falls die Angriffsreichweite 1 ist und du im <frontarc> des Angreifers bist, ändere 1<nonbreak>Ergebnis in ein <evade>-Ergebnis.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6418,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6419,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6420,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6421,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_159",
-            "force_side": null,
-            "id": 159,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Pilot der Skull-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7298,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7299,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7300,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase, falls 1 oder mehrere andere Schiffe in Reichweite 0 sind, erhalten du und jedes andere Schiff in Reichweite 0 je 1 Fangstrahlmarker.<return><shipability><sabold>Schlepperstrahl:</sabold> <smallcaps>Aktion:</smallcaps> Wähle ein Schiff in deinem <frontarc> in Reichweite 1. Jenes Schiff erhält 1 Fangstrahlmarker oder 2<nonbreak>Fangstrahlmarker, falls es in deinem <bullseye> in Reichweite 1 ist.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6432,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6433,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6434,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 3,
-            "ffg_id": "XW_P_163",
-            "force_side": null,
-            "id": 163,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Unkar Plutt",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7310,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7311,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7312,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Geiziger Rationsmeister",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein befreundetes nicht-limitiertes Schiff einen Angriff durchführt, falls der Verteidiger in deinem Feuerwinkel ist, darf der Angreifer 1 Angriffswürfel neu werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6442,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6443,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6444,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6445,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 3,
-            "ffg_id": "XW_P_166",
-            "force_side": null,
-            "id": 166,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Drea Renthal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7320,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7321,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7322,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7323,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Piratenfürstin",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Wer mit imperialen Credits winkt, kann auf eine große, wenn auch nicht sonderlich vertrauenswürdige Helferschar zählen.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6446,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6447,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6448,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6449,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 3,
-            "ffg_id": "XW_P_167",
-            "force_side": null,
-            "id": 167,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Söldner",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7324,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7325,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7326,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7327,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Du kannst nur über eine Notabsetzung abgesetzt werden, und du hast den Namen, die Initiative, die Pilotenfähigkeit und die Schiffs-<standardcharge> der befreundeten, zerstörten <smallcaps>Reißzahn</smallcaps>.<return><shipability><sabold>Fluchtschiff:</sabold> <smallcaps>Aufbau: </smallcaps>Erfordert die <smallcaps>Reißzahn</smallcaps>. Du <bold>musst</bold> das Spiel angedockt an der <smallcaps>Reißzahn</smallcaps> beginnen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6460,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6461,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6462,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "6",
-            "faction_id": 3,
-            "ffg_id": "XW_P_171",
-            "force_side": null,
-            "id": 171,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Nashtahwelpe</italic>",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 7340,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7341,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7342,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7343,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Notfallplan",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase darfst du 1 feindliches Schiff in deinem Feuerwinkel in Reichweite 0–2 wählen. Falls du das tust, transferiere 1 Fokus- oder Ausweichmarker von jenem Schiff auf dich selbst.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6474,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6475,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6476,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6477,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6478,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 3,
-            "ffg_id": "XW_P_175",
-            "force_side": null,
-            "id": 175,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Palob Godalhi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 7357,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7358,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7359,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7360,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Tethanischer Widerstandskämpfer",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du ein Manöver vollständig ausgeführt hast, darfst du 1<nonbreak>Stressmarker erhalten, um dein Schiff um 90° zu drehen.<return><shipability><sabold>Mikrodüsen:</sabold> Solange du eine Fassrolle durchführst, <bold>musst</bold> du die <leftbank>- oder <rightbank>-Schablone anstatt der <straight>-Schablone verwenden.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6493,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6494,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6495,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6496,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_179",
-            "force_side": null,
-            "id": 179,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Dalan Oberos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 3,
-            "statistics": [
-                {
-                    "id": 7373,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7374,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7375,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7376,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Elite-Kopfgeldjäger",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein befreundetes Schiff in Reichweite 0–1 verteidigt, darf es 1<nonbreak>seiner Würfel neu werfen.<return><shipability><sabold>Waffenaufhängung:</sabold> Du kannst 1<nonbreak><cannon>-,<nonbreak><torpedo>- oder <missile>-Aufwertung ausrüsten.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6509,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6510,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6511,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6512,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_183",
-            "force_side": null,
-            "id": 183,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Serissu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7389,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7390,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7391,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7392,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Fluglehrerin",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, darfst du 1<nonbreak><hit>-Schaden erleiden, um beliebig viele deiner Würfel neu zu werfen.<return><shipability><sabold>Waffenaufhängung:</sabold> Du kannst 1<nonbreak><cannon>-,<nonbreak><torpedo>- oder <missile>-Aufwertung ausrüsten.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6525,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6526,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6527,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6528,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 3,
-            "ffg_id": "XW_P_187",
-            "force_side": null,
-            "id": 187,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Inaldra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7405,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7406,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7407,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7408,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Stationsleiterin von Tansarii Point",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du in Angriffsreichweite 3 verteidigst oder in Angriffsreichweite<nonbreak>1 einen Angriff durchführst, wirf 1<nonbreak>zusätzlichen Würfel.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6541,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6542,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6543,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_191",
-            "force_side": null,
-            "id": 191,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Talonbane Cobra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7421,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7422,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7423,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7424,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Der Schrecken von Tansarii Point",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der Kihraxz-Angriffsjäger wurde eigens für das Verbrechersyndikat Schwarze Sonne entwickelt, dessen hochbezahlte Fliegerasse ein leistungsstarkes, wendiges Schiff verlangten, das ihren Fähigkeiten entsprach.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6553,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6554,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6555,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 3,
-            "ffg_id": "XW_P_195",
-            "force_side": null,
-            "id": 195,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Fliegerass der Schwarzen Sonne",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7437,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7438,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7439,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7440,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du eine <boost>-Aktion durchgeführt hast, darfst du eine <evade>-Aktion durchführen.<return><shipability><sabold>Hochentwickeltes Droidengehirn:</sabold> Nachdem du eine <calculate>-Aktion durchgeführt hast, erhalte 1 Berechnungsmarker.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6567,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6568,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6569,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6570,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 3,
-            "ffg_id": "XW_P_199",
-            "force_side": null,
-            "id": 199,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•IG-88C",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 21,
-            "statistics": [
-                {
-                    "id": 7453,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7454,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7455,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7456,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Cleverer Computer",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Die legendären Finder der Gand verehren den Nebelschleier, der ihren Heimatplaneten umhüllt. Um ihre Beute aufzuspüren, deuten sie mystische Zeichen und Visionen.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6581,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6582,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6583,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_203",
-            "force_side": null,
-            "id": 203,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Gand-Finder",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 22,
-            "statistics": [
-                {
-                    "id": 7469,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7470,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7471,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7472,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Angriff durchgeführt hast, erleidet jedes feindliche Schiff in deinem <bullseye>1<nonbreak><hit>-Schaden, es sei denn, es entfernt 1<nonbreak>grünen Marker.<return><shipability><sabold>Todsicherer Treffer:</sabold> Solange du einen Angriff durchführst, falls der Verteidiger in deinem <bullseye> ist, können Verteidigungswürfel nicht unter Verwendung von grünen Markern modifiziert werden.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6593,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6594,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6595,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6596,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                10,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_207",
-            "force_side": null,
-            "id": 207,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Torani Kulda",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 39,
-            "statistics": [
-                {
-                    "id": 7486,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7487,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7488,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "7"
-                },
-                {
-                    "id": 7489,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rodianische Auftragsmörderin",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du bis zu 2<nonbreak>deiner Würfel neu werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5919,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5920,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5921,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_23",
-            "force_side": null,
-            "id": 23,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Braylen Stramm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6760,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6761,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6762,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6763,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Klinge Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Falls du fliehen würdest, darfst du 1<nonbreak><standardcharge><nonbreak>ausgeben. Falls du das tust, platziere dich selbst stattdessen in der Reserve. Zu Beginn der nächsten Planungsphase platziere dich selbst innerhalb von Reichweite 1 des Spielflächenrandes, über den du geflohen bist.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6608,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6609,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6610,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                8,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 3,
-            "ffg_id": "XW_P_211",
-            "force_side": null,
-            "id": 211,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Moralo Eval",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 24,
-            "statistics": [
-                {
-                    "id": 7503,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 7504,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7505,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "9"
-                },
-                {
-                    "id": 7506,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                },
-                {
-                    "id": 7507,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Kriminelles Superhirn",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase darfst du ein befreundetes Schiff in Reichweite 0–1 wählen. Falls du das tust, transferiere alle grünen Marker, die dir zugeordnet sind, auf jenes Schiff.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6620,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6621,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6622,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_215",
-            "force_side": null,
-            "id": 215,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Manaroo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 45,
-            "statistics": [
-                {
-                    "id": 7521,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7522,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7523,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7524,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Anmutige Aruzanerin",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Seine schweren Waffensysteme und unverwüstlichen Schilde machen den B-Flügler zu einer der innovativsten Jagdmaschinen der Allianz.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5928,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5929,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5930,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_26",
-            "force_side": null,
-            "id": 26,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot der blauen Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6772,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6773,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6774,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6775,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, darfst du 1<nonbreak>Stressmarker ausgeben, um alle deine <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5922,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5923,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5924,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_24",
-            "force_side": null,
-            "id": 24,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Ten Numb",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6764,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6765,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6766,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6767,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Blau Fünf",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Das Cockpit des B-Flüglers ist in einen einzigartigen Gyrostabilisator eingebunden, der den Piloten während des gesamten Fluges in aufrechter Position hält.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5925,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5926,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5927,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 1,
-            "ffg_id": "XW_P_25",
-            "force_side": null,
-            "id": 25,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Veteran der Klingen-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6768,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6769,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6770,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6771,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Primärangriff durchführst, falls der Angriff durch ein Hindernis versperrt ist, darfst du 1 zusätzlichen Würfel werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6645,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6646,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6647,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6648,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_222",
-            "force_side": null,
-            "id": 222,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7555,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7556,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7557,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7558,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Das corellianische Kind",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Primärangriff durchführst, falls mindestens 1 anderes befreundetes Schiff in Reichweite 0–1 des Verteidigers ist, darfst du 1 zusätzlichen Angriffswürfel werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5934,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5935,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5936,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_28",
-            "force_side": null,
-            "id": 28,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lieutenant Blount",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6780,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6781,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6782,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6783,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Teamspieler",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der für den Langzeiteinsatz konzipierte TIE/ag wird in erster Linie von Elitepiloten geflogen, die das Potential des schwer bewaffneten und wendigen Jägers voll ausschöpfen können.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6294,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6295,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6296,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_129",
-            "force_side": null,
-            "id": 129,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Aufklärer der Onyx-Staffel",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7171,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7172,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7173,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7174,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Befreundete Schiffe in Reichweite 0–1 können Angriffe in Reichweite 0 zu Hindernissen durchführen.<return><shipability><sabold>Co-Pilot:</sabold> Solange du angedockt bist, hat dein Träger-Schiff deine Piloten-Fähigkeit zusätzlich zu seiner eigenen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6664,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6665,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6666,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "24",
-            "faction_id": 3,
-            "ffg_id": "XW_P_227",
-            "force_side": null,
-            "id": 227,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Pionier aus dem Outer Rim",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
-            "statistics": [
-                {
-                    "id": 7575,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7576,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7577,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7578,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Geschickter Gesetzloser",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der Z-95-Kopfjäger ist ein direkter Vorläufer von Incoms Vorzeigemodell, dem T-65-X-Flügler. Obwohl er nach modernen Standards als veraltet gilt, ist er nach wie vor ein vielseitiger und schlagkräftiger Sternjäger.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5940,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5941,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5942,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "23",
-            "faction_id": 1,
-            "ffg_id": "XW_P_30",
-            "force_side": null,
-            "id": 30,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Pilot der Banditen-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6788,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6789,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6790,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6791,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du Würfel geworfen hast, falls du nicht gestresst bist, darfst du 1 Stressmarker erhalten um alle deine Leerseiten neu zu werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6649,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6650,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6651,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6652,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 3,
-            "ffg_id": "XW_P_223",
-            "force_side": null,
-            "id": 223,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7559,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7560,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7561,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7562,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Charmanter Spieler",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein anderes befreundetes Schiff in Reichweite 0–1 verteidigt, vor dem Schritt „Ergebnisse neutralisieren“, falls du im Angriffswinkel bist, darfst du 1<nonbreak><hit>- oder <crit>-Schaden erleiden, um 1<nonbreak>passendes Ergebnis zu negieren. ",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5857,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5858,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5859,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_7",
-            "force_side": null,
-            "id": 7,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Biggs Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6696,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6697,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6698,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6699,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rot Drei",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bevor du aktiviert wirst, falls du fokussiert bist, darfst du eine Aktion durchführen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5863,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5864,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5865,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_9",
-            "force_side": null,
-            "id": 9,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Edrio Two Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6704,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6705,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6706,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6707,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Veteran der Sturmengel",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Primärangriff durchführst, falls du beschädigt bist, darfst du 1 zusätzlichen Angriffswürfel werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5946,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5947,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5948,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_32",
-            "force_side": null,
-            "id": 32,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Wullffwarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6796,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6797,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6798,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6799,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Wookiee-Häuptling",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Die AF4-Serie ist das jüngste Modell der bewährten Kopfjäger-Produktreihe, die mit ihrem günstigen Preis und ihrer robusten Bauweise zu den Favoriten vieler unabhängiger Organisationen wie der Rebellion gehört.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5937,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5938,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5939,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "25",
-            "faction_id": 1,
-            "ffg_id": "XW_P_29",
-            "force_side": null,
-            "id": 29,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot der Tala-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6784,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6785,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6786,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6787,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem ein befreundetes Schiff in Reichweite 0–1 zum Verteidiger geworden ist, darfst du 1 Verstärkungsmarker ausgeben. Falls du das tust, erhält jenes Schiff 1 Ausweichmarker.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5943,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5944,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5945,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "56",
-            "faction_id": 1,
-            "ffg_id": "XW_P_31",
-            "force_side": null,
-            "id": 31,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lowhhrick",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6792,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6793,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6794,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6795,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Entflohener Gladiator",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Angriff durchgeführt hast, darfst du 1 befreundetes Schiff in Reichweite 1 wählen. Jenes Schiff darf eine Aktion durchführen, die es als rot behandelt.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5931,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5932,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5933,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "36",
-            "faction_id": 1,
-            "ffg_id": "XW_P_27",
-            "force_side": null,
-            "id": 27,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Airen Cracken",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6776,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6777,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6778,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6779,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Geheimdienstchef",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bevor du aktiviert wirst, darfst du eine <barrelroll>- oder <boost>-Aktion durchführen.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5955,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5956,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5957,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_35",
-            "force_side": null,
-            "id": 35,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6808,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6809,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6810,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6811,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der Quadrijet-Transferschlepper, im Volksmund „Quadjumper“ genannt, ist gleichermaßen behände in Weltall und Atmosphäre, was ihn zu einem beliebten Schmuggler- und Entdeckerschiff macht. </flavor><return><shipability><sabold>Schlepperstrahl:</sabold> <smallcaps>Aktion:</smallcaps> Wähle ein Schiff in deinem <frontarc> in Reichweite 1. Jenes Schiff erhält 1 Fangstrahlmarker oder 2<nonbreak>Fangstrahlmarker, falls es in deinem <bullseye><nonbreak>in Reichweite 1 ist.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6435,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6436,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6437,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 3,
-            "ffg_id": "XW_P_164",
-            "force_side": null,
-            "id": 164,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Waffenschmuggler von Jakku",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7313,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7314,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7315,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Mit seinen drei weitreichenden Sureggi-Zwillingslaserkanonen soll das Auzituck-Kanonenboot Sklavenjäger im Kashyyyk-System abschrecken.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5949,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5950,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5951,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_33",
-            "force_side": null,
-            "id": 33,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Verteidiger von Kashyyyk",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6800,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6801,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6802,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6803,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du 1<nonbreak><forcecharge> ausgeben, um bis zu 2 deiner <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5958,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5959,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5960,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_36",
-            "force_side": 2,
-            "id": 36,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6812,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6813,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6814,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6815,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6816,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Primärangriff durchführst, darfst du entweder 1<nonbreak>Schild ausgeben, um 1 zusätzlichen Angriffswürfel zu werfen, oder, falls du keine Schilde hast, du darfst 1<nonbreak>Angriffswürfel weniger werfen, um 1<nonbreak>Schild wiederherzustellen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6048,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6049,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6050,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6051,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6052,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_62",
-            "force_side": null,
-            "id": 62,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Miranda Doni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6919,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6920,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6921,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6922,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Schweres Geschütz",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Während des Schrittes „Aktion durchführen“ darfst du 1 Aktion durchführen, auch solange du gestresst bist. Nachdem du eine Aktion durchgeführt hast, solange du gestresst bist, erleide 1<nonbreak><hit>-Schaden, es sei denn, du legst 1<nonbreak>deiner Schadenskarten offen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_83",
-            "force_side": null,
-            "id": 307,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•„Chopper“",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Aktion:</smallcaps> Gib 1 nicht-wiederkehrende <standardcharge> von einer anderen ausgerüsteten Aufwertung aus, um 1 Schild wiederherzustellen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_99",
-            "force_side": null,
-            "id": 323,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•„Chopper“",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du ein Manöver vollständig ausgeführt hast, falls du in dieser Runde noch kein Gerät abgeworfen oder gestartet hast, darfst du 1<nonbreak>Bombe abwerfen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_143",
-            "force_side": null,
-            "id": 368,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•„Genie“",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Du kannst 1 Jagdshuttle oder eine Raumfähre der <italic>Sheathipede</italic>-Klasse andocken lassen.<return>Deine angedockten Schiffe können nur von deinen hinteren Stoppern aus abgesetzt werden.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_102",
-            "force_side": null,
-            "id": 326,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Ghost</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 23,
-                            "raw_name": "VCX-100 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "An dir kann 1<nonbreak>Z-95-AF4-Kopfjäger andocken.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_148",
-            "force_side": null,
-            "id": 373,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Reißzahn</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 24,
-                            "raw_name": "YV-666 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Du kannst in Reichweite 0–1 andocken.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_106",
-            "force_side": null,
-            "id": 330,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Phantom</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 32,
-                            "raw_name": "Attack Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    },
-                    {
-                        "kwargs": {
-                            "pk": 8,
-                            "raw_name": "Sheathipede-class Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Primärangriff durchführst, falls der Verteidiger in deinem <frontarc> ist, wirf 1<nonbreak>zusätzlichen Angriffswürfel.<return>Entferne den <crew>-Slot. Füge den <astro>-Slot hinzu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_152",
-            "force_side": null,
-            "id": 377,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Vollstrecker Eins</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 45,
-                            "raw_name": "JumpMaster 5000"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase darfst du 1 feindliches Schiff in Reichweite 0–1 wählen. Falls du das tust, erhältst du 1 Berechnungsmarker, es sei denn, jenes Schiff entscheidet sich dafür, 1<nonbreak>Stressmarker zu erhalten.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_127",
-            "force_side": null,
-            "id": 352,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•0-0-0",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 338
-                        },
-                        "type": "CARD_INCLUDED"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 93
-                        },
-                        "type": "CARD_INCLUDED"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem ein anderes befreundetes Schiff in Reichweite 0–3 verteidigt hat, falls es zerstört ist, erhält der Angreifer 2 Stressmarker.<return>Solange ein befreundetes Schiff in Reichweite 0–3 einen Angriff gegen ein gestresstes Schiff durchführt, darf es 1 Angriffswürfel neu werfen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_109",
-            "force_side": null,
-            "id": 335,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Admiral Sloane",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Primärangriff durchgeführt hast, falls du fokussiert bist, darfst du einen Bonus-<turretarc>-Angriff gegen ein Schiff, das du in dieser Runde noch nicht angegriffen hast, durchführen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "14",
-            "faction_id": null,
-            "ffg_id": "XW_U_95",
-            "force_side": null,
-            "id": 319,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bistan",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Primärangriff durchgeführt hast, der verfehlt hat, falls du nicht gestresst bist, <bold>musst</bold> du 1 Stressmarker erhalten, um einen Bonus-Primärangriff gegen dasselbe Ziel durchzuführen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_139",
-            "force_side": null,
-            "id": 364,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bossk",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du eine <focus>-Aktion durchführst, darfst du sie behandeln, als wäre sie rot. Falls du das tust, erhalte 1 zusätzlichen Fokusmarker für jedes feindliche Schiff in Reichweite 0–1, bis zu einem Maximum von 2.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_79",
-            "force_side": null,
-            "id": 303,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Baze Malbus",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Während der Endphase darfst du 2<nonbreak><illicit>-Aufwertungen wählen, die befreundete Schiffe in Reichweite 0–1 ausgerüstet haben. Falls du das tust, darfst du diese Aufwertungen austauschen.<return><smallcaps>Spielende:</smallcaps> Lege alle <illicit>-Aufwertungen auf ihre ursprünglichen Schiffe zurück.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_131",
-            "force_side": null,
-            "id": 356,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Cikatro Vizago",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Aktion:</smallcaps> Gib 1<nonbreak><standardcharge> aus, um eine <cloak>-Aktion durchzuführen.<return>Zu Beginn der Planungsphase wirf 1<nonbreak>Angriffswürfel. Bei einem <focus>-Ergebnis, enttarne dich oder lege deinen Tarnungsmarker ab.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_57",
-            "force_side": null,
-            "id": 286,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Tarngerät",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6594,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Während der Aktivierungsphase können feindliche Schiffe in Reichweite 0–1 keine Stressmarker entfernen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_113",
-            "force_side": null,
-            "id": 339,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Todestruppen",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8,
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Während der Systemphase darfst du 2 <standardcharge> ausgeben. Falls du das tust, darf jedes befreundete Schiff ein Schiff, das du als Ziel erfasst hast, als Ziel erfassen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_117",
-            "force_side": null,
-            "id": 343,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Großmoff Tarkin",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "STRESS"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6601,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Aufbau:</smallcaps> Nachdem die Streitkräfte platziert worden sind, wähle 1<nonbreak>feindliches Schiff und ordne ihm den Zustand Abhörgerät zu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_44",
-            "force_side": null,
-            "id": 273,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Informant",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Falls ein befreundetes Schiff in Reichweite 0–3 einen Fokusmarker erhalten würde, darf es stattdessen 1<nonbreak>Ausweichmarker erhalten.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_85",
-            "force_side": null,
-            "id": 309,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Jyn Erso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst, falls der Angreifer gestresst ist, darfst du 1 Stressmarker vom Angreifer entfernen, um 1 deiner Leerseiten/<focus>-Ergebnisse in ein <evade>-Ergebnis zu ändern.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_135",
-            "force_side": null,
-            "id": 360,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Latts Razzi",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls keine anderen befreundeten Schiffe in Reichweite 0–2 sind, darfst du 1<nonbreak><standardcharge> ausgeben, um 1 deiner Würfel neu zu werfen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_9",
-            "force_side": null,
-            "id": 238,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Einsamer Wolf",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6606,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du verteidigt hast, falls der Angriff getroffen hat, darfst du den Angreifer als Ziel erfassen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_89",
-            "force_side": null,
-            "id": 313,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du koordinierst, kann das von dir gewählte Schiff eine Aktion nur dann durchführen, falls jene Aktion auch in deiner Aktionsleiste ist.",
-            "available_actions": [
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 5830,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_16",
-            "force_side": null,
-            "id": 245,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Staffelführer",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bevor du Schaden durch ein Hindernis oder die Detonation einer befreundeten Bombe erleiden würdest, darfst du 1<nonbreak><standardcharge> ausgeben. Falls du das tust, verhindere 1 Schaden.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_68",
-            "force_side": null,
-            "id": 292,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ablative Panzerung",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "LARGE"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6614,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Ändere 1<nonbreak><hit>-Ergebnis in ein<nonbreak><crit>-Ergebnis.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_33",
-            "force_side": null,
-            "id": 262,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Verstärkte Protonentorpedos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6615,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "5"
-                },
-                {
-                    "id": 6617,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                5
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1"
-        },
-        {
-            "ability_text": "Nachdem du dein Rad aufgedeckt hast, darfst du 1 Aktion durchführen.<return>Falls du das tust, kannst du während deiner Aktivierung keine weitere Aktion durchführen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_23",
-            "force_side": null,
-            "id": 252,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Verbesserte Sensoren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du eine <slam>-Aktion durchgeführt hast, falls du das Manöver vollständig ausgeführt hast, darfst du eine weiße Aktion aus deiner Aktionsleiste durchführen, wobei du jene Aktion behandelst, als wäre sie rot.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_69",
-            "force_side": null,
-            "id": 293,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Verbesserter SLAM",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Slam",
-                            "pk": 13,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bombe</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Streubombe abzuwerfen.<return>Zu Beginn der Aktivierungsphase darfst du 1 Schild ausgeben, um 2<nonbreak><standardcharge> wiederherzustellen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_63",
-            "force_side": null,
-            "id": 392,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Streubombengenerator",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6622,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12,
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Nach diesem Angriff darfst du diesen Angriff als Bonusangriff gegen ein anderes Ziel in Reichweite 0–1 des Verteidigers durchführen, wobei du die <targetlock>-Voraussetzung ignorierst.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_37",
-            "force_side": null,
-            "id": 266,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Clusterraketen",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6623,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6625,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "4"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                6
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<flavor>Der UT-60D-U-Flügler deckt den Bedarf der Rebellion an schnellen, unverwüstlichen Truppentransportern. Meistens wird er eingesetzt, um Soldaten im Schutz der Dunkelheit oder inmitten eines tobenden Gefechts an ihren Einsatzort zu befördern. </flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6042,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6043,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6044,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_60",
-            "force_side": null,
-            "id": 60,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Aufklärer der blauen ",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6911,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6912,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6913,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6914,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du Schub gibst oder eineFassrolle fliegst, kannst du dichdurch Hindernisse hindurch­bewegen und sie überschneiden.<return>Nachdem du dich durch ein Hindernis hindurchbewegt oder es überschnitten hast, darfst du 1<nonbreak><standardcharge> ausgeben, um seine Effekte bis zum Ende der Runde zu ignorieren.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_24",
-            "force_side": null,
-            "id": 253,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Kollisionssensor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6626,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bevor du aktiviert wirst, darfst du 1<nonbreak><standardcharge> ausgeben. Falls du das tust, kannst du bis zum Ende der Runde Aktionen durchführen und rote Manöver ausführen, auch solange du gestresst bist.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_58",
-            "force_side": null,
-            "id": 287,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Illegale Kybernetik",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6631,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du eine weiße <boost>-Aktion durchführst, darfst du sie behandeln, als wäre sie rot, um stattdessen die [1<nonbreak><leftturn>]- oder [1<nonbreak><rightturn>]-Schablone zu verwenden.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                12
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_2",
-            "force_side": null,
-            "id": 231,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Draufgänger",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Boost",
-                            "pk": 1,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Aufbau:</smallcaps> Verliere 1<nonbreak><standardcharge>.<return><smallcaps>Aktion:</smallcaps> Stelle 1<nonbreak><standardcharge> wieder her.<return><smallcaps>Aktion:</smallcaps> Gib 1<nonbreak><standardcharge> aus, um 1 Schild wiederherzustellen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_43",
-            "force_side": null,
-            "id": 272,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "GNK-„Gonk“-Droide",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6636,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen <turretarc>-Angriff durchführst, nach dem Schritt „Verteidigungswürfel modifizieren“, entfernt der Verteidiger 1 Fokus- oder 1 Berechnungsmarker.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_49",
-            "force_side": null,
-            "id": 278,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Erstklassiger Bordschütze",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Auch wer sich keinen verbesserten Schildgenerator leisten kann, muss nicht auf erhöhten Schutz verzichten, sondern kann sich mit zusätzlichen Panzerplatten an der Schiffshülle behelfen.</flavor>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "*",
-            "faction_id": null,
-            "ffg_id": "XW_U_73",
-            "force_side": null,
-            "id": 297,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Verstärkte Hülle",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6642,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_28",
-            "force_side": null,
-            "id": 257,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ionenkanone",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6643,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                3
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
-        },
-        {
-            "ability_text": "Solange du einen <frontarc>-Angriff durchführst, falls du nicht im Feuerwinkel des Verteidigers bist, wirft der Verteidiger 1<nonbreak>Verteidigungswürfel weniger.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_11",
-            "force_side": null,
-            "id": 240,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ausmanövrieren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du dein Rad aufgedeckt hast, darfst du 1<nonbreak><standardcharge> ausgeben und 1 Entwaffnet-Marker erhalten, um 1<nonbreak>Schild wiederherzustellen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-            "card_set_ids": [
-                1,
-                4,
-                6,
-                7
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_53",
-            "force_side": null,
-            "id": 282,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "R2-Astromechdroide",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6663,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst, werden <crit>-Ergebnisse neutralisiert, bevor <hit>-Ergebnisse neutralisiert werden.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5961,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5962,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5963,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_37",
-            "force_side": null,
-            "id": 37,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Zeb“ Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6817,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6818,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6819,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6820,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem ein feindliches Schiff in deinem Feuerwinkel begonnen hat zu kämpfen, falls du nicht gestresst bist, darfst du 1 Stressmarker erhalten. Falls du das tust, kann jenes Schiff keine Marker ausgeben, um Würfel zu modifizieren, solange es während dieser Phase einen Angriff durchführt.<return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5964,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5965,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_38",
-            "force_side": null,
-            "id": 38,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6821,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6822,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6823,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6824,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6825,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Rebell wider Willen",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Ein Vogel mit ausgebreiteten Schwingen diente der Corellianischen Ingenieursgesellschaft als Vorbild für das Design der „Hawk“-Serie, einer Reihe von erstklassigen Transportschiffen. Der flinke und robuste HWK-290 wird oft von Rebellenagenten als mobile Operationsbasis eingesetzt.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5987,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5988,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5989,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5990,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5991,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_45",
-            "force_side": null,
-            "id": 45,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebellen-Aufklärer",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6854,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6855,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6856,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6857,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du 1<nonbreak><forcecharge> ausgeben, um bis zu 2 deiner <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern. <return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5966,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5967,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                10,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_39",
-            "force_side": 2,
-            "id": 39,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6826,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6827,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6828,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6829,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6830,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6831,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst, werden <crit>-Ergebnisse neutralisiert, bevor <hit>-Ergebnisse neutralisiert werden.<return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5968,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5969,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_40",
-            "force_side": null,
-            "id": 40,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Zeb“ Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6832,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6833,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6834,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6835,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6836,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du koordinierst, falls du ein Schiff mit genau 1 Stressmarker wählst, kann es Aktionen durchführen.<return><shipability><sabold>Kommunikationsantennen:</sabold> Solange du angedockt bist, erhält dein Trägerschiff <coordinate>. Bevor dein Trägerschiff aktiviert wird, darf es eine <coordinate>-Aktion durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5970,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5971,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_41",
-            "force_side": null,
-            "id": 41,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-            "initiative": 1,
-            "is_unique": true,
-            "name": "•AP-5",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6837,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6838,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6839,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6840,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6841,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Entflohener Inventardroide",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein befreundetes Schiff in deinem Feuerwinkel einen Primärangriff durchführt, falls du nicht gestresst bist, darfst du 1<nonbreak>Stressmarker erhalten. Falls du das tust, darf jenes Schiff 1<nonbreak>zusätzlichen Angriffswürfel werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5972,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5973,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5974,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5975,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5976,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_42",
-            "force_side": null,
-            "id": 42,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Jan Ors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6842,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6843,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6844,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6845,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Spionageexpertin",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase darfst du 1 deiner Fokusmarker auf ein<nonbreak>befreundetes Schiff in deinem Feuerwinkel transferieren.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5977,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5978,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5979,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5980,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5981,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_43",
-            "force_side": null,
-            "id": 43,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kyle Katarn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6846,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6847,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6848,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6849,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Unbeugsamer Agent",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase darfst du 1 Schiff in deinem Feuerwinkel wählen. Falls du das tust, kämpft es in dieser Phase bei Initiative 7 anstatt bei seiner normalen Initiative.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5982,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5983,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5984,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5985,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5986,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_44",
-            "force_side": null,
-            "id": 44,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Roark Garnet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6850,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6851,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6852,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6853,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gutherziger Schmuggler",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bevor du aktiviert wirst, darfst du eine <barrelroll>- oder <boost>-Aktion durchführen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5995,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5996,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5997,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 1,
-            "ffg_id": "XW_P_47",
-            "force_side": null,
-            "id": 47,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6862,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6863,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6864,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du zum Verteidiger geworden bist (bevor Würfel geworfen werden), darfst du 1<nonbreak><forcecharge> wiederherstellen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5842,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5843,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5844,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                17,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "62",
-            "faction_id": 1,
-            "ffg_id": "XW_P_2",
-            "force_side": 2,
-            "id": 2,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Luke Skywalker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6675,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6676,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6677,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6678,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 6679,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rot Fünf",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein befreundetes Schiff einen Angriff durchführt, falls der Verteidiger in deinem <frontarc> ist, darf der Angreifer 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis ändern.<return><shipability><sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6009,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6010,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6011,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6012,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6013,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 1,
-            "ffg_id": "XW_P_51",
-            "force_side": null,
-            "id": 51,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Gavin Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6875,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6876,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6877,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6878,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Tapferer Flügelmann",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Die Spitzenpiloten der Renegaten-Staffel gehören zur absoluten Elite der Rebellion. </flavor><return><shipability> <sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6014,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6015,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6016,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6017,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6018,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "63",
-            "faction_id": 1,
-            "ffg_id": "XW_P_52",
-            "force_side": null,
-            "id": 52,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Eskorte der Renegaten-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6879,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6880,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6881,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6882,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der E-Flügler verbindet die besten Eigenschaften von X-Flügler und A-Flügler, und kann mit überlegener Feuerkraft, Geschwindigkeit und Manövrierbarkeit aufwarten.</flavor><return><shipability> <sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6019,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6020,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6021,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6022,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6023,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "61",
-            "faction_id": 1,
-            "ffg_id": "XW_P_53",
-            "force_side": null,
-            "id": 53,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Eskorte der Schurken-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6883,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6884,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6885,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6886,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du ein rotes oder blaues Manöver aufgedeckt hast, darfst du dein Rad auf ein anderes Manöver derselben Schwierigkeit einstellen.<return><shipability><sabold>Geladen und entsichert:</sabold> Solange du angedockt bist, nachdem dein Trägerschiff einen <frontarc>-Primärangriff oder <turret>-Angriff durchgeführt hat, darf es einen Bonus-<reararc>-Primärangriff durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5952,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5953,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5954,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "39",
-            "faction_id": 1,
-            "ffg_id": "XW_P_34",
-            "force_side": null,
-            "id": 34,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6804,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6805,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6806,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6807,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem ein feindliches Schiff ein Manöver ausgeführt hat, falls es in Reichweite 0 ist, darfst du eine Aktion durchführen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6039,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6040,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6041,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_59",
-            "force_side": null,
-            "id": 59,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Heff Tobber",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6907,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6908,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6909,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6910,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Blau Acht",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Ursprünglich hatten sich Saw Gerreras Partisanen während der Klonkriege formiert, um den Streitkräften der Separatisten auf Onderon die Stirn zu bieten. Als das Imperium die Macht übernahm, setzten sie ihren Kampf gegen die Tyrannei einfach fort.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6045,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6046,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6047,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_61",
-            "force_side": null,
-            "id": 61,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Überzeugter Partisan",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6915,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6916,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6917,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6918,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der K-Flügler von Koensayr zeichnet sich durch einen topmodernen Sublicht-Antriebsmotor (kurz: SLAM) sowie beispiellose achtzehn Waffenaufhängungen aus. Was Geschwindigkeit und Feuerkraft anbelangt, steht er außer Konkurrenz.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6058,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6059,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6060,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6061,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6062,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 1,
-            "ffg_id": "XW_P_64",
-            "force_side": null,
-            "id": 64,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot der Beschützer-Staffel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6927,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6928,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6929,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6930,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls du gestresst bist, darfst du 1<nonbreak><forcecharge> ausgeben, um bis zu 2 deiner <focus>-Ergebnisse in <evade>- oder <hit>-Ergebnisse zu ändern.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5992,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5993,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5994,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_46",
-            "force_side": 2,
-            "id": 46,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6858,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6859,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6860,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6861,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Angriff durchgeführt hast, ordne dem Verteidiger den Zustand <smallcaps>Sperrfeuer</smallcaps> zu.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5998,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5999,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6000,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_48",
-            "force_side": null,
-            "id": 48,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Captain Rex",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6865,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6866,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6867,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Veteran der Klonkriege",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst, werden <crit>-Ergebnisse neutralisiert, bevor <hit>-Ergebnisse neutralisiert werden.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6001,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6002,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6003,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "26",
-            "faction_id": 1,
-            "ffg_id": "XW_P_49",
-            "force_side": null,
-            "id": 49,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Zeb“ Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6868,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6869,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6870,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bei Initiative 0 darfst du einen Bonus-Primärangriff gegen ein feindliches Schiff in deinem <bullseye> durchführen. Falls du das tust, erhalte zu Beginn der nächsten Planungsphase 1 Entwaffnet-Marker.<return><shipability><sabold>Experimentelle Scanner:</sabold> Du kannst Ziele jenseits von Reichweite 3 erfassen. Du kannst keine Ziele in Reichweite 1 erfassen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6004,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6005,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6006,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6007,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6008,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 1,
-            "ffg_id": "XW_P_50",
-            "force_side": null,
-            "id": 50,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Corran Horn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6871,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6872,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6873,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6874,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Hartnäckiger Ermittler",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst, falls ein feindliches Schiff in Reichweite 0–1 ist, füge 1<nonbreak><evade>-Ergebnis zu deinen Würfelergebnissen hinzu.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6063,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6064,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6065,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "55",
-            "faction_id": 1,
-            "ffg_id": "XW_P_65",
-            "force_side": null,
-            "id": 65,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Norra Wexley",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6931,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6932,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6933,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6934,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6935,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Gold Neun",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Befreundete Schiffe können Objekte in Reichweite 0–3 eines beliebigen befreundeten Schiffes als Ziele erfassen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6024,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6025,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6026,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 1,
-            "ffg_id": "XW_P_54",
-            "force_side": null,
-            "id": 54,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Bodhi Rook",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6887,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6888,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6889,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6890,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Imperialer Überläufer",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Aktivierungsphase darfst du 1 befreundetes Schiff in Reichweite 1–3 wählen. Falls du das tust, entfernt jenes Schiff 1 Stressmarker.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6030,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6031,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6032,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_56",
-            "force_side": null,
-            "id": 56,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Cassian Andor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6895,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6896,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6897,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6898,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Aufgewachsen bei der Rebellion",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein befreundetes Schiff in Reichweite 0–2 verteidigt, kann der Angreifer nicht mehr als 1<nonbreak>Angriffswürfel neu werfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6033,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6034,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6035,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_57",
-            "force_side": null,
-            "id": 57,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6899,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6900,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6901,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6902,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Aufklärerin der Sturmengel",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du eine <focus>-Aktion durchgeführt hast, darfst du 1 deiner Fokusmarker auf ein befreundetes Schiff in Reichweite 1–2 transferieren.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6036,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6037,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6038,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_58",
-            "force_side": null,
-            "id": 58,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Benthic Two Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6903,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6904,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6905,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6906,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Meisterschütze der Sturmengel",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein befreundetes Schiff in Reichweite 0–2 verteidigt oder einen Angriff durchführt, darf es deine Fokusmarker ausgeben, als ob jenes Schiff sie hätte.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6053,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6054,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6055,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6056,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6057,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_63",
-            "force_side": null,
-            "id": 63,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Esege Tuketu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6923,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6924,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6925,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6926,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Selbstloser Held",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Fokusmarker ausgegeben hast, darfst du 1<nonbreak>befreundetes Schiff in Reichweite 1–3 wählen. Jenes Schiff erhält 1 Fokusmarker.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6066,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6067,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6068,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "51",
-            "faction_id": 1,
-            "ffg_id": "XW_P_66",
-            "force_side": null,
-            "id": 66,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6936,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6937,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6938,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6939,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6940,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Rot Eins",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du verteidigst oder einen Primärangriff durchführst, darfst du 1 Zielerfassung, die du auf dem feindlichen Schiff hast, ausgeben, um 1<nonbreak><focus>-Ergebnis zu deinen Würfelergebnissen hinzuzufügen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6069,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6070,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6071,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "53",
-            "faction_id": 1,
-            "ffg_id": "XW_P_67",
-            "force_side": null,
-            "id": 67,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Shara Bey",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6941,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6942,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6943,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6944,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6945,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Grün Vier",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du ein Manöver vollständig ausgeführt hast, falls du gestresst bist, darfst du 1 Angriffswürfel werfen. Bei einem <hit>- oder <crit>-Ergebnis entferne 1<nonbreak>Stressmarker.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6072,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6073,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6074,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_68",
-            "force_side": null,
-            "id": 68,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ibtisam",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6946,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6947,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6948,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6949,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6950,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Überlebende von Endor",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du Würfel geworfen hast, falls du in Reichweite 0–1 eines Hindernisses bist, darfst du alle deine Würfel neu werfen. Dies zählt für alle anderen Effekte nicht als Neuwerfen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6075,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6076,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6077,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6078,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "92",
-            "faction_id": 1,
-            "ffg_id": "XW_P_69",
-            "force_side": null,
-            "id": 69,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6951,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6952,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6953,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6954,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Verwegener Söldner",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bevor dir eine offene Schadenskarte zugeteilt werden würde, darfst du 1<nonbreak><standardcharge> ausgeben, um die Karte stattdessen verdeckt zugeteilt zu bekommen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6083,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6084,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6085,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6086,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 1,
-            "ffg_id": "XW_P_71",
-            "force_side": null,
-            "id": 71,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6959,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6960,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6961,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6962,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                },
-                {
-                    "id": 6963,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Der Mächtige",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Mit seiner robusten Bauweise und modularen Konstruktion gehört der YT-1300 zu den beliebtesten, weitverbreitetsten und am stärksten modifizierten Raumfrachtern der Galaxis. </flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6087,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6088,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6089,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6090,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "78",
-            "faction_id": 1,
-            "ffg_id": "XW_P_72",
-            "force_side": null,
-            "id": 72,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Schmuggler aus dem ",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6964,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6965,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6966,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6967,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du ein rotes oder blaues Manöver aufgedeckt hast, darfst du dein Rad auf ein anderes Manöver derselben Schwierigkeit einstellen.<return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6091,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6092,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6093,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "76",
-            "faction_id": 1,
-            "ffg_id": "XW_P_73",
-            "force_side": null,
-            "id": 73,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6968,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6969,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6970,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6971,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein befreundetes Schiff in deinem Feuerwinkel verteidigt, darfst du 1<nonbreak><forcecharge> ausgeben. Falls du das tust, wirft der Angreifer 1 Angriffswürfel weniger.<return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6094,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6095,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6096,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "90",
-            "faction_id": 1,
-            "ffg_id": "XW_P_74",
-            "force_side": 2,
-            "id": 74,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kanan Jarrus",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6972,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6973,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6974,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6975,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                },
-                {
-                    "id": 6976,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Spectre-1",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zu Beginn der Kampfphase erhält jedes feindliche Schiff in Reichweite 0 2 Störsignalmarker. <return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6097,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6098,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6099,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 1,
-            "ffg_id": "XW_P_75",
-            "force_side": null,
-            "id": 75,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Chopper“",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6977,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6978,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6979,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6980,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-3",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Der VCX-100 ist ein weiteres Erfolgsmodell der Corellianischen Ingenieursgesellschaft, geräumiger und mit mehr Ausstattungsoptionen als die beliebte YT-Serie.</flavor><return><shipability><sabold>Heckgeschütz:</sabold> Solange du ein angedocktes Schiff hast, hast du eine <reararc>-Primärwaffe mit einem Angriffswert in Höhe des Angriffswertes der <frontarc>-Primärwaffe deines angedockten Schiffes.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6100,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6101,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6102,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 1,
-            "ffg_id": "XW_P_76",
-            "force_side": null,
-            "id": 76,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebell von Lothal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6981,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6982,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6983,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6984,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>In der Schlacht von Yavin begleiteten die Elite­-piloten der schwarzen Staffel mit ihren TIE/ln-Jägern Darth Vader auf seinem vernichtenden Schlag gegen die Rebellion.</flavor>",
             "available_actions": [
                 {
@@ -12311,6 +7715,93 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du eine Aktion durchgeführt hast, darfst du 1<nonbreak><forcecharge> ausgeben, um eine Aktion durchzuführen.<return><shipability><sabold>Verbesserter Zielcomputer:</sabold> Solange du einen Primärangriff gegen einen Verteidiger durchführst, den du als Ziel erfasst hast, wirf 1<nonbreak>zusätzlichen Angriffswürfel und ändere 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6154,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6155,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6156,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 2,
+            "ffg_id": "XW_P_93",
+            "force_side": 1,
+            "id": 93,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Darth Vader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7038,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7039,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7040,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7041,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7042,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Schwarz Eins",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12552,6 +8043,87 @@
                 }
             ],
             "subtitle": "Gnadenloser Verwalter",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der TIE-x1-Turbojäger wurde nur in geringer Stückzahl produziert, dafür wurden viele seiner Innovationen bei der Entwicklung von Sienars nächstem TIE-Modell, dem TIE-Abfangjäger, übernommen.</flavor><return><shipability><sabold>Verbesserter Zielcomputer:</sabold> Solange du einen Primärangriff gegen einen Verteidiger durchführst, den du als Ziel erfasst hast, wirf 1 zusätzlichen Angriffswürfel und ändere 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6166,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6167,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6168,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 2,
+            "ffg_id": "XW_P_97",
+            "force_side": null,
+            "id": 97,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Fliegerass der Storm-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7055,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7056,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7057,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7058,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12835,6 +8407,278 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Sienars TIE-v1-Turbojäger war eine bahnbrechende Entwicklung auf dem Gebiet der Sternenjäger-Technologie. Er verfügt über stärkere Triebwerke, einen Raketenwerfer sowie klappbare S-Flügel.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6182,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6183,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6184,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6185,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6186,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_101",
+            "force_side": null,
+            "id": 101,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Imperialer Baron",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7073,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7074,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7075,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7076,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Die gefürchteten Inquisitoren haben nicht nur freie Hand bei der Ausübung ihrer Pflichten, sondern auch Zugang zu modernster Spitzentechnik wie dem TIE-v1-Turbojäger-Prototypen.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6187,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6188,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6189,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6190,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6191,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 2,
+            "ffg_id": "XW_P_102",
+            "force_side": 1,
+            "id": 102,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Inquisitor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7077,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7078,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7079,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7080,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7081,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase, falls ein feindliches Schiff in deinem <bullseye> ist, erhalte 1 Fokusmarker.<return><shipability><sabold>Automatische Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <barrelroll>-Aktion oder eine rote <boost>-Aktion durchführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6192,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6193,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6194,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6195,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 2,
+            "ffg_id": "XW_P_103",
+            "force_side": null,
+            "id": 103,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Soontir Fel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 41,
+            "statistics": [
+                {
+                    "id": 7082,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7083,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7084,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Legendäres Fliegerass",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Nachdem du einen Angriff durchgeführt hast, darfst du eine <barrelroll>- oder <boost>-Aktion durchführen, auch falls du gestresst bist.<return><shipability><sabold>Automatische Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <barrelroll>-Aktion oder eine rote <boost>-Aktion durchführen.</shipability>",
             "available_actions": [
                 {
@@ -12995,86 +8839,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Zu Beginn der Kampfphase, falls ein feindliches Schiff in deinem <bullseye> ist, erhalte 1 Fokusmarker.<return><shipability><sabold>Automatische Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <barrelroll>-Aktion oder eine rote <boost>-Aktion durchführen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6192,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6193,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6194,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6195,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 2,
-            "ffg_id": "XW_P_103",
-            "force_side": null,
-            "id": 103,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Soontir Fel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 41,
-            "statistics": [
-                {
-                    "id": 7082,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7083,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7084,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Legendäres Fliegerass",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>Sienar Flottensysteme konzipierte den TIE-Abfangjäger mit vier Laserkanonen an den Tragflächenspitzen. Dadurch ist er seinen Vorgängermodellen waffentechnisch weit überlegen.</flavor><return><shipability><sabold>Automatische Schubdüsen:</sabold> Nachdem du eine Aktion durchgeführt hast, darfst du eine rote <barrelroll>-Aktion oder eine rote <boost>-Aktion durchführen.</shipability>",
             "available_actions": [
                 {
@@ -13149,6 +8913,91 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du eine <reload>-Aktion durchgeführt hast, darfst du 1<nonbreak><standardcharge> von 1 deiner ausgerüsteten <talent>-Aufwertungskarten wiederherstellen. <return><shipability><sabold>Wendiger Bomber:</sabold> Falls du unter Verwendung einer <straight>-Schablone ein Gerät abwerfen würdest, darfst du stattdessen eine <leftbank>- oder <rightbank>-Schablone derselben Geschwindigkeit verwenden.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6208,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6209,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6210,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6211,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_107",
+            "force_side": null,
+            "id": 107,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Tomax Bren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7094,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7095,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7096,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Ungestümer Einzelkämpfer",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13319,6 +9168,90 @@
                 }
             ],
             "subtitle": "Scimitar Eins",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du zerstört worden bist, bevor du entfernt wirst, darfst du einen Angriff durchführen und 1 Gerät abwerfen oder starten.<return><shipability><sabold>Wendiger Bomber:</sabold> Falls du unter Verwendung einer <straight>-Schablone ein Gerät abwerfen würdest, darfst du stattdessen eine <leftbank>- oder <rightbank>-Schablone derselben Geschwindigkeit verwenden.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6220,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6221,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6222,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6223,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_110",
+            "force_side": null,
+            "id": 110,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Todesfeuer“",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7103,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7104,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7105,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Unverwüstlich und unerschrocken",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13580,6 +9513,93 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange du verteidigst, falls der Angreifer keine grünen Marker hat, darfst du 1 deiner Leerseiten- oder <focus>-Ergebnisse in ein <evade>-Ergebnis ändern.<return><sabold>Adaptive Querruder:</sabold> Bevor du dein Rad aufdeckst, falls du nicht gestresst bist, <bold>musst</bold> du ein weißes [1<nonbreak><leftbank>]-, [1<nonbreak><straight>]- oder [1<nonbreak><rightbank>]-Manöver ausführen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6236,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6237,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6238,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6239,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 2,
+            "ffg_id": "XW_P_114",
+            "force_side": null,
+            "id": 114,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Captain Feroph",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 43,
+            "statistics": [
+                {
+                    "id": 7116,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7117,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7118,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7119,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Imperial Kurier",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Nachdem du unter Verwendung deiner Schiffsfähigkeit <smallcaps>Adaptive Querruder</smallcaps> ein Manöver mit Geschwindigkeit 1 vollständig ausgeführt hast, darfst du eine <coordinate>-Aktion durchführen. Falls du das tust, überspringe deinen Schritt „Aktion durchführen“.<return><sabold>Adaptive Querruder:</sabold> Bevor du dein Rad aufdeckst, falls du nicht gestresst bist, <bold>musst</bold> du ein weißes [1<nonbreak><leftbank>]-, [1<nonbreak><straight>]- oder [1<nonbreak><rightbank>]-Manöver ausführen.",
             "available_actions": [
                 {
@@ -13826,6 +9846,80 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange du verteidigst, nach dem Schritt „Ergebnisse neutralisieren“, falls du nicht gestresst bist, darfst du 1<nonbreak><hit>-Schaden erleiden und 1<nonbreak>Stressmarker erhalten. Falls du das tust, negiere alle Würfelergebnisse.<return><shipability><sabold>Adaptive Querruder:</sabold> Bevor du dein Rad aufdeckst, falls du nicht gestresst bist, <bold>musst</bold> du ein weißes [1<nonbreak><leftbank>]-, [1<nonbreak><straight>]- oder [1<nonbreak><rightbank>]-Manöver ausführen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6251,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6252,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6253,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_118",
+            "force_side": null,
+            "id": 118,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•„Countdown“",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 16,
+            "statistics": [
+                {
+                    "id": 7131,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7132,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7133,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Stärker als der Tod",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen Angriff durchführst, falls du 1 oder weniger Schadenskarten hast, darfst du 1 zusätzlichen Angriffswürfel werfen.<return><shipability><sabold>Adaptive Querruder:</sabold> Bevor du dein Rad aufdeckst, falls du nicht gestresst bist, <bold>musst</bold> du ein weißes [1<nonbreak><leftbank>]-, [1<nonbreak><straight>]- oder [1<nonbreak><rightbank>]-Manöver ausführen.</shipability>",
             "available_actions": [
                 {
@@ -14047,26 +10141,40 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Solange ein beschädigtes befreundetes Schiff in Reichweite 0–3 einen Angriff durchführt, darf es 1<nonbreak>Angriffswürfel neu werfen.",
+            "ability_text": "Nachdem du einen Angriff durchgeführt hast, der getroffen hat, falls du ausweichst, lege 1 der Schadenskarten des Verteidigers offen.<return><shipability><sabold>Vollgas:</sabold> Nachdem du ein Manöver mit Geschwindigkeit 3–5 vollständig ausgeführt hast, darfst du eine <evade>-Aktion durchführen.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6263,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6266,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14074,156 +10182,54 @@
             "available_upgrades": [
                 1,
                 2,
-                8,
-                8,
-                13,
-                14,
-                18
+                3,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_55",
-            "force_side": null,
-            "id": 55,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6891,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6892,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6893,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6894,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Zwanghafter Gesetzloser",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Die gefürchteten Inquisitoren haben nicht nur freie Hand bei der Ausübung ihrer Pflichten, sondern auch Zugang zu modernster Spitzentechnik wie dem TIE-v1-Turbojäger-Prototypen.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6187,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6188,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6189,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6190,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6191,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 1,
-            "cost": "40",
+            "cost": "84",
             "faction_id": 2,
-            "ffg_id": "XW_P_102",
-            "force_side": 1,
-            "id": 102,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Inquisitor",
+            "ffg_id": "XW_P_122",
+            "force_side": null,
+            "id": 122,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 25,
+            "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7143,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7078,
+                    "id": 7144,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7145,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7080,
+                    "id": 7146,
                     "recurring": false,
                     "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7081,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
+                    "value": "4"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Onyx Eins",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -14768,6 +10774,169 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Der für den Langzeiteinsatz konzipierte TIE/ag wird in erster Linie von Elitepiloten geflogen, die das Potential des schwer bewaffneten und wendigen Jägers voll ausschöpfen können.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6294,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6295,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6296,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_129",
+            "force_side": null,
+            "id": 129,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Aufklärer der Onyx-Staffel",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7171,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7172,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7173,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7174,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Bei der Entwicklung des TIE-Aggressors setzte Sienar Flottensysteme mehr auf Vielseitigkeit und Leistung als auf reine Kosteneffizienz.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6297,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6298,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6299,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 2,
+            "ffg_id": "XW_P_130",
+            "force_side": null,
+            "id": 130,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Experte von Sienar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7175,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7176,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7177,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7178,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Nachdem du einen Angriff durchgeführt hast, der getroffen hat, erhalte 1 Ausweichmarker.<return><shipability><sabold>Stygium-Gitter:</sabold> Nachdem du dich enttarnt hast, darfst du eine <evade>-Aktion durchführen. Zu Beginn der Endphase darfst du 1 Ausweichmarker ausgeben, um 1 Tarnungsmarker zu erhalten.</shipability>",
             "available_actions": [
                 {
@@ -15018,6 +11187,92 @@
                 },
                 {
                     "id": 7190,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>In einem geheimen Forschungsprojekt auf dem Mond Imdaar Alpha wurde entwickelt, was viele für unmöglich gehalten hatten: der TIE-Phantom, ein kleiner Sternenjäger mit Tarnvorrichtung.</flavor><return><shipability><sabold>Stygium-Gitter:</sabold> Nachdem du dich enttarnt hast, darfst du eine <evade>-Aktion durchführen. Zu Beginn der Endphase darfst du 1 Ausweichmarker ausgeben, um 1 Tarnungsmarker zu erhalten.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6312,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6313,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6314,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 7,
+                    "base_action_side_effect": null,
+                    "id": 6315,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_134",
+            "force_side": null,
+            "id": 134,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Testpilot von Imdaar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 27,
+            "statistics": [
+                {
+                    "id": 7191,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7192,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7193,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7194,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15285,6 +11540,94 @@
                 },
                 {
                     "id": 7206,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Inspiriert von anderen Modellen der Cygnus Raumwerften, ist der Sternflügler der <untalic>Alpha</untalic>-Klasse ein vielseitiges Kanonenboot, das für verschiedene Einsatzgebiete umgerüstet werden kann und somit ideal für die Spezialeinheiten der Imperialen Flotte ist.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6328,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6329,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6330,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6331,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                6,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "35",
+            "faction_id": 2,
+            "ffg_id": "XW_P_138",
+            "force_side": null,
+            "id": 138,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot der Nu-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 14,
+            "statistics": [
+                {
+                    "id": 7207,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7208,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7209,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7210,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -15590,6 +11933,101 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Zu Beginn der Kampfphase darfst du 1 oder mehrere befreundete Schiffe in Reichweite 0–3 wählen. Falls du das tust, transferiere alle feindlichen Zielerfassungsmarker von den gewählten Schiffen auf dich.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6347,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6348,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 6349,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6350,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                8,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 2,
+            "ffg_id": "XW_P_142",
+            "force_side": null,
+            "id": 142,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Captain Kagi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 26,
+            "statistics": [
+                {
+                    "id": 7223,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7224,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 7225,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7226,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7227,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Shuttlepilot des Imperators",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Zu Beginn der Aktivierungsphase darfst du 1<nonbreak><standardcharge> ausgeben. Falls du das tust, <bold>müssen</bold> befreundete Schiffe, solange sie in dieser Runde Ziele erfassen, Ziele jenseits von Reichweite 3 erfassen, anstatt in Reichweite 0–3.",
             "available_actions": [
                 {
@@ -15876,6 +12314,202 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Du kannst Primärangriffe in Reichweite<nonbreak>0 durchführen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6363,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6364,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6365,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6366,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6367,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 2,
+            "ffg_id": "XW_P_146",
+            "force_side": null,
+            "id": 146,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Captain Oicunn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7244,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7245,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7246,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7247,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Genialer Taktiker",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen Angriff durchführst, falls du verstärkt bist und der Verteidiger in dem <fullfront> oder <fullrear> ist, der zu deinem Verstärkungsmarker passt, darfst du 1 deiner <focus>-Ergebnisse in ein <crit>-Ergebnis ändern.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6368,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6369,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6370,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6371,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6372,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "88",
+            "faction_id": 2,
+            "ffg_id": "XW_P_147",
+            "force_side": null,
+            "id": 147,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Konteradmiral Chiraneau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7248,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7249,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7250,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7251,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Berater von Admiral Piett",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -16174,6 +12808,104 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange du einen Primärangriff durchführst, falls mindestens 1<nonbreak>befreundetes nicht-limitiertes Schiff in Reichweite 0 des Verteidigers ist, wirf 1<nonbreak>zusätzlichen Angriffswürfel.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6386,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6387,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": "stress",
+                    "id": 6388,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6389,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
+            "card_set_ids": [
+                6,
+                11
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 3,
+            "ffg_id": "XW_P_151",
+            "force_side": null,
+            "id": 151,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kath Scarlet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 10,
+            "statistics": [
+                {
+                    "id": 7266,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7267,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "3"
+                },
+                {
+                    "id": 7268,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7269,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7270,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Captain der Binayre-Piraten",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls das feindliche Schiff gestresst ist, darfst du 1 deiner Würfel neu werfen.",
             "available_actions": [
                 {
@@ -16466,6 +13198,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls die Angriffsreichweite 1 ist, darfst du 1<nonbreak>zusätzlichen Würfel werfen.<return><shipability><sabold>Concordianischer Wirbel:</sabold> Solange du verteidigst, falls die Angriffsreichweite 1 ist und du im<frontarc><nonbreak>des Angreifers bist, ändere 1<nonbreak>Ergebnis in ein <evade>-Ergebnis.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6402,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6403,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6404,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6405,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 3,
+            "ffg_id": "XW_P_155",
+            "force_side": null,
+            "id": 155,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7286,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7287,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7288,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Skull Eins",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Zu Beginn der Kampfphase darfst du 1<nonbreak>feindliches Schiff in Reichweite 1 wählen. Falls du das tust und du in seinem <frontarc> bist, entfernt es alle seine grünen Marker.<return><shipability><sabold>Concordianischer Wirbel:</sabold> Solange du verteidigst, falls die Angriffsreichweite 1 ist und du im <frontarc> des Angreifers bist, ändere 1<nonbreak>Ergebnis in ein <evade>-Ergebnis.</shipability>",
             "available_actions": [
                 {
@@ -16705,6 +13517,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Die Fliegerasse der Skull-Staffel bevorzugen eine aggressive Kampftaktik und vertrauen dabei auf die schwenkbaren Tragflächen ihrer Schiffe, um ihre Beute mit unübertroffener Agilität zur Strecke zu bringen. </flavor><return><shipability> <sabold>Concordianischer Wirbel:</sabold> Solange du verteidigst, falls die Angriffsreichweite 1 ist und du im <frontarc> des Angreifers bist, ändere 1<nonbreak>Ergebnis in ein <evade>-Ergebnis.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6418,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6419,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6420,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6421,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_159",
+            "force_side": null,
+            "id": 159,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Pilot der Skull-Staffel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7298,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7299,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7300,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Jeder Pilot eines mandalorianischen Fangjägers beherrscht den Concordianischen Wirbel, ein Manöver, bei dem das schmale Profil des Jägers für einen tödlichen Frontalangriff genutzt wird. </flavor><return><shipability> <sabold>Concordianischer Wirbel:</sabold> Solange du verteidigst, falls die Angriffsreichweite 1 ist und du im <frontarc> des Angreifers bist, ändere 1<nonbreak>Ergebnis in ein <evade>-Ergebnis.</shipability>",
             "available_actions": [
                 {
@@ -16935,6 +13827,156 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Zu Beginn der Kampfphase, falls 1 oder mehrere andere Schiffe in Reichweite 0 sind, erhalten du und jedes andere Schiff in Reichweite 0 je 1 Fangstrahlmarker.<return><shipability><sabold>Schlepperstrahl:</sabold> <smallcaps>Aktion:</smallcaps> Wähle ein Schiff in deinem <frontarc> in Reichweite 1. Jenes Schiff erhält 1 Fangstrahlmarker oder 2<nonbreak>Fangstrahlmarker, falls es in deinem <bullseye> in Reichweite 1 ist.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6432,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6433,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6434,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 3,
+            "ffg_id": "XW_P_163",
+            "force_side": null,
+            "id": 163,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Unkar Plutt",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7310,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7311,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7312,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Geiziger Rationsmeister",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der Quadrijet-Transferschlepper, im Volksmund „Quadjumper“ genannt, ist gleichermaßen behände in Weltall und Atmosphäre, was ihn zu einem beliebten Schmuggler- und Entdeckerschiff macht. </flavor><return><shipability><sabold>Schlepperstrahl:</sabold> <smallcaps>Aktion:</smallcaps> Wähle ein Schiff in deinem <frontarc> in Reichweite 1. Jenes Schiff erhält 1 Fangstrahlmarker oder 2<nonbreak>Fangstrahlmarker, falls es in deinem <bullseye><nonbreak>in Reichweite 1 ist.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6435,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6436,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6437,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 3,
+            "ffg_id": "XW_P_164",
+            "force_side": null,
+            "id": 164,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Waffenschmuggler von Jakku",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7313,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7314,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7315,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen Nicht-<frontarc>-Angriff durchführst, wirf 1<nonbreak>zusätzlichen Angriffswürfel.",
             "available_actions": [
                 {
@@ -17021,6 +14063,188 @@
                 }
             ],
             "subtitle": "Abgebrühter Korsar",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange ein befreundetes nicht-limitiertes Schiff einen Angriff durchführt, falls der Verteidiger in deinem Feuerwinkel ist, darf der Angreifer 1 Angriffswürfel neu werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6442,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6443,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6444,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6445,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 3,
+            "ffg_id": "XW_P_166",
+            "force_side": null,
+            "id": 166,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Drea Renthal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7320,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7321,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7322,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7323,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Piratenfürstin",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Wer mit imperialen Credits winkt, kann auf eine große, wenn auch nicht sonderlich vertrauenswürdige Helferschar zählen.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6446,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6447,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6448,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6449,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 3,
+            "ffg_id": "XW_P_167",
+            "force_side": null,
+            "id": 167,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Söldner",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7324,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7325,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7326,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7327,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17271,6 +14495,85 @@
                 }
             ],
             "subtitle": "Imposanter Marodeur",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Du kannst nur über eine Notabsetzung abgesetzt werden, und du hast den Namen, die Initiative, die Pilotenfähigkeit und die Schiffs-<standardcharge> der befreundeten, zerstörten <smallcaps>Reißzahn</smallcaps>.<return><shipability><sabold>Fluchtschiff:</sabold> <smallcaps>Aufbau: </smallcaps>Erfordert die <smallcaps>Reißzahn</smallcaps>. Du <bold>musst</bold> das Spiel angedockt an der <smallcaps>Reißzahn</smallcaps> beginnen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6460,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6461,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6462,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "6",
+            "faction_id": 3,
+            "ffg_id": "XW_P_171",
+            "force_side": null,
+            "id": 171,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Nashtahwelpe</italic>",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 7340,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7341,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7342,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7343,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Notfallplan",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17532,6 +14835,102 @@
                 }
             ],
             "subtitle": "Söldner aus dem Outer Rim",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase darfst du 1 feindliches Schiff in deinem Feuerwinkel in Reichweite 0–2 wählen. Falls du das tust, transferiere 1 Fokus- oder Ausweichmarker von jenem Schiff auf dich selbst.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6474,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6475,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6476,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6477,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6478,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 3,
+            "ffg_id": "XW_P_175",
+            "force_side": null,
+            "id": 175,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Palob Godalhi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 7357,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7358,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7359,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7360,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Tethanischer Widerstandskämpfer",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17815,6 +15214,94 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Nachdem du ein Manöver vollständig ausgeführt hast, darfst du 1<nonbreak>Stressmarker erhalten, um dein Schiff um 90° zu drehen.<return><shipability><sabold>Mikrodüsen:</sabold> Solange du eine Fassrolle durchführst, <bold>musst</bold> du die <leftbank>- oder <rightbank>-Schablone anstatt der <straight>-Schablone verwenden.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6493,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6494,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6495,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6496,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_179",
+            "force_side": null,
+            "id": 179,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Dalan Oberos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 3,
+            "statistics": [
+                {
+                    "id": 7373,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7374,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7375,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7376,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Elite-Kopfgeldjäger",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du verteidigst, nach dem Schritt „Ergebnisse neutralisieren“, darf ein anderes befreundetes Schiff in Reichweite 0–1 und im Angriffswinkel 1<nonbreak><hit>- oder <crit>-Schaden erleiden. Falls es das tut, negiere 1<nonbreak>passendes Ergebnis.<return><shipability><sabold>Mikrodüsen:</sabold> Solange du eine Fassrolle durchführst, <bold>musst</bold> du die <leftbank>-oder <rightbank>-Schablone  anstatt der <straight>-Schablone verwenden.</shipability>",
             "available_actions": [
                 {
@@ -18078,6 +15565,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange ein befreundetes Schiff in Reichweite 0–1 verteidigt, darf es 1<nonbreak>seiner Würfel neu werfen.<return><shipability><sabold>Waffenaufhängung:</sabold> Du kannst 1<nonbreak><cannon>-,<nonbreak><torpedo>- oder <missile>-Aufwertung ausrüsten.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6509,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6510,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6511,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6512,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_183",
+            "force_side": null,
+            "id": 183,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Serissu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7389,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7390,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7391,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7392,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Fluglehrerin",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Nachdem du ein Ziel erfasst hast, musst du alle deine Fokus- und Ausweichmarker entfernen. Dann erhalte dieselbe Anzahl an Fokus- und Ausweichmarkern, die das erfasste Schiff hat.<return><shipability><sabold>Waffenaufhängung:</sabold> Du kannst 1<nonbreak><cannon>-,<nonbreak><torpedo>- oder <missile>-Aufwertung ausrüsten.</shipability>",
             "available_actions": [
                 {
@@ -18331,6 +15904,91 @@
                 }
             ],
             "subtitle": "Glücksritter",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, darfst du 1<nonbreak><hit>-Schaden erleiden, um beliebig viele deiner Würfel neu zu werfen.<return><shipability><sabold>Waffenaufhängung:</sabold> Du kannst 1<nonbreak><cannon>-,<nonbreak><torpedo>- oder <missile>-Aufwertung ausrüsten.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6525,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6526,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6527,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6528,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 3,
+            "ffg_id": "XW_P_187",
+            "force_side": null,
+            "id": 187,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Inaldra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7405,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7406,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7407,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7408,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Stationsleiterin von Tansarii Point",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -18592,6 +16250,88 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange du in Angriffsreichweite 3 verteidigst oder in Angriffsreichweite<nonbreak>1 einen Angriff durchführst, wirf 1<nonbreak>zusätzlichen Würfel.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6541,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6542,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6543,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_191",
+            "force_side": null,
+            "id": 191,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Talonbane Cobra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7421,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7422,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7423,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7424,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Der Schrecken von Tansarii Point",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du verteidigst, falls du hinter dem Angreifer bist, wirf 1<nonbreak>zusätzlichen Verteidigungswürfel.<return>Solange du einen Angriff durchführst, falls du hinter dem Angreifer bist, wirf 1<nonbreak>zusätzlichen Angriffswürfel.",
             "available_actions": [
                 {
@@ -18832,6 +16572,88 @@
                 }
             ],
             "subtitle": "Aggressiver Opportunist",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Der Kihraxz-Angriffsjäger wurde eigens für das Verbrechersyndikat Schwarze Sonne entwickelt, dessen hochbezahlte Fliegerasse ein leistungsstarkes, wendiges Schiff verlangten, das ihren Fähigkeiten entsprach.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6553,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6554,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6555,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 3,
+            "ffg_id": "XW_P_195",
+            "force_side": null,
+            "id": 195,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Fliegerass der Schwarzen Sonne",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7437,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7438,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7439,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7440,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19100,6 +16922,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Nachdem du eine <boost>-Aktion durchgeführt hast, darfst du eine <evade>-Aktion durchführen.<return><shipability><sabold>Hochentwickeltes Droidengehirn:</sabold> Nachdem du eine <calculate>-Aktion durchgeführt hast, erhalte 1 Berechnungsmarker.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6567,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6568,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6569,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6570,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 3,
+            "ffg_id": "XW_P_199",
+            "force_side": null,
+            "id": 199,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•IG-88C",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 21,
+            "statistics": [
+                {
+                    "id": 7453,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7454,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7455,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7456,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Cleverer Computer",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen Segnor-Looping (<leftsloop> oder <rightsloop>)ausführst, darfst du stattdessen eine andere Schablone derselben Geschwindigkeit verwenden: entweder die Wende (<leftturn> oder <rightturn>) mit gleicher Orientierung oder die Gerade (<straight>).<return><shipability><sabold>Hochentwickeltes Droidengehirn:</sabold> Nachdem du eine <calculate>-Aktion durchgeführt hast, erhalte 1 Berechnungsmarker.</shipability>",
             "available_actions": [
                 {
@@ -19355,6 +17268,87 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Die legendären Finder der Gand verehren den Nebelschleier, der ihren Heimatplaneten umhüllt. Um ihre Beute aufzuspüren, deuten sie mystische Zeichen und Visionen.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6581,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6582,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6583,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_203",
+            "force_side": null,
+            "id": 203,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Gand-Finder",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 22,
+            "statistics": [
+                {
+                    "id": 7469,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7470,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7471,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7472,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Bevor eine befreundete Bombe oder Mine detonieren würde, darfst du 1<nonbreak><standardcharge> ausgeben, um die Detonation zu verhindern.<return> Solange du gegen einen Angriff verteidigst, der durch eine Bombe oder Mine versperrt ist, wirf 1<nonbreak>zusätzlichen Verteidigungswürfel.",
             "available_actions": [
                 {
@@ -19604,6 +17598,95 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du einen Angriff durchgeführt hast, erleidet jedes feindliche Schiff in deinem <bullseye>1<nonbreak><hit>-Schaden, es sei denn, es entfernt 1<nonbreak>grünen Marker.<return><shipability><sabold>Todsicherer Treffer:</sabold> Solange du einen Angriff durchführst, falls der Verteidiger in deinem <bullseye> ist, können Verteidigungswürfel nicht unter Verwendung von grünen Markern modifiziert werden.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6593,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6594,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6595,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6596,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                10,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_207",
+            "force_side": null,
+            "id": 207,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Torani Kulda",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 39,
+            "statistics": [
+                {
+                    "id": 7486,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7487,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7488,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "7"
+                },
+                {
+                    "id": 7489,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rodianische Auftragsmörderin",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19878,6 +17961,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Falls du fliehen würdest, darfst du 1<nonbreak><standardcharge><nonbreak>ausgeben. Falls du das tust, platziere dich selbst stattdessen in der Reserve. Zu Beginn der nächsten Planungsphase platziere dich selbst innerhalb von Reichweite 1 des Spielflächenrandes, über den du geflohen bist.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6608,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6609,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6610,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                8,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 3,
+            "ffg_id": "XW_P_211",
+            "force_side": null,
+            "id": 211,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Moralo Eval",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 24,
+            "statistics": [
+                {
+                    "id": 7503,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 7504,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7505,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "9"
+                },
+                {
+                    "id": 7506,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                },
+                {
+                    "id": 7507,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Kriminelles Superhirn",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Zu Beginn der Kampfphase darfst du ein Schiff in Reichweite 1 wählen und eine Zielerfassung, die du auf jenem Schiff hast, ausgeben. Falls du das tust, erhält jenes Schiff 1 Fangstrahlmarker.",
             "available_actions": [
                 {
@@ -20130,6 +18304,88 @@
                 }
             ],
             "subtitle": "Rachsüchtiger Corellianer",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase darfst du ein befreundetes Schiff in Reichweite 0–1 wählen. Falls du das tust, transferiere alle grünen Marker, die dir zugeordnet sind, auf jenes Schiff.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6620,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6621,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6622,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_215",
+            "force_side": null,
+            "id": 215,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Manaroo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 45,
+            "statistics": [
+                {
+                    "id": 7521,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7522,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7523,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7524,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Anmutige Aruzanerin",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20689,38 +18945,39 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Viele Raumfahrer bestreiten ihr Leben, indem sie den Outer Rim bereisen, wo der Unterschied zwischen Schmugglern und seriösen Händlern oft kaum zu erkennen ist. Am Rande der Zivilisation sind Käufer äußerst selten, daher sollte man nicht nach der Herkunft der Ware fragen, solange der Preis niedrig genug ist. </flavor>",
+            "ability_text": "Solange du verteidigst oder einen Primärangriff durchführst, falls der Angriff durch ein Hindernis versperrt ist, darfst du 1 zusätzlichen Würfel werfen.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 6645,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 6646,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 6647,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 6648,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
+                1,
                 6,
                 8,
                 8,
@@ -20729,51 +18986,142 @@
                 15,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "54",
             "faction_id": 3,
-            "ffg_id": "XW_P_225",
+            "ffg_id": "XW_P_222",
             "force_side": null,
-            "id": 225,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Frachtercaptain",
+            "id": 222,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 7555,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 7556,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 7557,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 7558,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Das corellianische Kind",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du Würfel geworfen hast, falls du nicht gestresst bist, darfst du 1 Stressmarker erhalten um alle deine Leerseiten neu zu werfen.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6649,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6650,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6651,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6652,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 3,
+            "ffg_id": "XW_P_223",
+            "force_side": null,
+            "id": 223,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7559,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7560,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7561,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7562,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Charmanter Spieler",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20869,6 +19217,96 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Viele Raumfahrer bestreiten ihr Leben, indem sie den Outer Rim bereisen, wo der Unterschied zwischen Schmugglern und seriösen Händlern oft kaum zu erkennen ist. Am Rande der Zivilisation sind Käufer äußerst selten, daher sollte man nicht nach der Herkunft der Ware fragen, solange der Preis niedrig genug ist. </flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6657,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6658,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6659,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6660,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 3,
+            "ffg_id": "XW_P_225",
+            "force_side": null,
+            "id": 225,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Frachtercaptain",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7567,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7568,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7569,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7570,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Nachdem du Würfel geworfen hast, falls du nicht gestresst bist, darfst du 1 Stressmarker erhalten um alle deine Leerseiten neu zu werfen.<return><shipability><sabold>Co-Pilot:</sabold> Solange du angedockt bist, hat dein Träger-Schiff deine Piloten-Fähigkeit zusätzlich zu seiner eigenen.</shipability>",
             "available_actions": [
                 {
@@ -20948,42 +19386,160 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Solange du einen Primärangriff durchführst, falls der Verteidiger in deinem <bullseye> ist, vor dem Schritt „Ergebnisse neutralisieren“, darfst du 1<nonbreak><standardcharge> ausgeben, um 1<nonbreak><evade>-Ergebnis zu negieren.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                9
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_1",
-            "force_side": null,
-            "id": 230,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Meisterhafter Schuss",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
+            "ability_text": "Befreundete Schiffe in Reichweite 0–1 können Angriffe in Reichweite 0 zu Hindernissen durchführen.<return><shipability><sabold>Co-Pilot:</sabold> Solange du angedockt bist, hat dein Träger-Schiff deine Piloten-Fähigkeit zusätzlich zu seiner eigenen.</shipability>",
+            "available_actions": [
                 {
-                    "id": 6632,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6664,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6665,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6666,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
                 }
             ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+            "available_upgrades": [
+                1,
+                8,
+                14
             ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "24",
+            "faction_id": 3,
+            "ffg_id": "XW_P_227",
+            "force_side": null,
+            "id": 227,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Pionier aus dem Outer Rim",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7575,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7576,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7577,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7578,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Geschickter Gesetzloser",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Falls du keine Schilde hast, verringere die Schwierigkeit deiner Drehmanöver (<leftbank> und <rightbank>) .<return><shipability><sabold>Co-Pilot:</sabold> Solange du angedockt bist, hat dein Träger-Schiff deine Piloten-Fähigkeit zusätzlich zu seiner eigenen.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6667,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6668,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6669,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "22",
+            "faction_id": 3,
+            "ffg_id": "XW_P_228",
+            "force_side": null,
+            "id": 228,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•L3-37",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7579,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7580,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7581,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7582,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Droiden-Revolutionärin",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21069,81 +19625,94 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Falls du keine Schilde hast, verringere die Schwierigkeit deiner Drehmanöver (<leftbank> und <rightbank>) .<return><shipability><sabold>Co-Pilot:</sabold> Solange du angedockt bist, hat dein Träger-Schiff deine Piloten-Fähigkeit zusätzlich zu seiner eigenen.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6667,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6668,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6669,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "ability_text": "Solange du einen Primärangriff durchführst, falls der Verteidiger in deinem <bullseye> ist, vor dem Schritt „Ergebnisse neutralisieren“, darfst du 1<nonbreak><standardcharge> ausgeben, um 1<nonbreak><evade>-Ergebnis zu negieren.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
             "card_set_ids": [
-                13
+                4,
+                5,
+                6,
+                9
             ],
-            "card_type_id": 1,
-            "cost": "22",
-            "faction_id": 3,
-            "ffg_id": "XW_P_228",
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_1",
             "force_side": null,
-            "id": 228,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•L3-37",
+            "id": 230,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Meisterhafter Schuss",
             "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 6632,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7580,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7581,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7582,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
+                    "statistic_id": 7,
+                    "value": "1"
                 }
             ],
-            "subtitle": "Droiden-Revolutionärin",
-            "upgrade_types": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du eine weiße <boost>-Aktion durchführst, darfst du sie behandeln, als wäre sie rot, um stattdessen die [1<nonbreak><leftturn>]- oder [1<nonbreak><rightturn>]-Schablone zu verwenden.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                12
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_2",
+            "force_side": null,
+            "id": 231,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Draufgänger",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Boost",
+                            "pk": 1,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21351,6 +19920,39 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange ein feindliches Schiff in Reichweite 0 verteidigt, wirft es 1<nonbreak>Verteidigungswürfel weniger.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_7",
+            "force_side": null,
+            "id": 236,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Furchteinflößend",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen Angriff durchführst, falls du ausweichst, darfst du 1<nonbreak>der <evade>-Ergebnisse des Verteidigers in ein <focus>-Ergebnis ändern.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21400,6 +20002,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange du verteidigst oder einen Angriff durchführst, falls keine anderen befreundeten Schiffe in Reichweite 0–2 sind, darfst du 1<nonbreak><standardcharge> ausgeben, um 1 deiner Würfel neu zu werfen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_9",
+            "force_side": null,
+            "id": 238,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Einsamer Wolf",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6606,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen Angriff durchführst, falls der Verteidiger in deinem <bullseye> ist, darfst du 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis ändern.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21420,6 +20062,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Treffsicherheit",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen <frontarc>-Angriff durchführst, falls du nicht im Feuerwinkel des Verteidigers bist, wirft der Verteidiger 1<nonbreak>Verteidigungswürfel weniger.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_11",
+            "force_side": null,
+            "id": 240,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ausmanövrieren",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21558,37 +20233,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Zu Beginn der Kampfphase darfst du 1<nonbreak><forcecharge> ausgeben. Falls du das tust, kämpfe in dieser Phase bei Initiative 7 anstatt bei deinem normalen Initiativwert.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-            "card_set_ids": [
-                1,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_19",
-            "force_side": null,
-            "id": 248,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Geschärfte Sinne",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                17
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Solange ein anderes befreundetes Schiff in Reichweite 0–1 verteidigt, vor dem Schritt „Ergebnisse neutralisieren“, falls du im Angriffswinkel bist, darfst du 1<nonbreak><crit>-Schaden erleiden, um 1<nonbreak><crit>-Ergebnis zu negieren.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21630,6 +20274,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Solange du koordinierst, kann das von dir gewählte Schiff eine Aktion nur dann durchführen, falls jene Aktion auch in deiner Aktionsleiste ist.",
+            "available_actions": [
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 5830,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_16",
+            "force_side": null,
+            "id": 245,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Staffelführer",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Zu Beginn der Kampfphase darfst du 1 befreundetes Schiff in Reichweite 1 wählen. Falls du das tust, behandelt jenes Schiff seine Initiative bis zum Ende der Runde so, als würde sie deiner Initiative entsprechen.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21658,6 +20343,70 @@
             "subtitle": null,
             "upgrade_types": [
                 1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen Angriff durchführst, der durch ein Hindernis versperrt ist, wirf 1 zusätzlichen Angriffswürfel.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_18",
+            "force_side": null,
+            "id": 247,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Trickschuss",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase darfst du 1<nonbreak><forcecharge> ausgeben. Falls du das tust, kämpfe in dieser Phase bei Initiative 7 anstatt bei deinem normalen Initiativwert.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+            "card_set_ids": [
+                1,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_19",
+            "force_side": null,
+            "id": 248,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Geschärfte Sinne",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                17
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -21763,6 +20512,78 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Nachdem du dein Rad aufgedeckt hast, darfst du 1 Aktion durchführen.<return>Falls du das tust, kannst du während deiner Aktivierung keine weitere Aktion durchführen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_23",
+            "force_side": null,
+            "id": 252,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Verbesserte Sensoren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du Schub gibst oder eineFassrolle fliegst, kannst du dichdurch Hindernisse hindurch­bewegen und sie überschneiden.<return>Nachdem du dich durch ein Hindernis hindurchbewegt oder es überschnitten hast, darfst du 1<nonbreak><standardcharge> ausgeben, um seine Effekte bis zum Ende der Runde zu ignorieren.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_24",
+            "force_side": null,
+            "id": 253,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Kollisionssensor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6626,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen Angriff durchführst, falls du den Verteidiger als Ziel erfasst hast, darfst du 1<nonbreak>Angriffswürfel neu werfen. Falls du das tust, kannst du während dieses Angriffs deine Zielerfassung nicht ausgeben.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21783,6 +20604,37 @@
             "initiative": null,
             "is_unique": false,
             "name": "Feuerkontrollsystem",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Während der Systemphase, falls du eine Bombe abwerfen oder starten würdest, darfst du sie stattdessen unter Verwendung der [5<nonbreak><straight>]-Schablone starten.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_set_ids": [
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_26",
+            "force_side": null,
+            "id": 255,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Flugbahnsimulator",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21836,83 +20688,43 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Während der Systemphase, falls du eine Bombe abwerfen oder starten würdest, darfst du sie stattdessen unter Verwendung der [5<nonbreak><straight>]-Schablone starten.",
+            "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
             "card_set_ids": [
+                4,
                 5,
                 6
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "5",
             "faction_id": null,
-            "ffg_id": "XW_U_26",
+            "ffg_id": "XW_U_28",
             "force_side": null,
-            "id": 255,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "id": 257,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Flugbahnsimulator",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5835,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_32",
-            "force_side": null,
-            "id": 261,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ionengeschütz",
+            "name": "Ionenkanone",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6645,
+                    "id": 6643,
                     "recurring": false,
-                    "statistic_id": 12,
+                    "statistic_id": 10,
                     "value": "3"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
-                4
+                3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 - 3"
         },
         {
             "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, fügen alle <hit>/<crit>-Ergebnisse Störsignalmarker anstatt Schaden zu.",
@@ -21993,48 +20805,144 @@
             "weapon_range": "1 - 3"
         },
         {
-            "ability_text": "<smallcaps>Angriff (</smallcaps><focus><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge><nonbreak>aus. Falls der Verteidiger in deinem <bullseye> ist, darfst du 1 oder mehrere <standardcharge> ausgeben, um ebenso viele Angriffswürfel neu zu werfen.",
-            "available_actions": [],
+            "ability_text": "<smallcaps>Angriff</smallcaps>",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5832,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
             "card_set_ids": [
-                5
+                4,
+                5,
+                6
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_36",
+            "ffg_id": "XW_U_31",
             "force_side": null,
-            "id": 265,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "id": 260,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Raketensalve",
+            "name": "Dorsaler Geschützturm",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6619,
+                    "id": 6633,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6621,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "5"
+                    "statistic_id": 12,
+                    "value": "2"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5835,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+            "card_set_ids": [
+                4,
+                5,
                 6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_32",
+            "force_side": null,
+            "id": 261,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ionengeschütz",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6645,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Ändere 1<nonbreak><hit>-Ergebnis in ein<nonbreak><crit>-Ergebnis.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+            "card_set_ids": [
+                4,
+                5,
                 6
             ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_33",
+            "force_side": null,
+            "id": 262,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Verstärkte Protonentorpedos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6615,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "5"
+                },
+                {
+                    "id": 6617,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                5
+            ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "1"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
@@ -22129,6 +21037,96 @@
             ],
             "weapon_no_bonus": true,
             "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Angriff (</smallcaps><focus><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge><nonbreak>aus. Falls der Verteidiger in deinem <bullseye> ist, darfst du 1 oder mehrere <standardcharge> ausgeben, um ebenso viele Angriffswürfel neu zu werfen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_36",
+            "force_side": null,
+            "id": 265,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Raketensalve",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6619,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6621,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "5"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6,
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Nach diesem Angriff darfst du diesen Angriff als Bonusangriff gegen ein anderes Ziel in Reichweite 0–1 des Verteidigers durchführen, wobei du die <targetlock>-Voraussetzung ignorierst.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_37",
+            "force_side": null,
+            "id": 266,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Clusterraketen",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6623,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6625,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "4"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "1 - 2"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge>aus. Nachdem dieser Angriff getroffen hat, legt jedes Schiff in Reichweite 0–1 zum Verteidiger 1 seiner Schadenskarten offen.",
@@ -22267,38 +21265,6 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Solange du verteidigst, bevor die Angriffswürfel geworfen werden, darfstdu eine Zielerfassung, die du auf dem Angreifer hast, ausgeben, um 1<nonbreak>Angriffswürfel zu werfen. Falls du das tust, erhält der Angreifer 1<nonbreak>Störsignalmarker. Dann, bei einem <hit>- oder <crit>-Ergebnis, erhältst du 1<nonbreak>Störsignalmarker.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_42",
-            "force_side": null,
-            "id": 271,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Freischaffender Hacker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Angriff (</smallcaps><focus><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge><nonbreak>aus.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22344,6 +21310,109 @@
             "weapon_range": "1 - 2"
         },
         {
+            "ability_text": "Solange du verteidigst, bevor die Angriffswürfel geworfen werden, darfstdu eine Zielerfassung, die du auf dem Angreifer hast, ausgeben, um 1<nonbreak>Angriffswürfel zu werfen. Falls du das tust, erhält der Angreifer 1<nonbreak>Störsignalmarker. Dann, bei einem <hit>- oder <crit>-Ergebnis, erhältst du 1<nonbreak>Störsignalmarker.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_42",
+            "force_side": null,
+            "id": 271,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Freischaffender Hacker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Aufbau:</smallcaps> Verliere 1<nonbreak><standardcharge>.<return><smallcaps>Aktion:</smallcaps> Stelle 1<nonbreak><standardcharge> wieder her.<return><smallcaps>Aktion:</smallcaps> Gib 1<nonbreak><standardcharge> aus, um 1 Schild wiederherzustellen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_43",
+            "force_side": null,
+            "id": 272,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "GNK-„Gonk“-Droide",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6636,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Aufbau:</smallcaps> Nachdem die Streitkräfte platziert worden sind, wähle 1<nonbreak>feindliches Schiff und ordne ihm den Zustand Abhörgerät zu.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_44",
+            "force_side": null,
+            "id": 273,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Informant",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Am Ende der Runde darfst du 1<nonbreak>Angriffswürfel werfen, um 1<nonbreak>offene Schadenskarte zu reparieren. Dann, bei einem <hit>-Ergebnis, lege 1<nonbreak>Schadenskarte offen.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22363,6 +21432,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Unerfahrener Techniker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du eine <focus>-Aktion durchgeführt hast, erhalte 1 Fokusmarker.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_46",
+            "force_side": null,
+            "id": 275,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Aufmerksamer Co-Pilot",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -22456,6 +21558,38 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen <turretarc>-Angriff durchführst, nach dem Schritt „Verteidigungswürfel modifizieren“, entfernt der Verteidiger 1 Fokus- oder 1 Berechnungsmarker.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_49",
+            "force_side": null,
+            "id": 278,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Erstklassiger Bordschütze",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -22587,6 +21721,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Nachdem du dein Rad aufgedeckt hast, darfst du 1<nonbreak><standardcharge> ausgeben und 1 Entwaffnet-Marker erhalten, um 1<nonbreak>Schild wiederherzustellen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+            "card_set_ids": [
+                1,
+                4,
+                6,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_53",
+            "force_side": null,
+            "id": 282,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "R2-Astromechdroide",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6663,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Du kannst bis zu 2 Zielerfassungen aufrechterhalten. Jede Zielerfassung muss ein anderes Objekt als Ziel haben.<return>Nachdem du eine <targetlock>-Aktion durchgeführt hast, darfst du ein Ziel erfassen.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22702,6 +21876,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallcaps>Aktion:</smallcaps> Gib 1<nonbreak><standardcharge> aus, um eine <cloak>-Aktion durchzuführen.<return>Zu Beginn der Planungsphase wirf 1<nonbreak>Angriffswürfel. Bei einem <focus>-Ergebnis, enttarne dich oder lege deinen Tarnungsmarker ab.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_57",
+            "force_side": null,
+            "id": 286,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Tarngerät",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6594,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor du aktiviert wirst, darfst du 1<nonbreak><standardcharge> ausgeben. Falls du das tust, kannst du bis zum Ende der Runde Aktionen durchführen und rote Manöver ausführen, auch solange du gestresst bist.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_58",
+            "force_side": null,
+            "id": 287,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Illegale Kybernetik",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6631,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Nachdem du zerstört worden bist, erleidet jedes andere Schiff in Reichweite 0–1 1<nonbreak><hit>-Schaden.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22797,45 +22062,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mine</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone ein Connernetz abzuwerfen.<return>Die <standardcharge> dieser Karte kann nicht wiederhergestellt werden.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_64",
-            "force_side": null,
-            "id": 393,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Connernetz",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6630,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Aktion:</smallcaps> Gib 1<nonbreak><standardcharge> aus. Wirf unter Verwendung der [1<nonbreak><straight>]-Schablone 1 freie Fracht ab.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22890,18 +22116,10 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Angriff</smallcaps>",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5832,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
+            "ability_text": "Bevor du Schaden durch ein Hindernis oder die Detonation einer befreundeten Bombe erleiden würdest, darfst du 1<nonbreak><standardcharge> ausgeben. Falls du das tust, verhindere 1 Schaden.",
+            "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
             "card_set_ids": [
                 4,
                 5,
@@ -22910,60 +22128,35 @@
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_31",
+            "ffg_id": "XW_U_68",
             "force_side": null,
-            "id": 260,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+            "id": 292,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Dorsaler Geschützturm",
-            "restrictions": [],
+            "name": "Ablative Panzerung",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "LARGE"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6633,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                4
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<bitalic>Bombe</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Protonenbombe abzuwerfen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_65",
-            "force_side": null,
-            "id": 394,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Protonenbomben",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6655,
+                    "id": 6614,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -22971,88 +22164,50 @@
             ],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mine</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Annäherungsmine abzuwerfen.<return>Die <standardcharge> dieser Karte können nicht wiederhergestellt werden.",
+            "ability_text": "Nachdem du eine <slam>-Aktion durchgeführt hast, falls du das Manöver vollständig ausgeführt hast, darfst du eine weiße Aktion aus deiner Aktionsleiste durchführen, wobei du jene Aktion behandelst, als wäre sie rot.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
             "card_set_ids": [
                 4,
                 5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_66",
-            "force_side": null,
-            "id": 395,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Annäherungsminen",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6662,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bombe</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Seismische Bombe abzuwerfen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8,
-                11
+                6
             ],
             "card_type_id": 2,
             "cost": "3",
             "faction_id": null,
-            "ffg_id": "XW_U_67",
+            "ffg_id": "XW_U_69",
             "force_side": null,
-            "id": 396,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "id": 293,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Seismische Bomben",
-            "restrictions": [],
+            "name": "Verbesserter SLAM",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Slam",
+                            "pk": 13,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6666,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23187,6 +22342,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Auch wer sich keinen verbesserten Schildgenerator leisten kann, muss nicht auf erhöhten Schutz verzichten, sondern kann sich mit zusätzlichen Panzerplatten an der Schiffshülle behelfen.</flavor>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "*",
+            "faction_id": null,
+            "ffg_id": "XW_U_73",
+            "force_side": null,
+            "id": 297,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Verstärkte Hülle",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6642,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "+1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen <torpedo>- oder <missile>-Angriff durchführst, nachdem du die Angriffswürfel geworfen hast, darfst du alle Würfelergebnisse negieren, um 1<nonbreak><standardcharge> wiederherzustellen, die du als Kosten für den Angriff ausgegeben hast.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23291,54 +22486,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Bevor du Verteidigungswürfel wirfst, darfst du 1<nonbreak>Berechnungs­marker ausgeben, um laut eine Zahl von 1 oder höher zu raten. Falls du das tust und genau so viele <evade>-Ergebnisse wirfst, wie du geraten hast, füge 1<nonbreak><evade>-Ergebnis hinzu.<return>Nachdem du die <calculate>-Aktion",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5827,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_80",
-            "force_side": null,
-            "id": 304,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•C-3PO",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Solange du verteidigst, falls deine <standardcharge> aktiv ist, wirf 1<nonbreak>zusätzlichen Verteidigungswürfel.<return>Nachdem du Schaden erlitten hast, verliere 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23422,6 +22569,94 @@
             "subtitle": null,
             "upgrade_types": [
                 14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du eine <focus>-Aktion durchführst, darfst du sie behandeln, als wäre sie rot. Falls du das tust, erhalte 1 zusätzlichen Fokusmarker für jedes feindliche Schiff in Reichweite 0–1, bis zu einem Maximum von 2.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_79",
+            "force_side": null,
+            "id": 303,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Baze Malbus",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor du Verteidigungswürfel wirfst, darfst du 1<nonbreak>Berechnungs­marker ausgeben, um laut eine Zahl von 1 oder höher zu raten. Falls du das tust und genau so viele <evade>-Ergebnisse wirfst, wie du geraten hast, füge 1<nonbreak><evade>-Ergebnis hinzu.<return>Nachdem du die <calculate>-Aktion",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5827,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "12",
+            "faction_id": null,
+            "ffg_id": "XW_U_80",
+            "force_side": null,
+            "id": 304,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•C-3PO",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23514,6 +22749,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Während des Schrittes „Aktion durchführen“ darfst du 1 Aktion durchführen, auch solange du gestresst bist. Nachdem du eine Aktion durchgeführt hast, solange du gestresst bist, erleide 1<nonbreak><hit>-Schaden, es sei denn, du legst 1<nonbreak>deiner Schadenskarten offen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_83",
+            "force_side": null,
+            "id": 307,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Chopper“",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Du kannst rote Manöver ausführen, auch solange du gestresst bist. Nachdem du ein rotes Manöver vollständig ausgeführt hast, falls du 3 oder mehr Stressmarker hast, entferne 1 Stressmarker und erleide 1<nonbreak><hit>-Schaden.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23531,6 +22806,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Hera Syndulla",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Falls ein befreundetes Schiff in Reichweite 0–3 einen Fokusmarker erhalten würde, darf es stattdessen 1<nonbreak>Ausweichmarker erhalten.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_85",
+            "force_side": null,
+            "id": 309,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Jyn Erso",
             "restrictions": [
                 [
                     {
@@ -23688,6 +23003,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Nachdem du verteidigt hast, falls der Angriff getroffen hat, darfst du den Angreifer als Ziel erfassen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_89",
+            "force_side": null,
+            "id": 313,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Verringere die Schwierigkeit deiner Drehmanöver (<leftbank> und <rightbank>).",
             "available_actions": [],
             "available_upgrades": [],
@@ -23705,6 +23060,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Nien Nunb",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Während der Endphase, falls du beschädigt bist und keine Schilde hast, darfst du 1<nonbreak>Angriffswürfel werfen, um 1<nonbreak>Schild wiederherzustellen. Bei einem <hit>-Ergebnis lege 1 deiner Schadenskarten offen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_91",
+            "force_side": null,
+            "id": 315,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R2-D2",
             "restrictions": [
                 [
                     {
@@ -23768,23 +23163,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Während der Endphase, falls du beschädigt bist und keine Schilde hast, darfst du 1<nonbreak>Angriffswürfel werfen, um 1<nonbreak>Schild wiederherzustellen. Bei einem <hit>-Ergebnis lege 1 deiner Schadenskarten offen.",
+            "ability_text": "Solange du einen Angriff durchführst, darfst du 1<nonbreak><hit>-Schaden erleiden, um alle deine <focus>-Ergebnisse in <crit>-Ergebnisse zu ändern.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
             "card_set_ids": [
-                4
+                2
             ],
             "card_type_id": 2,
             "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_91",
+            "ffg_id": "XW_U_93",
             "force_side": null,
-            "id": 315,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "id": 317,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R2-D2",
+            "name": "•Saw Gerrera",
             "restrictions": [
                 [
                     {
@@ -23803,6 +23198,86 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Du kannst Primärangriffe in Reichweite 0 durchführen. Feindliche Schiffe in Reichweite 0 können Primärangriffe gegen dich durchführen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_94",
+            "force_side": null,
+            "id": 318,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Zeb“ Orrelios",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du einen Primärangriff durchgeführt hast, falls du fokussiert bist, darfst du einen Bonus-<turretarc>-Angriff gegen ein Schiff, das du in dieser Runde noch nicht angegriffen hast, durchführen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "14",
+            "faction_id": null,
+            "ffg_id": "XW_U_95",
+            "force_side": null,
+            "id": 319,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bistan",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23895,46 +23370,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Solange du einen Angriff durchführst, darfst du 1<nonbreak><hit>-Schaden erleiden, um alle deine <focus>-Ergebnisse in <crit>-Ergebnisse zu ändern.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_93",
-            "force_side": null,
-            "id": 317,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Zu Beginn der Kampfphase darfst du 1<nonbreak><forcecharge> ausgeben, um deinen <turretarc>-Anzeiger zu rotieren.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23977,6 +23412,46 @@
             "subtitle": null,
             "upgrade_types": [
                 16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Aktion:</smallcaps> Gib 1 nicht-wiederkehrende <standardcharge> von einer anderen ausgerüsteten Aufwertung aus, um 1 Schild wiederherzustellen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_99",
+            "force_side": null,
+            "id": 323,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Chopper“",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24076,23 +23551,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Du kannst Primärangriffe in Reichweite 0 durchführen. Feindliche Schiffe in Reichweite 0 können Primärangriffe gegen dich durchführen.",
+            "ability_text": "Du kannst 1 Jagdshuttle oder eine Raumfähre der <italic>Sheathipede</italic>-Klasse andocken lassen.<return>Deine angedockten Schiffe können nur von deinen hinteren Stoppern aus abgesetzt werden.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 2,
-            "cost": "1",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_94",
+            "ffg_id": "XW_U_102",
             "force_side": null,
-            "id": 318,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "id": 326,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•„Zeb“ Orrelios",
+            "name": "•<italic>Ghost</italic>",
             "restrictions": [
                 [
                     {
@@ -24102,6 +23577,15 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 23,
+                            "raw_name": "VCX-100 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
@@ -24110,40 +23594,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du einen Angriff durchführst, der durch ein Hindernis versperrt ist, wirf 1 zusätzlichen Angriffswürfel.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_18",
-            "force_side": null,
-            "id": 247,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Trickschuss",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24311,6 +23762,103 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Du kannst in Reichweite 0–1 andocken.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_106",
+            "force_side": null,
+            "id": 330,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Phantom</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 32,
+                            "raw_name": "Attack Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    },
+                    {
+                        "kwargs": {
+                            "pk": 8,
+                            "raw_name": "Sheathipede-class Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor du aktiviert wirst, darfst du diese Karte umdrehen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+            "card_set_ids": [
+                2,
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_107",
+            "force_side": null,
+            "id": 331,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Schwenkflügel (geöffnet)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 15,
+                            "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du verteidigst, wirf 1<nonbreak>Verteidigungswürfel weniger.<return>Nachdem du ein [0<nonbreak><stop>]-Manöver ausgeführt hast, darfst du dein Schiff um 90° oder um 180° drehen.<return>Bevor du aktiviert wirst, darfst du diese Karte umdrehen.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24332,6 +23880,49 @@
                         "kwargs": {
                             "pk": 15,
                             "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Bevor du aktiviert wirst, darfst du diese Karte umdrehen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_set_ids": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_108",
+            "force_side": null,
+            "id": 333,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Servomotorische S-Flügel (geöffnet)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 33,
+                            "raw_name": "T-65 X-wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -24402,34 +23993,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Bevor du aktiviert wirst, darfst du diese Karte umdrehen.",
+            "ability_text": "Nachdem ein anderes befreundetes Schiff in Reichweite 0–3 verteidigt hat, falls es zerstört ist, erhält der Angreifer 2 Stressmarker.<return>Solange ein befreundetes Schiff in Reichweite 0–3 einen Angriff gegen ein gestresstes Schiff durchführt, darf es 1 Angriffswürfel neu werfen.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
             "card_set_ids": [
-                1,
-                2,
-                4,
-                7
+                5
             ],
             "card_type_id": 2,
-            "cost": "0",
+            "cost": "10",
             "faction_id": null,
-            "ffg_id": "XW_U_108",
+            "ffg_id": "XW_U_109",
             "force_side": null,
-            "id": 333,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "id": 335,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Servomotorische S-Flügel (geöffnet)",
+            "is_unique": true,
+            "name": "•Admiral Sloane",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "pk": 33,
-                            "raw_name": "T-65 X-wing"
+                            "name": "Galactic Empire",
+                            "pk": 2
                         },
-                        "type": "SHIP_TYPE"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -24439,7 +24027,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                18
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24590,6 +24178,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Während der Aktivierungsphase können feindliche Schiffe in Reichweite 0–1 keine Stressmarker entfernen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_113",
+            "force_side": null,
+            "id": 339,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Todestruppen",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8,
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallcaps>Aufbau:</smallcaps> Bevor die Streitkräfte platziert werden, ordne den Zustand <smallcaps>Optimierter Prototyp</smallcaps> einem anderen befreundeten Schiff zu.",
             "available_actions": [
                 {
@@ -24733,6 +24362,111 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Während der Systemphase darfst du 2 <standardcharge> ausgeben. Falls du das tust, darf jedes befreundete Schiff ein Schiff, das du als Ziel erfasst hast, als Ziel erfassen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_117",
+            "force_side": null,
+            "id": 343,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Großmoff Tarkin",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6601,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Während der Endphase können feindliche Schiffe in Reichweite 1–2 keine Störsignalmarker entfernen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_118",
+            "force_side": null,
+            "id": 344,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "ISB-Hacker",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Zu Beginn der Kampfphase, falls du beschädigt bist, darfst du eine rote <reinforce>-Aktion durchführen.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24838,23 +24572,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Während der Endphase können feindliche Schiffe in Reichweite 1–2 keine Störsignalmarker entfernen.",
+            "ability_text": "Falls ein feindliches Schiff in Reichweite 0–1 einen Stressmarker erhalten würde, darfst du 1<nonbreak><forcecharge> ausgeben, um es stattdessen 1 Störsignal- oder 1 Fangstrahlmarker erhalten zu lassen.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
             "card_set_ids": [
-                3
+                5
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "12",
             "faction_id": null,
-            "ffg_id": "XW_U_118",
+            "ffg_id": "XW_U_121",
             "force_side": null,
-            "id": 344,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "id": 347,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "ISB-Hacker",
+            "is_unique": true,
+            "name": "•Siebte Schwester",
             "restrictions": [
                 [
                     {
@@ -24869,7 +24603,14 @@
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [],
+            "statistics": [
+                {
+                    "id": 6613,
+                    "recurring": false,
+                    "statistic_id": 4,
+                    "value": "+1"
+                }
+            ],
             "subtitle": null,
             "upgrade_types": [
                 8
@@ -24925,94 +24666,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Falls ein feindliches Schiff in Reichweite 0–1 einen Stressmarker erhalten würde, darfst du 1<nonbreak><forcecharge> ausgeben, um es stattdessen 1 Störsignal- oder 1 Fangstrahlmarker erhalten zu lassen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_121",
-            "force_side": null,
-            "id": 347,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Siebte Schwester",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6613,
-                    "recurring": false,
-                    "statistic_id": 4,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Bevor du aktiviert wirst, darfst du diese Karte umdrehen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
-            "card_set_ids": [
-                2,
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_107",
-            "force_side": null,
-            "id": 331,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Schwenkflügel (geöffnet)",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 15,
-                            "raw_name": "UT-60D U-wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Nachdem du ein Manöver teilweise ausgeführt hast, darfst du 1 weiße Aktion durchführen, wobei du jene Aktion behandelst, als wäre sie rot.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25062,38 +24715,29 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Nachdem du eine <coordinate>-Aktion durchgeführt hast, darfst du ein feindliches Schiff in Reichweite 0–3 des von dir koordinierten Schiffes wählen. Falls du das tust, erfasse jenes feindliche Schiff als Ziel, wobei du die Reichweitenbeschränkung ignorierst.",
+            "ability_text": "Solange du genau 1 Entwaffnet-Marker hast, kannst du trotzdem <torpedo>- und <missile>-Angriffe gegen Ziele durchführen, die du als Ziel erfasst hast. Falls du das tust, kannst du während des Angriffs deine Zielerfassung nicht ausgeben.<return>Füge <torpedo>- und <missile>-Slots hinzu.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_124",
+            "ffg_id": "XW_U_125",
             "force_side": null,
-            "id": 391,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "id": 350,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
             "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>ST-321</italic>",
+            "is_unique": false,
+            "name": "Os-1-Waffenarsenal",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 26,
-                            "raw_name": "Lambda-class T-4a Shuttle"
+                            "pk": 14,
+                            "raw_name": "Alpha-class Star Wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -25105,7 +24749,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                15
+                18
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25146,6 +24790,60 @@
             "subtitle": null,
             "upgrade_types": [
                 18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Kampfphase darfst du 1 feindliches Schiff in Reichweite 0–1 wählen. Falls du das tust, erhältst du 1 Berechnungsmarker, es sei denn, jenes Schiff entscheidet sich dafür, 1<nonbreak>Stressmarker zu erhalten.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_127",
+            "force_side": null,
+            "id": 352,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•0-0-0",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 338
+                        },
+                        "type": "CARD_INCLUDED"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 93
+                        },
+                        "type": "CARD_INCLUDED"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25249,6 +24947,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Cad Bane",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Während der Endphase darfst du 2<nonbreak><illicit>-Aufwertungen wählen, die befreundete Schiffe in Reichweite 0–1 ausgerüstet haben. Falls du das tust, darfst du diese Aufwertungen austauschen.<return><smallcaps>Spielende:</smallcaps> Lege alle <illicit>-Aufwertungen auf ihre ursprünglichen Schiffe zurück.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_131",
+            "force_side": null,
+            "id": 356,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Cikatro Vizago",
             "restrictions": [
                 [
                     {
@@ -25385,6 +25123,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Ketsu Onyo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du verteidigst, falls der Angreifer gestresst ist, darfst du 1 Stressmarker vom Angreifer entfernen, um 1 deiner Leerseiten/<focus>-Ergebnisse in ein <evade>-Ergebnis zu ändern.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_135",
+            "force_side": null,
+            "id": 360,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Latts Razzi",
             "restrictions": [
                 [
                     {
@@ -25563,6 +25341,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Nachdem du einen Primärangriff durchgeführt hast, der verfehlt hat, falls du nicht gestresst bist, <bold>musst</bold> du 1 Stressmarker erhalten, um einen Bonus-Primärangriff gegen dasselbe Ziel durchzuführen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_139",
+            "force_side": null,
+            "id": 364,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bossk",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Solange du einen Angriff durchführst, darfst du für jeden Stressmarker, den der Verteidiger hat, 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis ändern.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25711,6 +25529,133 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Nachdem du ein Manöver vollständig ausgeführt hast, falls du in dieser Runde noch kein Gerät abgeworfen oder gestartet hast, darfst du 1<nonbreak>Bombe abwerfen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_143",
+            "force_side": null,
+            "id": 368,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Genie“",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du einen Angriff gegen einen Verteidiger in deinem <frontarc> durchführst, darfst du 1<nonbreak><standardcharge> ausgeben, um 1 Angriffswürfel neu zu werfen. Falls das neugeworfene Ergebnis ein <crit> ist, erleide 1<nonbreak><crit>-Schaden.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_144",
+            "force_side": null,
+            "id": 369,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-P8",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6612,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Du kannst Angriffe gegen befreundete Schiffe durchführen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_145",
+            "force_side": null,
+            "id": 370,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-TK",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Füge den <bomb>-Slot hinzu.",
             "available_actions": [
                 {
@@ -25818,23 +25763,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Solange du einen Angriff gegen einen Verteidiger in deinem <frontarc> durchführst, darfst du 1<nonbreak><standardcharge> ausgeben, um 1 Angriffswürfel neu zu werfen. Falls das neugeworfene Ergebnis ein <crit> ist, erleide 1<nonbreak><crit>-Schaden.",
+            "ability_text": "An dir kann 1<nonbreak>Z-95-AF4-Kopfjäger andocken.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "4",
+            "cost": "1",
             "faction_id": null,
-            "ffg_id": "XW_U_144",
+            "ffg_id": "XW_U_148",
             "force_side": null,
-            "id": 369,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "id": 373,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R5-P8",
+            "name": "•<italic>Reißzahn</italic>",
             "restrictions": [
                 [
                     {
@@ -25844,22 +25789,73 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 24,
+                            "raw_name": "YV-666 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6612,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "3"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                10
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Du hast die Pilotenfähigkeit jedes anderen befreundeten Schiffes mit der Aufwertung <sabold>IG-2000</sabold>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_149",
+            "force_side": null,
+            "id": 374,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "<italic>IG-2000</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 21,
+                            "raw_name": "Aggressor Assault Fighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25971,23 +25967,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Du hast die Pilotenfähigkeit jedes anderen befreundeten Schiffes mit der Aufwertung <sabold>IG-2000</sabold>.",
+            "ability_text": "Solange du einen Primärangriff durchführst, falls der Verteidiger in deinem <frontarc> ist, wirf 1<nonbreak>zusätzlichen Angriffswürfel.<return>Entferne den <crew>-Slot. Füge den <astro>-Slot hinzu.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_149",
+            "ffg_id": "XW_U_152",
             "force_side": null,
-            "id": 374,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "id": 377,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "<italic>IG-2000</italic>",
+            "is_unique": true,
+            "name": "•<italic>Vollstrecker Eins</italic>",
             "restrictions": [
                 [
                     {
@@ -26001,8 +25997,8 @@
                 [
                     {
                         "kwargs": {
-                            "pk": 21,
-                            "raw_name": "Aggressor Assault Fighter"
+                            "pk": 45,
+                            "raw_name": "JumpMaster 5000"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -26172,23 +26168,72 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Aufbau:</smallcaps> Rüste diese Seite offen aus.<return>Solange du verteidigst, darfst du diese Karte umdrehen. Fall du das tust, muss der Angreifer alle Angriffswürfel neu werfen.",
+            "ability_text": "Nachdem eine deiner Aktionen scheitert, falls du keine grünen Marker hast, darfst du eine <focus>-Aktion durchführen.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_156",
+            "force_side": null,
+            "id": 381,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Gelassenheit",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zu Beginn der Endphase darfst du 1<nonbreak>Fokusmarker ausgeben, um 1<nonbreak>deiner offenen Schadenskarten zu reparieren.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_158",
+            "ffg_id": "XW_U_157",
             "force_side": null,
-            "id": 384,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+            "id": 382,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•L3-37",
+            "name": "•Chewbacca",
             "restrictions": [
                 [
                     {
@@ -26250,40 +26295,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Nachdem eine deiner Aktionen scheitert, falls du keine grünen Marker hast, darfst du eine <focus>-Aktion durchführen.",
+            "ability_text": "<smallcaps>Aufbau:</smallcaps> Rüste diese Seite offen aus.<return>Solange du verteidigst, darfst du diese Karte umdrehen. Fall du das tust, muss der Angreifer alle Angriffswürfel neu werfen.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_156",
+            "ffg_id": "XW_U_158",
             "force_side": null,
-            "id": 381,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "id": 384,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Gelassenheit",
+            "is_unique": true,
+            "name": "•L3-37",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "STRESS"
+                            "name": "Scum and Villainy",
+                            "pk": 3
                         },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -26293,7 +26329,47 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                1
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du die Würfel geworfen hast, darfst du 1 grünen Marker ausgeben um bis zu 2 deiner Ergebnisse neu zu werfen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_159",
+            "force_side": null,
+            "id": 385,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26316,6 +26392,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Tobias Beckett",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Solange du dich bewegst und Angriffe durchführst, ignorierst du Hindernisse, die du als Ziel erfasst hast.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_161",
+            "force_side": null,
+            "id": 387,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Qi’ra",
             "restrictions": [
                 [
                     {
@@ -26369,46 +26485,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Nachdem du die Würfel geworfen hast, darfst du 1 grünen Marker ausgeben um bis zu 2 deiner Ergebnisse neu zu werfen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_159",
-            "force_side": null,
-            "id": 385,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Bevor du kämpfst, darfst du eine rote<nonbreak><focus>-Aktion durchführen.",
             "available_actions": [],
             "available_upgrades": [],
@@ -26444,331 +26520,6 @@
             "subtitle": null,
             "upgrade_types": [
                 16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange du dich bewegst und Angriffe durchführst, ignorierst du Hindernisse, die du als Ziel erfasst hast.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_161",
-            "force_side": null,
-            "id": 387,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Qi’ra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du einen Stressmarker bekommen hast, darfst du 1<nonbreak>Angriffswürfel werfen, um ihn zu entfernen. Bei einem <hit>-Ergebnis erleide 1<nonbreak><hit>-Schaden.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5851,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5852,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5853,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_5",
-            "force_side": null,
-            "id": 5,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Jek Porkins",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6688,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6689,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6690,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6691,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rot Sechs",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Du kannst Primärangriffe in Reichweite<nonbreak>0 durchführen.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6363,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6364,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6365,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6366,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6367,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_146",
-            "force_side": null,
-            "id": 146,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Captain Oicunn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7244,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7245,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7246,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7247,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Genialer Taktiker",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Solange ein feindliches Schiff in Reichweite 0 verteidigt, wirft es 1<nonbreak>Verteidigungswürfel weniger.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_7",
-            "force_side": null,
-            "id": 236,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Furchteinflößend",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Nachdem du eine <focus>-Aktion durchgeführt hast, erhalte 1 Fokusmarker.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_46",
-            "force_side": null,
-            "id": 275,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Aufmerksamer Co-Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Du kannst Angriffe gegen befreundete Schiffe durchführen.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_145",
-            "force_side": null,
-            "id": 370,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•R5-TK",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26818,6 +26569,255 @@
             "subtitle": null,
             "upgrade_types": [
                 15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Nachdem du eine <coordinate>-Aktion durchgeführt hast, darfst du ein feindliches Schiff in Reichweite 0–3 des von dir koordinierten Schiffes wählen. Falls du das tust, erfasse jenes feindliche Schiff als Ziel, wobei du die Reichweitenbeschränkung ignorierst.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_124",
+            "force_side": null,
+            "id": 391,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>ST-321</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 26,
+                            "raw_name": "Lambda-class T-4a Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bombe</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Streubombe abzuwerfen.<return>Zu Beginn der Aktivierungsphase darfst du 1 Schild ausgeben, um 2<nonbreak><standardcharge> wiederherzustellen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_63",
+            "force_side": null,
+            "id": 392,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Streubombengenerator",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6622,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12,
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mine</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone ein Connernetz abzuwerfen.<return>Die <standardcharge> dieser Karte kann nicht wiederhergestellt werden.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_64",
+            "force_side": null,
+            "id": 393,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Connernetz",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6630,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bombe</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Protonenbombe abzuwerfen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_65",
+            "force_side": null,
+            "id": 394,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Protonenbomben",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6655,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mine</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Annäherungsmine abzuwerfen.<return>Die <standardcharge> dieser Karte können nicht wiederhergestellt werden.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_66",
+            "force_side": null,
+            "id": 395,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Annäherungsminen",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6662,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bombe</bitalic><return>Während der Systemphase darfst du 1<nonbreak><standardcharge> ausgeben, um unter Verwendung der [1<nonbreak><straight>]-Schablone eine Seismische Bombe abzuwerfen.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_67",
+            "force_side": null,
+            "id": 396,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Seismische Bomben",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6666,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
             ],
             "weapon_no_bonus": false,
             "weapon_range": null

--- a/translation_helper/api_export_de.json
+++ b/translation_helper/api_export_de.json
@@ -6,21 +6,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 6673,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 6674,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 6675,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -53,25 +53,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 7588,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 7589,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 7590,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 7591,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -88,21 +88,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5842,
+                    "id": 6676,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5843,
+                    "id": 6677,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5844,
+                    "id": 6678,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -134,31 +134,31 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6675,
+                    "id": 7592,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6676,
+                    "id": 7593,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6677,
+                    "id": 7594,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6678,
+                    "id": 7595,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 6679,
+                    "id": 7596,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -175,21 +175,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 6679,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 6680,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 6681,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -221,25 +221,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 7597,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 7598,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 7599,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 7600,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -256,21 +256,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5848,
+                    "id": 6682,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5849,
+                    "id": 6683,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5850,
+                    "id": 6684,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -303,25 +303,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6684,
+                    "id": 7601,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6685,
+                    "id": 7602,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6686,
+                    "id": 7603,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6687,
+                    "id": 7604,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -338,21 +338,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5851,
+                    "id": 6685,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5852,
+                    "id": 6686,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5853,
+                    "id": 6687,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -384,25 +384,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6688,
+                    "id": 7605,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6689,
+                    "id": 7606,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6690,
+                    "id": 7607,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6691,
+                    "id": 7608,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -419,21 +419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5854,
+                    "id": 6688,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5855,
+                    "id": 6689,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5856,
+                    "id": 6690,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -466,25 +466,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6692,
+                    "id": 7609,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6693,
+                    "id": 7610,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6694,
+                    "id": 7611,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6695,
+                    "id": 7612,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -501,21 +501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5857,
+                    "id": 6691,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5858,
+                    "id": 6692,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5859,
+                    "id": 6693,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -547,25 +547,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6696,
+                    "id": 7613,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6697,
+                    "id": 7614,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6698,
+                    "id": 7615,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6699,
+                    "id": 7616,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -582,21 +582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 6694,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 6695,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 6696,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -629,25 +629,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 7617,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6701,
+                    "id": 7618,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 7619,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6703,
+                    "id": 7620,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -664,21 +664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5863,
+                    "id": 6697,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5864,
+                    "id": 6698,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5865,
+                    "id": 6699,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -710,25 +710,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6704,
+                    "id": 7621,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6705,
+                    "id": 7622,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6706,
+                    "id": 7623,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6707,
+                    "id": 7624,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -745,21 +745,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5866,
+                    "id": 6700,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5867,
+                    "id": 6701,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5868,
+                    "id": 6702,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -793,25 +793,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6708,
+                    "id": 7625,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6709,
+                    "id": 7626,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6710,
+                    "id": 7627,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6711,
+                    "id": 7628,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -828,21 +828,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5869,
+                    "id": 6703,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5870,
+                    "id": 6704,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5871,
+                    "id": 6705,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -875,25 +875,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6712,
+                    "id": 7629,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6713,
+                    "id": 7630,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6714,
+                    "id": 7631,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6715,
+                    "id": 7632,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -910,21 +910,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5872,
+                    "id": 6706,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5873,
+                    "id": 6707,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5874,
+                    "id": 6708,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -956,25 +956,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6716,
+                    "id": 7633,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6717,
+                    "id": 7634,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6718,
+                    "id": 7635,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6719,
+                    "id": 7636,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -991,28 +991,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5875,
+                    "id": 6709,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5876,
+                    "id": 6710,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5877,
+                    "id": 6711,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5878,
+                    "id": 6712,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1046,25 +1046,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6720,
+                    "id": 7637,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6721,
+                    "id": 7638,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6722,
+                    "id": 7639,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6723,
+                    "id": 7640,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1081,28 +1081,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5879,
+                    "id": 6713,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5880,
+                    "id": 6714,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5881,
+                    "id": 6715,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5882,
+                    "id": 6716,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1137,25 +1137,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6724,
+                    "id": 7641,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6725,
+                    "id": 7642,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6726,
+                    "id": 7643,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6727,
+                    "id": 7644,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1172,28 +1172,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5883,
+                    "id": 6717,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5884,
+                    "id": 6718,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5885,
+                    "id": 6719,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5886,
+                    "id": 6720,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1228,25 +1228,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6728,
+                    "id": 7645,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6729,
+                    "id": 7646,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6730,
+                    "id": 7647,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6731,
+                    "id": 7648,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1263,28 +1263,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 6721,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 6722,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 6723,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 6724,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1318,25 +1318,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 7649,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 7650,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 7651,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 7652,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1353,28 +1353,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5891,
+                    "id": 6725,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5892,
+                    "id": 6726,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5893,
+                    "id": 6727,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5894,
+                    "id": 6728,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1409,25 +1409,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6736,
+                    "id": 7653,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6737,
+                    "id": 7654,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6738,
+                    "id": 7655,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6739,
+                    "id": 7656,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1444,28 +1444,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 6729,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 6730,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "id": 6731,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "id": 6732,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1499,25 +1499,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 7657,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 7658,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6742,
+                    "id": 7659,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6743,
+                    "id": 7660,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1534,35 +1534,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5899,
+                    "id": 6733,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5900,
+                    "id": 6734,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5901,
+                    "id": 6735,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5902,
+                    "id": 6736,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5903,
+                    "id": 6737,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1591,25 +1591,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6744,
+                    "id": 7661,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6745,
+                    "id": 7662,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6746,
+                    "id": 7663,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6747,
+                    "id": 7664,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1626,35 +1626,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
+                    "id": 6738,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5905,
+                    "id": 6739,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 6740,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
+                    "id": 6741,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 6742,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1683,25 +1683,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 7665,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 7666,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6750,
+                    "id": 7667,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 7668,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1718,35 +1718,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5909,
+                    "id": 6743,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5910,
+                    "id": 6744,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5911,
+                    "id": 6745,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5912,
+                    "id": 6746,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5913,
+                    "id": 6747,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1775,25 +1775,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6752,
+                    "id": 7669,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6753,
+                    "id": 7670,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6754,
+                    "id": 7671,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6755,
+                    "id": 7672,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1810,35 +1810,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5914,
+                    "id": 6748,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5915,
+                    "id": 6749,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5916,
+                    "id": 6750,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5917,
+                    "id": 6751,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5918,
+                    "id": 6752,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1866,25 +1866,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6756,
+                    "id": 7673,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6757,
+                    "id": 7674,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6758,
+                    "id": 7675,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6759,
+                    "id": 7676,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1901,21 +1901,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5919,
+                    "id": 6753,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5920,
+                    "id": 6754,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5921,
+                    "id": 6755,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1948,25 +1948,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6760,
+                    "id": 7677,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6761,
+                    "id": 7678,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6762,
+                    "id": 7679,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6763,
+                    "id": 7680,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -1983,21 +1983,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5922,
+                    "id": 6756,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5923,
+                    "id": 6757,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5924,
+                    "id": 6758,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2030,25 +2030,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6764,
+                    "id": 7681,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6765,
+                    "id": 7682,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6766,
+                    "id": 7683,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6767,
+                    "id": 7684,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2065,21 +2065,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5925,
+                    "id": 6759,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5926,
+                    "id": 6760,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5927,
+                    "id": 6761,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2112,25 +2112,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6768,
+                    "id": 7685,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6769,
+                    "id": 7686,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6770,
+                    "id": 7687,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6771,
+                    "id": 7688,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2147,21 +2147,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5928,
+                    "id": 6762,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5929,
+                    "id": 6763,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5930,
+                    "id": 6764,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2193,25 +2193,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6772,
+                    "id": 7689,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6773,
+                    "id": 7690,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6774,
+                    "id": 7691,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6775,
+                    "id": 7692,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2228,21 +2228,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5931,
+                    "id": 6765,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5932,
+                    "id": 6766,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5933,
+                    "id": 6767,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2272,25 +2272,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6776,
+                    "id": 7693,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6777,
+                    "id": 7694,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6778,
+                    "id": 7695,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6779,
+                    "id": 7696,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2307,21 +2307,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5934,
+                    "id": 6768,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5935,
+                    "id": 6769,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5936,
+                    "id": 6770,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2351,25 +2351,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6780,
+                    "id": 7697,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6781,
+                    "id": 7698,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6782,
+                    "id": 7699,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6783,
+                    "id": 7700,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2386,21 +2386,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5937,
+                    "id": 6771,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5938,
+                    "id": 6772,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5939,
+                    "id": 6773,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2430,25 +2430,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6784,
+                    "id": 7701,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6785,
+                    "id": 7702,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6786,
+                    "id": 7703,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6787,
+                    "id": 7704,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2465,21 +2465,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5940,
+                    "id": 6774,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5941,
+                    "id": 6775,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5942,
+                    "id": 6776,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2508,25 +2508,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6788,
+                    "id": 7705,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6789,
+                    "id": 7706,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6790,
+                    "id": 7707,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6791,
+                    "id": 7708,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2543,21 +2543,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5943,
+                    "id": 6777,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5944,
+                    "id": 6778,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5945,
+                    "id": 6779,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2588,25 +2588,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6792,
+                    "id": 7709,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6793,
+                    "id": 7710,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6794,
+                    "id": 7711,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6795,
+                    "id": 7712,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2623,21 +2623,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5946,
+                    "id": 6780,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5947,
+                    "id": 6781,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5948,
+                    "id": 6782,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2668,25 +2668,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6796,
+                    "id": 7713,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6797,
+                    "id": 7714,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6798,
+                    "id": 7715,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6799,
+                    "id": 7716,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2703,21 +2703,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5949,
+                    "id": 6783,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5950,
+                    "id": 6784,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5951,
+                    "id": 6785,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2747,25 +2747,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6800,
+                    "id": 7717,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6801,
+                    "id": 7718,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6802,
+                    "id": 7719,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6803,
+                    "id": 7720,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2782,21 +2782,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5952,
+                    "id": 6786,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5953,
+                    "id": 6787,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5954,
+                    "id": 6788,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2828,25 +2828,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6804,
+                    "id": 7721,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6805,
+                    "id": 7722,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6806,
+                    "id": 7723,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6807,
+                    "id": 7724,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2863,21 +2863,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5955,
+                    "id": 6789,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5956,
+                    "id": 6790,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5957,
+                    "id": 6791,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2909,25 +2909,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6808,
+                    "id": 7725,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6809,
+                    "id": 7726,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6810,
+                    "id": 7727,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6811,
+                    "id": 7728,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2944,21 +2944,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5958,
+                    "id": 6792,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5959,
+                    "id": 6793,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5960,
+                    "id": 6794,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2990,31 +2990,31 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6812,
+                    "id": 7729,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6813,
+                    "id": 7730,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6814,
+                    "id": 7731,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6815,
+                    "id": 7732,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6816,
+                    "id": 7733,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3031,21 +3031,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5961,
+                    "id": 6795,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5962,
+                    "id": 6796,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5963,
+                    "id": 6797,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -3076,25 +3076,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6817,
+                    "id": 7734,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6818,
+                    "id": 7735,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6819,
+                    "id": 7736,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6820,
+                    "id": 7737,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3111,14 +3111,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5964,
+                    "id": 6798,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5965,
+                    "id": 6799,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3150,31 +3150,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6821,
+                    "id": 7738,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6822,
+                    "id": 7739,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6823,
+                    "id": 7740,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6824,
+                    "id": 7741,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6825,
+                    "id": 7742,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3191,14 +3191,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5966,
+                    "id": 6800,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5967,
+                    "id": 6801,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3230,37 +3230,37 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6826,
+                    "id": 7743,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6827,
+                    "id": 7744,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6828,
+                    "id": 7745,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6829,
+                    "id": 7746,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6830,
+                    "id": 7747,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6831,
+                    "id": 7748,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3277,14 +3277,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5968,
+                    "id": 6802,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5969,
+                    "id": 6803,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3316,31 +3316,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6832,
+                    "id": 7749,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6833,
+                    "id": 7750,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6834,
+                    "id": 7751,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6835,
+                    "id": 7752,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6836,
+                    "id": 7753,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3357,14 +3357,14 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 5970,
+                    "id": 6804,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5971,
+                    "id": 6805,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3396,31 +3396,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6837,
+                    "id": 7754,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6838,
+                    "id": 7755,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6839,
+                    "id": 7756,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6840,
+                    "id": 7757,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6841,
+                    "id": 7758,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3437,35 +3437,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5972,
+                    "id": 6806,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5973,
+                    "id": 6807,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5974,
+                    "id": 6808,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5975,
+                    "id": 6809,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5976,
+                    "id": 6810,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3498,25 +3498,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6842,
+                    "id": 7759,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6843,
+                    "id": 7760,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6844,
+                    "id": 7761,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6845,
+                    "id": 7762,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3533,35 +3533,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5977,
+                    "id": 6811,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5978,
+                    "id": 6812,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5979,
+                    "id": 6813,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5980,
+                    "id": 6814,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5981,
+                    "id": 6815,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3594,25 +3594,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6846,
+                    "id": 7763,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6847,
+                    "id": 7764,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6848,
+                    "id": 7765,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6849,
+                    "id": 7766,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3629,35 +3629,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5982,
+                    "id": 6816,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5983,
+                    "id": 6817,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5984,
+                    "id": 6818,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5985,
+                    "id": 6819,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5986,
+                    "id": 6820,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3690,25 +3690,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6850,
+                    "id": 7767,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6851,
+                    "id": 7768,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6852,
+                    "id": 7769,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6853,
+                    "id": 7770,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3725,35 +3725,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5987,
+                    "id": 6821,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5988,
+                    "id": 6822,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5989,
+                    "id": 6823,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5990,
+                    "id": 6824,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5991,
+                    "id": 6825,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3785,25 +3785,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6854,
+                    "id": 7771,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6855,
+                    "id": 7772,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6856,
+                    "id": 7773,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6857,
+                    "id": 7774,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3820,21 +3820,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5992,
+                    "id": 6826,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5993,
+                    "id": 6827,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5994,
+                    "id": 6828,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3863,25 +3863,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6858,
+                    "id": 7775,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6859,
+                    "id": 7776,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6860,
+                    "id": 7777,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6861,
+                    "id": 7778,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3898,21 +3898,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5995,
+                    "id": 6829,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5996,
+                    "id": 6830,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5997,
+                    "id": 6831,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3941,19 +3941,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6862,
+                    "id": 7779,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6863,
+                    "id": 7780,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6864,
+                    "id": 7781,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -3970,21 +3970,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5998,
+                    "id": 6832,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5999,
+                    "id": 6833,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6000,
+                    "id": 6834,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4012,19 +4012,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6865,
+                    "id": 7782,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6866,
+                    "id": 7783,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6867,
+                    "id": 7784,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4041,21 +4041,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6001,
+                    "id": 6835,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6002,
+                    "id": 6836,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6003,
+                    "id": 6837,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4083,19 +4083,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6868,
+                    "id": 7785,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6869,
+                    "id": 7786,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6870,
+                    "id": 7787,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4112,35 +4112,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6004,
+                    "id": 6838,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6005,
+                    "id": 6839,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6006,
+                    "id": 6840,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6007,
+                    "id": 6841,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6008,
+                    "id": 6842,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4172,25 +4172,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6871,
+                    "id": 7788,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6872,
+                    "id": 7789,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6873,
+                    "id": 7790,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6874,
+                    "id": 7791,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4207,35 +4207,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6009,
+                    "id": 6843,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6010,
+                    "id": 6844,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6011,
+                    "id": 6845,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6012,
+                    "id": 6846,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6013,
+                    "id": 6847,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4267,25 +4267,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6875,
+                    "id": 7792,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6876,
+                    "id": 7793,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6877,
+                    "id": 7794,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6878,
+                    "id": 7795,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4302,35 +4302,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6014,
+                    "id": 6848,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6015,
+                    "id": 6849,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6016,
+                    "id": 6850,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6017,
+                    "id": 6851,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6018,
+                    "id": 6852,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4362,25 +4362,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6879,
+                    "id": 7796,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6880,
+                    "id": 7797,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6881,
+                    "id": 7798,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6882,
+                    "id": 7799,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4397,35 +4397,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6019,
+                    "id": 6853,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6020,
+                    "id": 6854,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6021,
+                    "id": 6855,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6022,
+                    "id": 6856,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6023,
+                    "id": 6857,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4456,25 +4456,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6883,
+                    "id": 7800,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6884,
+                    "id": 7801,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6885,
+                    "id": 7802,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6886,
+                    "id": 7803,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4491,21 +4491,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6024,
+                    "id": 6858,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6025,
+                    "id": 6859,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6026,
+                    "id": 6860,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4538,25 +4538,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6887,
+                    "id": 7804,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6888,
+                    "id": 7805,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6889,
+                    "id": 7806,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6890,
+                    "id": 7807,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4573,21 +4573,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6861,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6862,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "id": 6863,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4621,25 +4621,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6891,
+                    "id": 7808,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6892,
+                    "id": 7809,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6893,
+                    "id": 7810,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6894,
+                    "id": 7811,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4656,21 +4656,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6030,
+                    "id": 6864,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6031,
+                    "id": 6865,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6032,
+                    "id": 6866,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4703,25 +4703,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6895,
+                    "id": 7812,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6896,
+                    "id": 7813,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6897,
+                    "id": 7814,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6898,
+                    "id": 7815,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4738,21 +4738,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6033,
+                    "id": 6867,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6034,
+                    "id": 6868,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6035,
+                    "id": 6869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4786,25 +4786,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6899,
+                    "id": 7816,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6900,
+                    "id": 7817,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6901,
+                    "id": 7818,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6902,
+                    "id": 7819,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4821,21 +4821,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6036,
+                    "id": 6870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6037,
+                    "id": 6871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6038,
+                    "id": 6872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4868,25 +4868,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6903,
+                    "id": 7820,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6904,
+                    "id": 7821,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6905,
+                    "id": 7822,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6906,
+                    "id": 7823,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4903,21 +4903,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6039,
+                    "id": 6873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6040,
+                    "id": 6874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6041,
+                    "id": 6875,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4950,25 +4950,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6907,
+                    "id": 7824,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6908,
+                    "id": 7825,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6909,
+                    "id": 7826,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6910,
+                    "id": 7827,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4985,21 +4985,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6042,
+                    "id": 6876,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6043,
+                    "id": 6877,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6044,
+                    "id": 6878,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5031,25 +5031,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6911,
+                    "id": 7828,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6912,
+                    "id": 7829,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6913,
+                    "id": 7830,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6914,
+                    "id": 7831,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5066,21 +5066,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6045,
+                    "id": 6879,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6046,
+                    "id": 6880,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6047,
+                    "id": 6881,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5113,25 +5113,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6915,
+                    "id": 7832,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6916,
+                    "id": 7833,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6917,
+                    "id": 7834,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6918,
+                    "id": 7835,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5148,35 +5148,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6048,
+                    "id": 6882,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6049,
+                    "id": 6883,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6050,
+                    "id": 6884,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6051,
+                    "id": 6885,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6052,
+                    "id": 6886,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5211,25 +5211,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6919,
+                    "id": 7836,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6920,
+                    "id": 7837,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6921,
+                    "id": 7838,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6922,
+                    "id": 7839,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5246,35 +5246,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6053,
+                    "id": 6887,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6054,
+                    "id": 6888,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6055,
+                    "id": 6889,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6056,
+                    "id": 6890,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6057,
+                    "id": 6891,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5309,25 +5309,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6923,
+                    "id": 7840,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6924,
+                    "id": 7841,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6925,
+                    "id": 7842,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6926,
+                    "id": 7843,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5344,35 +5344,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6058,
+                    "id": 6892,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6059,
+                    "id": 6893,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6060,
+                    "id": 6894,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6061,
+                    "id": 6895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6062,
+                    "id": 6896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5407,25 +5407,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6927,
+                    "id": 7844,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6928,
+                    "id": 7845,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6929,
+                    "id": 7846,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6930,
+                    "id": 7847,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5442,21 +5442,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6063,
+                    "id": 6897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6064,
+                    "id": 6898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6065,
+                    "id": 6899,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5489,31 +5489,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6931,
+                    "id": 7848,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6932,
+                    "id": 7849,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6933,
+                    "id": 7850,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6934,
+                    "id": 7851,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6935,
+                    "id": 7852,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5530,21 +5530,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6066,
+                    "id": 6900,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6067,
+                    "id": 6901,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6068,
+                    "id": 6902,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5577,31 +5577,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6936,
+                    "id": 7853,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6937,
+                    "id": 7854,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6938,
+                    "id": 7855,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6939,
+                    "id": 7856,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6940,
+                    "id": 7857,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5618,21 +5618,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6069,
+                    "id": 6903,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6070,
+                    "id": 6904,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6071,
+                    "id": 6905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5665,31 +5665,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6941,
+                    "id": 7858,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6942,
+                    "id": 7859,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6943,
+                    "id": 7860,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6944,
+                    "id": 7861,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6945,
+                    "id": 7862,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5706,21 +5706,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6072,
+                    "id": 6906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6073,
+                    "id": 6907,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6074,
+                    "id": 6908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5753,31 +5753,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6946,
+                    "id": 7863,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6947,
+                    "id": 7864,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6948,
+                    "id": 7865,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6949,
+                    "id": 7866,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6950,
+                    "id": 7867,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5794,28 +5794,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6075,
+                    "id": 6909,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6076,
+                    "id": 6910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6077,
+                    "id": 6911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6078,
+                    "id": 6912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5850,25 +5850,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6951,
+                    "id": 7868,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6952,
+                    "id": 7869,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6953,
+                    "id": 7870,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6954,
+                    "id": 7871,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5885,28 +5885,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6079,
+                    "id": 6913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6080,
+                    "id": 6914,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6081,
+                    "id": 6915,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6082,
+                    "id": 6916,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5941,25 +5941,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6955,
+                    "id": 7872,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6956,
+                    "id": 7873,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6957,
+                    "id": 7874,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6958,
+                    "id": 7875,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5976,28 +5976,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6083,
+                    "id": 6917,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6084,
+                    "id": 6918,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6085,
+                    "id": 6919,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6086,
+                    "id": 6920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6032,31 +6032,31 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6959,
+                    "id": 7876,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6960,
+                    "id": 7877,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6961,
+                    "id": 7878,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6962,
+                    "id": 7879,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
                 },
                 {
-                    "id": 6963,
+                    "id": 7880,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -6073,28 +6073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6087,
+                    "id": 6921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6088,
+                    "id": 6922,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6089,
+                    "id": 6923,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6090,
+                    "id": 6924,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6128,25 +6128,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6964,
+                    "id": 7881,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6965,
+                    "id": 7882,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6966,
+                    "id": 7883,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6967,
+                    "id": 7884,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -6163,21 +6163,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6091,
+                    "id": 6925,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6092,
+                    "id": 6926,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6093,
+                    "id": 6927,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6212,25 +6212,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6968,
+                    "id": 7885,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6969,
+                    "id": 7886,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6970,
+                    "id": 7887,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6971,
+                    "id": 7888,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6247,21 +6247,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6094,
+                    "id": 6928,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6095,
+                    "id": 6929,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6096,
+                    "id": 6930,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6296,31 +6296,31 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6972,
+                    "id": 7889,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6973,
+                    "id": 7890,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6974,
+                    "id": 7891,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6975,
+                    "id": 7892,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 6976,
+                    "id": 7893,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -6337,21 +6337,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6097,
+                    "id": 6931,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6098,
+                    "id": 6932,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6099,
+                    "id": 6933,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6385,25 +6385,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6977,
+                    "id": 7894,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6978,
+                    "id": 7895,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6979,
+                    "id": 7896,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6980,
+                    "id": 7897,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6420,21 +6420,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6100,
+                    "id": 6934,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6101,
+                    "id": 6935,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6102,
+                    "id": 6936,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6468,25 +6468,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6981,
+                    "id": 7898,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6982,
+                    "id": 7899,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6983,
+                    "id": 7900,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6984,
+                    "id": 7901,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6503,28 +6503,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6103,
+                    "id": 6937,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6104,
+                    "id": 6938,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6105,
+                    "id": 6939,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6106,
+                    "id": 6940,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6558,25 +6558,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6985,
+                    "id": 7902,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6986,
+                    "id": 7903,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6987,
+                    "id": 7904,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6988,
+                    "id": 7905,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6593,28 +6593,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6107,
+                    "id": 6941,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6108,
+                    "id": 6942,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6109,
+                    "id": 6943,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6110,
+                    "id": 6944,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6647,25 +6647,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6989,
+                    "id": 7906,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6990,
+                    "id": 7907,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6991,
+                    "id": 7908,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6992,
+                    "id": 7909,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6682,28 +6682,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6111,
+                    "id": 6945,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6112,
+                    "id": 6946,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6113,
+                    "id": 6947,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6114,
+                    "id": 6948,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6736,25 +6736,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6993,
+                    "id": 7910,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6994,
+                    "id": 7911,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6995,
+                    "id": 7912,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6996,
+                    "id": 7913,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6771,21 +6771,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6115,
+                    "id": 6949,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6116,
+                    "id": 6950,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6117,
+                    "id": 6951,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6815,19 +6815,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6997,
+                    "id": 7914,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6998,
+                    "id": 7915,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6999,
+                    "id": 7916,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6844,21 +6844,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6118,
+                    "id": 6952,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6119,
+                    "id": 6953,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6120,
+                    "id": 6954,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6888,19 +6888,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7000,
+                    "id": 7917,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7001,
+                    "id": 7918,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7002,
+                    "id": 7919,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6917,21 +6917,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6121,
+                    "id": 6955,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6122,
+                    "id": 6956,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6123,
+                    "id": 6957,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6961,19 +6961,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7003,
+                    "id": 7920,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7004,
+                    "id": 7921,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7005,
+                    "id": 7922,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6990,21 +6990,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6124,
+                    "id": 6958,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6125,
+                    "id": 6959,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6126,
+                    "id": 6960,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7033,25 +7033,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7006,
+                    "id": 7923,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7007,
+                    "id": 7924,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7008,
+                    "id": 7925,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7009,
+                    "id": 7926,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -7068,21 +7068,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6127,
+                    "id": 6961,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6128,
+                    "id": 6962,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6129,
+                    "id": 6963,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7111,19 +7111,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7010,
+                    "id": 7927,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7011,
+                    "id": 7928,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7012,
+                    "id": 7929,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7140,21 +7140,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6130,
+                    "id": 6964,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6131,
+                    "id": 6965,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6132,
+                    "id": 6966,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7183,19 +7183,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7013,
+                    "id": 7930,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7014,
+                    "id": 7931,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7015,
+                    "id": 7932,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7212,21 +7212,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6133,
+                    "id": 6967,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6134,
+                    "id": 6968,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6135,
+                    "id": 6969,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7255,19 +7255,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7016,
+                    "id": 7933,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7017,
+                    "id": 7934,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7018,
+                    "id": 7935,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7284,21 +7284,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6136,
+                    "id": 6970,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6137,
+                    "id": 6971,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6138,
+                    "id": 6972,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7327,19 +7327,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7019,
+                    "id": 7936,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7020,
+                    "id": 7937,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7021,
+                    "id": 7938,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7356,21 +7356,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6139,
+                    "id": 6973,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6140,
+                    "id": 6974,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6141,
+                    "id": 6975,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7398,19 +7398,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7022,
+                    "id": 7939,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7023,
+                    "id": 7940,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7024,
+                    "id": 7941,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7427,21 +7427,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6142,
+                    "id": 6976,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6143,
+                    "id": 6977,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6144,
+                    "id": 6978,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7470,25 +7470,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7025,
+                    "id": 7942,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7026,
+                    "id": 7943,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7027,
+                    "id": 7944,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7028,
+                    "id": 7945,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -7505,21 +7505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6145,
+                    "id": 6979,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6146,
+                    "id": 6980,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6147,
+                    "id": 6981,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7550,19 +7550,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7029,
+                    "id": 7946,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7030,
+                    "id": 7947,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7031,
+                    "id": 7948,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7579,21 +7579,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6148,
+                    "id": 6982,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6149,
+                    "id": 6983,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6150,
+                    "id": 6984,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7623,19 +7623,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7032,
+                    "id": 7949,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7033,
+                    "id": 7950,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7034,
+                    "id": 7951,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7652,21 +7652,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6151,
+                    "id": 6985,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6152,
+                    "id": 6986,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6153,
+                    "id": 6987,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7696,19 +7696,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7035,
+                    "id": 7952,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7036,
+                    "id": 7953,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7037,
+                    "id": 7954,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7725,21 +7725,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6154,
+                    "id": 6988,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6155,
+                    "id": 6989,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6156,
+                    "id": 6990,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7771,31 +7771,31 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7038,
+                    "id": 7955,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7039,
+                    "id": 7956,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7040,
+                    "id": 7957,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7041,
+                    "id": 7958,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7042,
+                    "id": 7959,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "3"
@@ -7812,21 +7812,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6157,
+                    "id": 6991,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6158,
+                    "id": 6992,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6159,
+                    "id": 6993,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7858,25 +7858,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7043,
+                    "id": 7960,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7044,
+                    "id": 7961,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7045,
+                    "id": 7962,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7046,
+                    "id": 7963,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7893,21 +7893,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6160,
+                    "id": 6994,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6161,
+                    "id": 6995,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6162,
+                    "id": 6996,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7938,25 +7938,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7047,
+                    "id": 7964,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7048,
+                    "id": 7965,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7049,
+                    "id": 7966,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7050,
+                    "id": 7967,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7973,21 +7973,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6163,
+                    "id": 6997,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6164,
+                    "id": 6998,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6165,
+                    "id": 6999,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8018,25 +8018,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7051,
+                    "id": 7968,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7052,
+                    "id": 7969,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7053,
+                    "id": 7970,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7054,
+                    "id": 7971,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8053,21 +8053,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6166,
+                    "id": 7000,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6167,
+                    "id": 7001,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6168,
+                    "id": 7002,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8099,25 +8099,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7055,
+                    "id": 7972,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7056,
+                    "id": 7973,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7057,
+                    "id": 7974,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7058,
+                    "id": 7975,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8134,21 +8134,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6169,
+                    "id": 7003,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6170,
+                    "id": 7004,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6171,
+                    "id": 7005,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8179,25 +8179,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7059,
+                    "id": 7976,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7060,
+                    "id": 7977,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7061,
+                    "id": 7978,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7062,
+                    "id": 7979,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8214,35 +8214,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6172,
+                    "id": 7006,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6173,
+                    "id": 7007,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6174,
+                    "id": 7008,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6175,
+                    "id": 7009,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6176,
+                    "id": 7010,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8272,31 +8272,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7063,
+                    "id": 7980,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7064,
+                    "id": 7981,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7065,
+                    "id": 7982,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7066,
+                    "id": 7983,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7067,
+                    "id": 7984,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8313,35 +8313,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6177,
+                    "id": 7011,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6178,
+                    "id": 7012,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6179,
+                    "id": 7013,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6180,
+                    "id": 7014,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6181,
+                    "id": 7015,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8371,31 +8371,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7068,
+                    "id": 7985,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7069,
+                    "id": 7986,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7070,
+                    "id": 7987,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7071,
+                    "id": 7988,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7072,
+                    "id": 7989,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8412,35 +8412,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6182,
+                    "id": 7016,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6183,
+                    "id": 7017,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6184,
+                    "id": 7018,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6185,
+                    "id": 7019,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6186,
+                    "id": 7020,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8470,25 +8470,25 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7073,
+                    "id": 7990,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7074,
+                    "id": 7991,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7075,
+                    "id": 7992,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7076,
+                    "id": 7993,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8505,35 +8505,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6187,
+                    "id": 7021,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6188,
+                    "id": 7022,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6189,
+                    "id": 7023,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6190,
+                    "id": 7024,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6191,
+                    "id": 7025,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8563,31 +8563,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7994,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7078,
+                    "id": 7995,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7996,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7080,
+                    "id": 7997,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7081,
+                    "id": 7998,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -8604,28 +8604,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6192,
+                    "id": 7026,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6193,
+                    "id": 7027,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6194,
+                    "id": 7028,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6195,
+                    "id": 7029,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8655,19 +8655,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7082,
+                    "id": 7999,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7083,
+                    "id": 8000,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7084,
+                    "id": 8001,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8684,28 +8684,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6196,
+                    "id": 7030,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6197,
+                    "id": 7031,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6198,
+                    "id": 7032,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6199,
+                    "id": 7033,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8735,19 +8735,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7085,
+                    "id": 8002,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7086,
+                    "id": 8003,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7087,
+                    "id": 8004,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8764,28 +8764,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6200,
+                    "id": 7034,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6201,
+                    "id": 7035,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6202,
+                    "id": 7036,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6203,
+                    "id": 7037,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8815,19 +8815,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7088,
+                    "id": 8005,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7089,
+                    "id": 8006,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7090,
+                    "id": 8007,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8844,28 +8844,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6204,
+                    "id": 7038,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6205,
+                    "id": 7039,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6206,
+                    "id": 7040,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6207,
+                    "id": 7041,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8894,19 +8894,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7091,
+                    "id": 8008,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7092,
+                    "id": 8009,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7093,
+                    "id": 8010,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8923,28 +8923,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6208,
+                    "id": 7042,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6209,
+                    "id": 7043,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6210,
+                    "id": 7044,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6211,
+                    "id": 7045,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8979,19 +8979,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7094,
+                    "id": 8011,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7095,
+                    "id": 8012,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7096,
+                    "id": 8013,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9008,28 +9008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6212,
+                    "id": 7046,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6213,
+                    "id": 7047,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6214,
+                    "id": 7048,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6215,
+                    "id": 7049,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9064,19 +9064,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7097,
+                    "id": 8014,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7098,
+                    "id": 8015,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7099,
+                    "id": 8016,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9093,28 +9093,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6216,
+                    "id": 7050,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6217,
+                    "id": 7051,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6218,
+                    "id": 7052,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6219,
+                    "id": 7053,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9149,19 +9149,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7100,
+                    "id": 8017,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7101,
+                    "id": 8018,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7102,
+                    "id": 8019,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9178,28 +9178,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6220,
+                    "id": 7054,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6221,
+                    "id": 7055,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6222,
+                    "id": 7056,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6223,
+                    "id": 7057,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9233,19 +9233,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7103,
+                    "id": 8020,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7104,
+                    "id": 8021,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7105,
+                    "id": 8022,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9262,28 +9262,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6224,
+                    "id": 7058,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6225,
+                    "id": 7059,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6226,
+                    "id": 7060,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6227,
+                    "id": 7061,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9318,19 +9318,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7106,
+                    "id": 8023,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7107,
+                    "id": 8024,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7108,
+                    "id": 8025,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9347,28 +9347,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6228,
+                    "id": 7062,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6229,
+                    "id": 7063,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6230,
+                    "id": 7064,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6231,
+                    "id": 7065,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9402,19 +9402,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7109,
+                    "id": 8026,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7110,
+                    "id": 8027,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7111,
+                    "id": 8028,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9431,28 +9431,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6232,
+                    "id": 7066,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6233,
+                    "id": 7067,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6234,
+                    "id": 7068,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6235,
+                    "id": 7069,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9483,25 +9483,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7112,
+                    "id": 8029,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7113,
+                    "id": 8030,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7114,
+                    "id": 8031,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7115,
+                    "id": 8032,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9518,28 +9518,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6236,
+                    "id": 7070,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6237,
+                    "id": 7071,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6238,
+                    "id": 7072,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6239,
+                    "id": 7073,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9570,25 +9570,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7116,
+                    "id": 8033,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7117,
+                    "id": 8034,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7118,
+                    "id": 8035,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7119,
+                    "id": 8036,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9605,28 +9605,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6240,
+                    "id": 7074,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6241,
+                    "id": 7075,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6242,
+                    "id": 7076,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6243,
+                    "id": 7077,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9656,25 +9656,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7120,
+                    "id": 8037,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7121,
+                    "id": 8038,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7122,
+                    "id": 8039,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7123,
+                    "id": 8040,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9691,28 +9691,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6244,
+                    "id": 7078,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6245,
+                    "id": 7079,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6246,
+                    "id": 7080,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6247,
+                    "id": 7081,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9742,25 +9742,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7124,
+                    "id": 8041,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7125,
+                    "id": 8042,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7126,
+                    "id": 8043,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7127,
+                    "id": 8044,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9777,21 +9777,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6248,
+                    "id": 7082,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6249,
+                    "id": 7083,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6250,
+                    "id": 7084,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9822,19 +9822,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7128,
+                    "id": 8045,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7129,
+                    "id": 8046,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7130,
+                    "id": 8047,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9851,21 +9851,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6251,
+                    "id": 7085,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6252,
+                    "id": 7086,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6253,
+                    "id": 7087,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9896,19 +9896,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7131,
+                    "id": 8048,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7132,
+                    "id": 8049,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7133,
+                    "id": 8050,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9925,21 +9925,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6254,
+                    "id": 7088,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6255,
+                    "id": 7089,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6256,
+                    "id": 7090,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9970,19 +9970,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7134,
+                    "id": 8051,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7135,
+                    "id": 8052,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7136,
+                    "id": 8053,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9999,21 +9999,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6257,
+                    "id": 7091,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6258,
+                    "id": 7092,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6259,
+                    "id": 7093,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10044,19 +10044,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7137,
+                    "id": 8054,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7138,
+                    "id": 8055,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7139,
+                    "id": 8056,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10073,21 +10073,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6260,
+                    "id": 7094,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6261,
+                    "id": 7095,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6262,
+                    "id": 7096,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10117,19 +10117,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7140,
+                    "id": 8057,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7141,
+                    "id": 8058,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7142,
+                    "id": 8059,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10146,35 +10146,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6263,
+                    "id": 7097,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6264,
+                    "id": 7098,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6265,
+                    "id": 7099,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6266,
+                    "id": 7100,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6267,
+                    "id": 7101,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10205,25 +10205,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7143,
+                    "id": 8060,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7144,
+                    "id": 8061,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7145,
+                    "id": 8062,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7146,
+                    "id": 8063,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10240,35 +10240,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6268,
+                    "id": 7102,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6269,
+                    "id": 7103,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6270,
+                    "id": 7104,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6271,
+                    "id": 7105,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6272,
+                    "id": 7106,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10299,25 +10299,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7147,
+                    "id": 8064,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7148,
+                    "id": 8065,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7149,
+                    "id": 8066,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7150,
+                    "id": 8067,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10334,35 +10334,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6273,
+                    "id": 7107,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6274,
+                    "id": 7108,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6275,
+                    "id": 7109,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6276,
+                    "id": 7110,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6277,
+                    "id": 7111,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10393,25 +10393,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7151,
+                    "id": 8068,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7152,
+                    "id": 8069,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7153,
+                    "id": 8070,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7154,
+                    "id": 8071,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10428,35 +10428,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6278,
+                    "id": 7112,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6279,
+                    "id": 7113,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6280,
+                    "id": 7114,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6281,
+                    "id": 7115,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6282,
+                    "id": 7116,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10487,25 +10487,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7155,
+                    "id": 8072,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7156,
+                    "id": 8073,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7157,
+                    "id": 8074,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7158,
+                    "id": 8075,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10522,35 +10522,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6283,
+                    "id": 7117,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6284,
+                    "id": 7118,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6285,
+                    "id": 7119,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6286,
+                    "id": 7120,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6287,
+                    "id": 7121,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10580,25 +10580,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7159,
+                    "id": 8076,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7160,
+                    "id": 8077,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7161,
+                    "id": 8078,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7162,
+                    "id": 8079,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10615,21 +10615,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6288,
+                    "id": 7122,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6289,
+                    "id": 7123,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6290,
+                    "id": 7124,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10662,25 +10662,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7163,
+                    "id": 8080,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7164,
+                    "id": 8081,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7165,
+                    "id": 8082,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7166,
+                    "id": 8083,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10697,21 +10697,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6291,
+                    "id": 7125,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6292,
+                    "id": 7126,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6293,
+                    "id": 7127,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10744,25 +10744,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7167,
+                    "id": 8084,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7168,
+                    "id": 8085,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7169,
+                    "id": 8086,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7170,
+                    "id": 8087,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10779,21 +10779,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6294,
+                    "id": 7128,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6295,
+                    "id": 7129,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6296,
+                    "id": 7130,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10826,25 +10826,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7171,
+                    "id": 8088,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7172,
+                    "id": 8089,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7173,
+                    "id": 8090,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7174,
+                    "id": 8091,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10861,21 +10861,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6297,
+                    "id": 7131,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6298,
+                    "id": 7132,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6299,
+                    "id": 7133,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10907,25 +10907,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7175,
+                    "id": 8092,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7176,
+                    "id": 8093,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7177,
+                    "id": 8094,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7178,
+                    "id": 8095,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10942,28 +10942,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6300,
+                    "id": 7134,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6301,
+                    "id": 7135,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6302,
+                    "id": 7136,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6303,
+                    "id": 7137,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10994,25 +10994,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7179,
+                    "id": 8096,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7180,
+                    "id": 8097,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7181,
+                    "id": 8098,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7182,
+                    "id": 8099,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11029,28 +11029,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6304,
+                    "id": 7138,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6305,
+                    "id": 7139,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6306,
+                    "id": 7140,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6307,
+                    "id": 7141,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11081,25 +11081,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7183,
+                    "id": 8100,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7184,
+                    "id": 8101,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7185,
+                    "id": 8102,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7186,
+                    "id": 8103,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11116,28 +11116,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6308,
+                    "id": 7142,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6309,
+                    "id": 7143,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6310,
+                    "id": 7144,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6311,
+                    "id": 7145,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11168,25 +11168,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7187,
+                    "id": 8104,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7188,
+                    "id": 8105,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7189,
+                    "id": 8106,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7190,
+                    "id": 8107,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11203,28 +11203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6312,
+                    "id": 7146,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6313,
+                    "id": 7147,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6314,
+                    "id": 7148,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6315,
+                    "id": 7149,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11254,25 +11254,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7191,
+                    "id": 8108,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7192,
+                    "id": 8109,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7193,
+                    "id": 8110,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7194,
+                    "id": 8111,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11289,28 +11289,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6316,
+                    "id": 7150,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6317,
+                    "id": 7151,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6318,
+                    "id": 7152,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6319,
+                    "id": 7153,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11343,25 +11343,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7195,
+                    "id": 8112,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7196,
+                    "id": 8113,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7197,
+                    "id": 8114,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7198,
+                    "id": 8115,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11378,28 +11378,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6320,
+                    "id": 7154,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6321,
+                    "id": 7155,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6322,
+                    "id": 7156,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6323,
+                    "id": 7157,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11432,25 +11432,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7199,
+                    "id": 8116,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7200,
+                    "id": 8117,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7201,
+                    "id": 8118,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7202,
+                    "id": 8119,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11467,28 +11467,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6324,
+                    "id": 7158,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6325,
+                    "id": 7159,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6326,
+                    "id": 7160,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6327,
+                    "id": 7161,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11521,25 +11521,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7203,
+                    "id": 8120,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7204,
+                    "id": 8121,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7205,
+                    "id": 8122,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7206,
+                    "id": 8123,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11556,28 +11556,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6328,
+                    "id": 7162,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6329,
+                    "id": 7163,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6330,
+                    "id": 7164,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6331,
+                    "id": 7165,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11609,25 +11609,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7207,
+                    "id": 8124,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7208,
+                    "id": 8125,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7209,
+                    "id": 8126,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7210,
+                    "id": 8127,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11644,35 +11644,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6332,
+                    "id": 7166,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6333,
+                    "id": 7167,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6334,
+                    "id": 7168,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6335,
+                    "id": 7169,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6336,
+                    "id": 7170,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11707,25 +11707,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7211,
+                    "id": 8128,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7212,
+                    "id": 8129,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7213,
+                    "id": 8130,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7214,
+                    "id": 8131,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11742,35 +11742,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6337,
+                    "id": 7171,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6338,
+                    "id": 7172,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6339,
+                    "id": 7173,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6340,
+                    "id": 7174,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6341,
+                    "id": 7175,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11805,25 +11805,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7215,
+                    "id": 8132,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7216,
+                    "id": 8133,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7217,
+                    "id": 8134,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7218,
+                    "id": 8135,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11840,35 +11840,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6342,
+                    "id": 7176,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6343,
+                    "id": 7177,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6344,
+                    "id": 7178,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6345,
+                    "id": 7179,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6346,
+                    "id": 7180,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11903,25 +11903,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7219,
+                    "id": 8136,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7220,
+                    "id": 8137,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7221,
+                    "id": 8138,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7222,
+                    "id": 8139,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11938,28 +11938,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6347,
+                    "id": 7181,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6348,
+                    "id": 7182,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6349,
+                    "id": 7183,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6350,
+                    "id": 7184,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11992,31 +11992,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7223,
+                    "id": 8140,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7224,
+                    "id": 8141,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7225,
+                    "id": 8142,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7226,
+                    "id": 8143,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7227,
+                    "id": 8144,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12033,28 +12033,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6351,
+                    "id": 7185,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6352,
+                    "id": 7186,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6353,
+                    "id": 7187,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6354,
+                    "id": 7188,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12087,37 +12087,37 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7228,
+                    "id": 8145,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7229,
+                    "id": 8146,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7230,
+                    "id": 8147,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7231,
+                    "id": 8148,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7232,
+                    "id": 8149,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7233,
+                    "id": 8150,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -12134,28 +12134,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6355,
+                    "id": 7189,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6356,
+                    "id": 7190,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6357,
+                    "id": 7191,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6358,
+                    "id": 7192,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12188,31 +12188,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7234,
+                    "id": 8151,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7235,
+                    "id": 8152,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7236,
+                    "id": 8153,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7237,
+                    "id": 8154,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7238,
+                    "id": 8155,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12229,28 +12229,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6359,
+                    "id": 7193,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6360,
+                    "id": 7194,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6361,
+                    "id": 7195,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6362,
+                    "id": 7196,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12283,31 +12283,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7239,
+                    "id": 8156,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7240,
+                    "id": 8157,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7241,
+                    "id": 8158,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7242,
+                    "id": 8159,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7243,
+                    "id": 8160,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12324,35 +12324,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6363,
+                    "id": 7197,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6364,
+                    "id": 7198,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6365,
+                    "id": 7199,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6366,
+                    "id": 7200,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6367,
+                    "id": 7201,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12387,25 +12387,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7244,
+                    "id": 8161,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7245,
+                    "id": 8162,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7246,
+                    "id": 8163,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7247,
+                    "id": 8164,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12422,35 +12422,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6368,
+                    "id": 7202,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6369,
+                    "id": 7203,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6370,
+                    "id": 7204,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6371,
+                    "id": 7205,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6372,
+                    "id": 7206,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12485,25 +12485,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7248,
+                    "id": 8165,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7249,
+                    "id": 8166,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7250,
+                    "id": 8167,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7251,
+                    "id": 8168,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12520,35 +12520,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6373,
+                    "id": 7207,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6374,
+                    "id": 7208,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6375,
+                    "id": 7209,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6376,
+                    "id": 7210,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6377,
+                    "id": 7211,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12582,25 +12582,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7252,
+                    "id": 8169,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7253,
+                    "id": 8170,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7254,
+                    "id": 8171,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7255,
+                    "id": 8172,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12617,28 +12617,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6378,
+                    "id": 7212,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6379,
+                    "id": 7213,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6380,
+                    "id": 7214,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6381,
+                    "id": 7215,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12674,31 +12674,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7256,
+                    "id": 8173,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7257,
+                    "id": 8174,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7258,
+                    "id": 8175,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7259,
+                    "id": 8176,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7260,
+                    "id": 8177,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12715,28 +12715,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6382,
+                    "id": 7216,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6383,
+                    "id": 7217,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6384,
+                    "id": 7218,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6385,
+                    "id": 7219,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12772,31 +12772,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7261,
+                    "id": 8178,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7262,
+                    "id": 8179,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7263,
+                    "id": 8180,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7264,
+                    "id": 8181,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7265,
+                    "id": 8182,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12813,28 +12813,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6386,
+                    "id": 7220,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6387,
+                    "id": 7221,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6388,
+                    "id": 7222,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6389,
+                    "id": 7223,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12870,31 +12870,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7266,
+                    "id": 8183,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7267,
+                    "id": 8184,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7268,
+                    "id": 8185,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7269,
+                    "id": 8186,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7270,
+                    "id": 8187,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12911,28 +12911,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6390,
+                    "id": 7224,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6391,
+                    "id": 7225,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6392,
+                    "id": 7226,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6393,
+                    "id": 7227,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12967,31 +12967,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7271,
+                    "id": 8188,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7272,
+                    "id": 8189,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7273,
+                    "id": 8190,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7274,
+                    "id": 8191,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7275,
+                    "id": 8192,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13008,28 +13008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6394,
+                    "id": 7228,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6395,
+                    "id": 7229,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6396,
+                    "id": 7230,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6397,
+                    "id": 7231,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13065,31 +13065,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7276,
+                    "id": 8193,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7277,
+                    "id": 8194,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7278,
+                    "id": 8195,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7279,
+                    "id": 8196,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7280,
+                    "id": 8197,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13106,28 +13106,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6398,
+                    "id": 7232,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6399,
+                    "id": 7233,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6400,
+                    "id": 7234,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6401,
+                    "id": 7235,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13162,31 +13162,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7281,
+                    "id": 8198,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7282,
+                    "id": 8199,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7283,
+                    "id": 8200,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7284,
+                    "id": 8201,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7285,
+                    "id": 8202,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13203,28 +13203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6402,
+                    "id": 7236,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6403,
+                    "id": 7237,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6404,
+                    "id": 7238,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6405,
+                    "id": 7239,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13254,19 +13254,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7286,
+                    "id": 8203,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7287,
+                    "id": 8204,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7288,
+                    "id": 8205,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13283,28 +13283,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6406,
+                    "id": 7240,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6407,
+                    "id": 7241,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6408,
+                    "id": 7242,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6409,
+                    "id": 7243,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13334,19 +13334,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7289,
+                    "id": 8206,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7290,
+                    "id": 8207,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7291,
+                    "id": 8208,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13363,28 +13363,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6410,
+                    "id": 7244,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6411,
+                    "id": 7245,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6412,
+                    "id": 7246,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6413,
+                    "id": 7247,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13413,19 +13413,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7292,
+                    "id": 8209,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7293,
+                    "id": 8210,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7294,
+                    "id": 8211,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13442,28 +13442,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6414,
+                    "id": 7248,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6415,
+                    "id": 7249,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6416,
+                    "id": 7250,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6417,
+                    "id": 7251,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13493,19 +13493,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7295,
+                    "id": 8212,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7296,
+                    "id": 8213,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7297,
+                    "id": 8214,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13522,28 +13522,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6418,
+                    "id": 7252,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6419,
+                    "id": 7253,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6420,
+                    "id": 7254,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6421,
+                    "id": 7255,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13573,19 +13573,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7298,
+                    "id": 8215,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7299,
+                    "id": 8216,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7300,
+                    "id": 8217,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13602,28 +13602,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6422,
+                    "id": 7256,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6423,
+                    "id": 7257,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6424,
+                    "id": 7258,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6425,
+                    "id": 7259,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13652,19 +13652,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7301,
+                    "id": 8218,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7302,
+                    "id": 8219,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7303,
+                    "id": 8220,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13681,21 +13681,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6426,
+                    "id": 7260,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6427,
+                    "id": 7261,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6428,
+                    "id": 7262,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13728,19 +13728,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7304,
+                    "id": 8221,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7305,
+                    "id": 8222,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7306,
+                    "id": 8223,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13757,21 +13757,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6429,
+                    "id": 7263,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6430,
+                    "id": 7264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6431,
+                    "id": 7265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13803,19 +13803,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7307,
+                    "id": 8224,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7308,
+                    "id": 8225,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7309,
+                    "id": 8226,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13832,21 +13832,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6432,
+                    "id": 7266,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6433,
+                    "id": 7267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6434,
+                    "id": 7268,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13878,19 +13878,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7310,
+                    "id": 8227,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7311,
+                    "id": 8228,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7312,
+                    "id": 8229,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13907,21 +13907,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6435,
+                    "id": 7269,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6436,
+                    "id": 7270,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6437,
+                    "id": 7271,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13953,19 +13953,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7313,
+                    "id": 8230,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7314,
+                    "id": 8231,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7315,
+                    "id": 8232,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13982,28 +13982,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6438,
+                    "id": 7272,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6439,
+                    "id": 7273,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6440,
+                    "id": 7274,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6441,
+                    "id": 7275,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14038,25 +14038,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7316,
+                    "id": 8233,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7317,
+                    "id": 8234,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7318,
+                    "id": 8235,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7319,
+                    "id": 8236,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14073,28 +14073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6442,
+                    "id": 7276,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6443,
+                    "id": 7277,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6444,
+                    "id": 7278,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6445,
+                    "id": 7279,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14129,25 +14129,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7320,
+                    "id": 8237,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7321,
+                    "id": 8238,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7322,
+                    "id": 8239,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7323,
+                    "id": 8240,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14164,28 +14164,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6446,
+                    "id": 7280,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6447,
+                    "id": 7281,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6448,
+                    "id": 7282,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6449,
+                    "id": 7283,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14220,25 +14220,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7324,
+                    "id": 8241,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7325,
+                    "id": 8242,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7326,
+                    "id": 8243,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7327,
+                    "id": 8244,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14255,28 +14255,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6450,
+                    "id": 7284,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6451,
+                    "id": 7285,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6452,
+                    "id": 7286,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6453,
+                    "id": 7287,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14310,25 +14310,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7328,
+                    "id": 8245,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7329,
+                    "id": 8246,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7330,
+                    "id": 8247,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7331,
+                    "id": 8248,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14345,21 +14345,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6454,
+                    "id": 7288,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6455,
+                    "id": 7289,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6456,
+                    "id": 7290,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14390,25 +14390,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7332,
+                    "id": 8249,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7333,
+                    "id": 8250,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7334,
+                    "id": 8251,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7335,
+                    "id": 8252,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14425,21 +14425,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6457,
+                    "id": 7291,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6458,
+                    "id": 7292,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6459,
+                    "id": 7293,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14470,25 +14470,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7336,
+                    "id": 8253,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7337,
+                    "id": 8254,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7338,
+                    "id": 8255,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7339,
+                    "id": 8256,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14505,21 +14505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6460,
+                    "id": 7294,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6461,
+                    "id": 7295,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6462,
+                    "id": 7296,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14549,25 +14549,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7340,
+                    "id": 8257,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7341,
+                    "id": 8258,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7342,
+                    "id": 8259,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7343,
+                    "id": 8260,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14584,21 +14584,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6463,
+                    "id": 7297,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6464,
+                    "id": 7298,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6465,
+                    "id": 7299,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14629,25 +14629,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7344,
+                    "id": 8261,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7345,
+                    "id": 8262,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7346,
+                    "id": 8263,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7347,
+                    "id": 8264,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14664,21 +14664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6466,
+                    "id": 7300,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6467,
+                    "id": 7301,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6468,
+                    "id": 7302,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14708,25 +14708,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7348,
+                    "id": 8265,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7349,
+                    "id": 8266,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7350,
+                    "id": 8267,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7351,
+                    "id": 8268,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14743,35 +14743,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6469,
+                    "id": 7303,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6470,
+                    "id": 7304,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6471,
+                    "id": 7305,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6472,
+                    "id": 7306,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6473,
+                    "id": 7307,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14804,31 +14804,31 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7352,
+                    "id": 8269,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7353,
+                    "id": 8270,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7354,
+                    "id": 8271,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7355,
+                    "id": 8272,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7356,
+                    "id": 8273,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "3"
@@ -14845,35 +14845,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6474,
+                    "id": 7308,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6475,
+                    "id": 7309,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6476,
+                    "id": 7310,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6477,
+                    "id": 7311,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6478,
+                    "id": 7312,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14906,25 +14906,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7357,
+                    "id": 8274,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7358,
+                    "id": 8275,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7359,
+                    "id": 8276,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7360,
+                    "id": 8277,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14941,35 +14941,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6479,
+                    "id": 7313,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6480,
+                    "id": 7314,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6481,
+                    "id": 7315,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6482,
+                    "id": 7316,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6483,
+                    "id": 7317,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15001,25 +15001,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7361,
+                    "id": 8278,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7362,
+                    "id": 8279,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7363,
+                    "id": 8280,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7364,
+                    "id": 8281,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15036,35 +15036,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6484,
+                    "id": 7318,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6485,
+                    "id": 7319,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6486,
+                    "id": 7320,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6487,
+                    "id": 7321,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6488,
+                    "id": 7322,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15096,25 +15096,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7365,
+                    "id": 8282,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7366,
+                    "id": 8283,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7367,
+                    "id": 8284,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7368,
+                    "id": 8285,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15131,28 +15131,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6489,
+                    "id": 7323,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6490,
+                    "id": 7324,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6491,
+                    "id": 7325,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6492,
+                    "id": 7326,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 }
@@ -15184,25 +15184,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7369,
+                    "id": 8286,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7370,
+                    "id": 8287,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7371,
+                    "id": 8288,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7372,
+                    "id": 8289,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15219,28 +15219,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6493,
+                    "id": 7327,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6494,
+                    "id": 7328,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6495,
+                    "id": 7329,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6496,
+                    "id": 7330,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15272,25 +15272,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7373,
+                    "id": 8290,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7374,
+                    "id": 8291,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7375,
+                    "id": 8292,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7376,
+                    "id": 8293,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15307,28 +15307,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6497,
+                    "id": 7331,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6498,
+                    "id": 7332,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6499,
+                    "id": 7333,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6500,
+                    "id": 7334,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15360,25 +15360,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7377,
+                    "id": 8294,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7378,
+                    "id": 8295,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7379,
+                    "id": 8296,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7380,
+                    "id": 8297,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15395,28 +15395,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6501,
+                    "id": 7335,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6502,
+                    "id": 7336,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6503,
+                    "id": 7337,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6504,
+                    "id": 7338,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15448,25 +15448,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7381,
+                    "id": 8298,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7382,
+                    "id": 8299,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7383,
+                    "id": 8300,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7384,
+                    "id": 8301,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15483,28 +15483,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6505,
+                    "id": 7339,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6506,
+                    "id": 7340,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6507,
+                    "id": 7341,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6508,
+                    "id": 7342,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15535,25 +15535,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7385,
+                    "id": 8302,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7386,
+                    "id": 8303,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7387,
+                    "id": 8304,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7388,
+                    "id": 8305,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15570,28 +15570,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6509,
+                    "id": 7343,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6510,
+                    "id": 7344,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6511,
+                    "id": 7345,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6512,
+                    "id": 7346,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15621,25 +15621,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7389,
+                    "id": 8306,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7390,
+                    "id": 8307,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7391,
+                    "id": 8308,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7392,
+                    "id": 8309,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15656,28 +15656,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6513,
+                    "id": 7347,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6514,
+                    "id": 7348,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6515,
+                    "id": 7349,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6516,
+                    "id": 7350,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15707,25 +15707,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7393,
+                    "id": 8310,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7394,
+                    "id": 8311,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7395,
+                    "id": 8312,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7396,
+                    "id": 8313,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15742,28 +15742,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6517,
+                    "id": 7351,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6518,
+                    "id": 7352,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6519,
+                    "id": 7353,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6520,
+                    "id": 7354,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15793,25 +15793,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7397,
+                    "id": 8314,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7398,
+                    "id": 8315,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7399,
+                    "id": 8316,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7400,
+                    "id": 8317,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15828,28 +15828,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6521,
+                    "id": 7355,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6522,
+                    "id": 7356,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6523,
+                    "id": 7357,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6524,
+                    "id": 7358,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15879,25 +15879,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7401,
+                    "id": 8318,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7402,
+                    "id": 8319,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7403,
+                    "id": 8320,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7404,
+                    "id": 8321,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15914,28 +15914,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6525,
+                    "id": 7359,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6526,
+                    "id": 7360,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6527,
+                    "id": 7361,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6528,
+                    "id": 7362,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15964,25 +15964,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7405,
+                    "id": 8322,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7406,
+                    "id": 8323,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7407,
+                    "id": 8324,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7408,
+                    "id": 8325,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15999,28 +15999,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6529,
+                    "id": 7363,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6530,
+                    "id": 7364,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6531,
+                    "id": 7365,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6532,
+                    "id": 7366,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16049,25 +16049,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7409,
+                    "id": 8326,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7410,
+                    "id": 8327,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7411,
+                    "id": 8328,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7412,
+                    "id": 8329,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16084,28 +16084,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6533,
+                    "id": 7367,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6534,
+                    "id": 7368,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6535,
+                    "id": 7369,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6536,
+                    "id": 7370,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16135,25 +16135,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7413,
+                    "id": 8330,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7414,
+                    "id": 8331,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7415,
+                    "id": 8332,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7416,
+                    "id": 8333,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16170,28 +16170,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6537,
+                    "id": 7371,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6538,
+                    "id": 7372,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6539,
+                    "id": 7373,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6540,
+                    "id": 7374,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16220,25 +16220,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7417,
+                    "id": 8334,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7418,
+                    "id": 8335,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7419,
+                    "id": 8336,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7420,
+                    "id": 8337,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16255,21 +16255,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6541,
+                    "id": 7375,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6542,
+                    "id": 7376,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6543,
+                    "id": 7377,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16302,25 +16302,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7421,
+                    "id": 8338,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7422,
+                    "id": 8339,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7423,
+                    "id": 8340,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7424,
+                    "id": 8341,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16337,21 +16337,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6544,
+                    "id": 7378,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6545,
+                    "id": 7379,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6546,
+                    "id": 7380,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16384,25 +16384,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7425,
+                    "id": 8342,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7426,
+                    "id": 8343,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7427,
+                    "id": 8344,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7428,
+                    "id": 8345,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16419,21 +16419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6547,
+                    "id": 7381,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6548,
+                    "id": 7382,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6549,
+                    "id": 7383,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16466,25 +16466,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7429,
+                    "id": 8346,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7430,
+                    "id": 8347,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7431,
+                    "id": 8348,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7432,
+                    "id": 8349,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16501,21 +16501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6550,
+                    "id": 7384,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6551,
+                    "id": 7385,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6552,
+                    "id": 7386,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16547,25 +16547,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7433,
+                    "id": 8350,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7434,
+                    "id": 8351,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7435,
+                    "id": 8352,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7436,
+                    "id": 8353,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16582,21 +16582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6553,
+                    "id": 7387,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6554,
+                    "id": 7388,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6555,
+                    "id": 7389,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16629,25 +16629,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7437,
+                    "id": 8354,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7438,
+                    "id": 8355,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7439,
+                    "id": 8356,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7440,
+                    "id": 8357,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16664,21 +16664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6556,
+                    "id": 7390,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6557,
+                    "id": 7391,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6558,
+                    "id": 7392,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16710,25 +16710,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7441,
+                    "id": 8358,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7442,
+                    "id": 8359,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7443,
+                    "id": 8360,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7444,
+                    "id": 8361,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16745,28 +16745,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6559,
+                    "id": 7393,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6560,
+                    "id": 7394,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6561,
+                    "id": 7395,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6562,
+                    "id": 7396,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16801,25 +16801,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7445,
+                    "id": 8362,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7446,
+                    "id": 8363,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7447,
+                    "id": 8364,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7448,
+                    "id": 8365,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16836,28 +16836,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6563,
+                    "id": 7397,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6564,
+                    "id": 7398,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6565,
+                    "id": 7399,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6566,
+                    "id": 7400,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16892,25 +16892,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7449,
+                    "id": 8366,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7450,
+                    "id": 8367,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7451,
+                    "id": 8368,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7452,
+                    "id": 8369,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16927,28 +16927,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6567,
+                    "id": 7401,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6568,
+                    "id": 7402,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6569,
+                    "id": 7403,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6570,
+                    "id": 7404,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16983,25 +16983,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7453,
+                    "id": 8370,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7454,
+                    "id": 8371,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7455,
+                    "id": 8372,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7456,
+                    "id": 8373,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17018,28 +17018,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6571,
+                    "id": 7405,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6572,
+                    "id": 7406,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6573,
+                    "id": 7407,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6574,
+                    "id": 7408,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17074,25 +17074,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7457,
+                    "id": 8374,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7458,
+                    "id": 8375,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7459,
+                    "id": 8376,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7460,
+                    "id": 8377,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17109,21 +17109,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6575,
+                    "id": 7409,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6576,
+                    "id": 7410,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6577,
+                    "id": 7411,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17156,25 +17156,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7461,
+                    "id": 8378,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7462,
+                    "id": 8379,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7463,
+                    "id": 8380,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7464,
+                    "id": 8381,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17191,21 +17191,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6578,
+                    "id": 7412,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6579,
+                    "id": 7413,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6580,
+                    "id": 7414,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17238,25 +17238,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7465,
+                    "id": 8382,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7466,
+                    "id": 8383,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7467,
+                    "id": 8384,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7468,
+                    "id": 8385,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17273,21 +17273,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6581,
+                    "id": 7415,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6582,
+                    "id": 7416,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6583,
+                    "id": 7417,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17319,25 +17319,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7469,
+                    "id": 8386,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7470,
+                    "id": 8387,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7471,
+                    "id": 8388,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7472,
+                    "id": 8389,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17354,21 +17354,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6584,
+                    "id": 7418,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6585,
+                    "id": 7419,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6586,
+                    "id": 7420,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17402,31 +17402,31 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7473,
+                    "id": 8390,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7474,
+                    "id": 8391,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7475,
+                    "id": 8392,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7476,
+                    "id": 8393,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7477,
+                    "id": 8394,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -17443,21 +17443,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6587,
+                    "id": 7421,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6588,
+                    "id": 7422,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6589,
+                    "id": 7423,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17491,25 +17491,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7478,
+                    "id": 8395,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7479,
+                    "id": 8396,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7480,
+                    "id": 8397,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7481,
+                    "id": 8398,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17526,21 +17526,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6590,
+                    "id": 7424,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6591,
+                    "id": 7425,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6592,
+                    "id": 7426,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17573,25 +17573,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7482,
+                    "id": 8399,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7483,
+                    "id": 8400,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7484,
+                    "id": 8401,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7485,
+                    "id": 8402,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17608,28 +17608,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6593,
+                    "id": 7427,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6594,
+                    "id": 7428,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6595,
+                    "id": 7429,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6596,
+                    "id": 7430,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17662,25 +17662,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7486,
+                    "id": 8403,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7487,
+                    "id": 8404,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7488,
+                    "id": 8405,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7489,
+                    "id": 8406,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17697,28 +17697,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6597,
+                    "id": 7431,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6598,
+                    "id": 7432,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6599,
+                    "id": 7433,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6600,
+                    "id": 7434,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17751,31 +17751,31 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7490,
+                    "id": 8407,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7491,
+                    "id": 8408,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7492,
+                    "id": 8409,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7493,
+                    "id": 8410,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7494,
+                    "id": 8411,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -17792,28 +17792,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6601,
+                    "id": 7435,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6602,
+                    "id": 7436,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6603,
+                    "id": 7437,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6604,
+                    "id": 7438,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17846,25 +17846,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7495,
+                    "id": 8412,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7496,
+                    "id": 8413,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7497,
+                    "id": 8414,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7498,
+                    "id": 8415,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17881,21 +17881,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6605,
+                    "id": 7439,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6606,
+                    "id": 7440,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6607,
+                    "id": 7441,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17931,25 +17931,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7499,
+                    "id": 8416,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7500,
+                    "id": 8417,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7501,
+                    "id": 8418,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7502,
+                    "id": 8419,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17966,21 +17966,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6608,
+                    "id": 7442,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6609,
+                    "id": 7443,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6610,
+                    "id": 7444,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18016,31 +18016,31 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7503,
+                    "id": 8420,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7504,
+                    "id": 8421,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7505,
+                    "id": 8422,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7506,
+                    "id": 8423,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7507,
+                    "id": 8424,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -18057,21 +18057,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6611,
+                    "id": 7445,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6612,
+                    "id": 7446,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6613,
+                    "id": 7447,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18107,25 +18107,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7508,
+                    "id": 8425,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7509,
+                    "id": 8426,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7510,
+                    "id": 8427,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7511,
+                    "id": 8428,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18142,21 +18142,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6614,
+                    "id": 7448,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6615,
+                    "id": 7449,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6616,
+                    "id": 7450,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18191,25 +18191,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7512,
+                    "id": 8429,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7513,
+                    "id": 8430,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7514,
+                    "id": 8431,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7515,
+                    "id": 8432,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18226,21 +18226,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6617,
+                    "id": 7451,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6618,
+                    "id": 7452,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6619,
+                    "id": 7453,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18273,31 +18273,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7516,
+                    "id": 8433,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7517,
+                    "id": 8434,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7518,
+                    "id": 8435,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7519,
+                    "id": 8436,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7520,
+                    "id": 8437,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -18314,21 +18314,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6620,
+                    "id": 7454,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6621,
+                    "id": 7455,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6622,
+                    "id": 7456,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18346,7 +18346,7 @@
                 6
             ],
             "card_type_id": 1,
-            "cost": "54",
+            "cost": "56",
             "faction_id": 3,
             "ffg_id": "XW_P_215",
             "force_side": null,
@@ -18356,30 +18356,30 @@
             "is_unique": true,
             "name": "•Manaroo",
             "restrictions": [],
-            "ship_ability_text": null,
+            "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7521,
+                    "id": 8438,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7522,
+                    "id": 8439,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7523,
+                    "id": 8440,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7524,
+                    "id": 8441,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18396,21 +18396,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6623,
+                    "id": 7457,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6624,
+                    "id": 7458,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6625,
+                    "id": 7459,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18443,31 +18443,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7525,
+                    "id": 8442,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7526,
+                    "id": 8443,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7527,
+                    "id": 8444,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7528,
+                    "id": 8445,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7529,
+                    "id": 8446,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -18484,21 +18484,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6626,
+                    "id": 7460,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6627,
+                    "id": 7461,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6628,
+                    "id": 7462,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18530,25 +18530,25 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7530,
+                    "id": 8447,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7531,
+                    "id": 8448,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7532,
+                    "id": 8449,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7533,
+                    "id": 8450,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18565,28 +18565,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6629,
+                    "id": 7463,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6630,
+                    "id": 7464,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6631,
+                    "id": 7465,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6632,
+                    "id": 7466,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18619,31 +18619,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7534,
+                    "id": 8451,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7535,
+                    "id": 8452,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7536,
+                    "id": 8453,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7537,
+                    "id": 8454,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7538,
+                    "id": 8455,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18660,28 +18660,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6633,
+                    "id": 7467,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6634,
+                    "id": 7468,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6635,
+                    "id": 7469,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6636,
+                    "id": 7470,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18714,37 +18714,37 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7539,
+                    "id": 8456,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7540,
+                    "id": 8457,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7541,
+                    "id": 8458,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7542,
+                    "id": 8459,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7543,
+                    "id": 8460,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7544,
+                    "id": 8461,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -18761,28 +18761,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6637,
+                    "id": 7471,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6638,
+                    "id": 7472,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6639,
+                    "id": 7473,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6640,
+                    "id": 7474,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18815,31 +18815,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7545,
+                    "id": 8462,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7546,
+                    "id": 8463,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7547,
+                    "id": 8464,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7548,
+                    "id": 8465,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7549,
+                    "id": 8466,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18856,28 +18856,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6641,
+                    "id": 7475,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6642,
+                    "id": 7476,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6643,
+                    "id": 7477,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6644,
+                    "id": 7478,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18909,31 +18909,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7550,
+                    "id": 8467,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7551,
+                    "id": 8468,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7552,
+                    "id": 8469,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7553,
+                    "id": 8470,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7554,
+                    "id": 8471,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18950,28 +18950,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6645,
+                    "id": 7479,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6646,
+                    "id": 7480,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6647,
+                    "id": 7481,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6648,
+                    "id": 7482,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19006,25 +19006,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7555,
+                    "id": 8472,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7556,
+                    "id": 8473,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7557,
+                    "id": 8474,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7558,
+                    "id": 8475,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19041,28 +19041,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6649,
+                    "id": 7483,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6650,
+                    "id": 7484,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6651,
+                    "id": 7485,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6652,
+                    "id": 7486,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19097,25 +19097,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7559,
+                    "id": 8476,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7560,
+                    "id": 8477,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7561,
+                    "id": 8478,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7562,
+                    "id": 8479,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19132,28 +19132,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6653,
+                    "id": 7487,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6654,
+                    "id": 7488,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6655,
+                    "id": 7489,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6656,
+                    "id": 7490,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19187,25 +19187,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7563,
+                    "id": 8480,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7564,
+                    "id": 8481,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7565,
+                    "id": 8482,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7566,
+                    "id": 8483,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19222,28 +19222,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 7491,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 7492,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 7493,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 7494,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19277,25 +19277,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 8484,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 8485,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 8486,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 8487,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19312,21 +19312,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6661,
+                    "id": 7495,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6662,
+                    "id": 7496,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6663,
+                    "id": 7497,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19356,25 +19356,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7571,
+                    "id": 8488,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7572,
+                    "id": 8489,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7573,
+                    "id": 8490,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7574,
+                    "id": 8491,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19391,21 +19391,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6664,
+                    "id": 7498,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6665,
+                    "id": 7499,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6666,
+                    "id": 7500,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19435,25 +19435,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7575,
+                    "id": 8492,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7576,
+                    "id": 8493,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7577,
+                    "id": 8494,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7578,
+                    "id": 8495,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19470,21 +19470,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6667,
+                    "id": 7501,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6668,
+                    "id": 7502,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6669,
+                    "id": 7503,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19514,25 +19514,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 8496,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7580,
+                    "id": 8497,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7581,
+                    "id": 8498,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7582,
+                    "id": 8499,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19549,21 +19549,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6670,
+                    "id": 7504,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6671,
+                    "id": 7505,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6672,
+                    "id": 7506,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19589,31 +19589,31 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7583,
+                    "id": 8500,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7584,
+                    "id": 8501,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7585,
+                    "id": 8502,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7586,
+                    "id": 8503,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7587,
+                    "id": 8504,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "3"
@@ -20685,7 +20685,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
@@ -20724,7 +20724,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, fügen alle <hit>/<crit>-Ergebnisse Störsignalmarker anstatt Schaden zu.",
@@ -20763,7 +20763,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, fügen alle <hit>/<crit>-Ergebnisse Fangstrahlmarker anstatt Schaden zu.",
@@ -20802,7 +20802,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff</smallcaps>",
@@ -20849,7 +20849,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Angriff:</smallcaps> Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
@@ -20897,7 +20897,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Ändere 1<nonbreak><hit>-Ergebnis in ein<nonbreak><crit>-Ergebnis.",
@@ -20989,7 +20989,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Ändere 1<nonbreak><hit>-Ergebnis in ein <crit>-Ergebnis.",
@@ -21036,7 +21036,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><focus><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge><nonbreak>aus. Falls der Verteidiger in deinem <bullseye> ist, darfst du 1 oder mehrere <standardcharge> ausgeben, um ebenso viele Angriffswürfel neu zu werfen.",
@@ -21080,7 +21080,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Nach diesem Angriff darfst du diesen Angriff als Bonusangriff gegen ein anderes Ziel in Reichweite 0–1 des Verteidigers durchführen, wobei du die <targetlock>-Voraussetzung ignorierst.",
@@ -21126,7 +21126,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge>aus. Nachdem dieser Angriff getroffen hat, legt jedes Schiff in Reichweite 0–1 zum Verteidiger 1 seiner Schadenskarten offen.",
@@ -21172,7 +21172,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Nachdem du den Verteidiger deklariert hast, darf der Verteidiger wählen, 1<nonbreak><hit>-Schaden zu erleiden. Falls er das tut, überspringe die Schritte „Angriffswürfel“ und „Verteidigungswürfel“, und der Angriff wird behandelt, als hätte er getroffen.",
@@ -21217,7 +21217,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><targetlock><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge> aus. Falls dieser Angriff trifft, gib 1<nonbreak><hit>- oder <crit>-Ergebnis aus, um den Verteidiger 1<nonbreak><hit>-Schaden erleiden zu lassen. Alle übrigen <hit>/<crit>-Ergebnisse fügen Ionenmarker anstatt Schaden zu.",
@@ -21262,7 +21262,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Angriff (</smallcaps><focus><smallcaps>):</smallcaps> Gib 1<nonbreak><standardcharge><nonbreak>aus.",
@@ -21307,7 +21307,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "Solange du verteidigst, bevor die Angriffswürfel geworfen werden, darfstdu eine Zielerfassung, die du auf dem Angreifer hast, ausgeben, um 1<nonbreak>Angriffswürfel zu werfen. Falls du das tust, erhält der Angreifer 1<nonbreak>Störsignalmarker. Dann, bei einem <hit>- oder <crit>-Ergebnis, erhältst du 1<nonbreak>Störsignalmarker.",

--- a/translation_helper/api_export_en.json
+++ b/translation_helper/api_export_en.json
@@ -6,21 +6,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 6673,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 6674,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 6675,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -46,32 +46,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Wedge Antilles",
+            "name": "•Wedge Antilles",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 7588,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 7589,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 7590,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 7591,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -88,21 +88,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5842,
+                    "id": 6676,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5843,
+                    "id": 6677,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5844,
+                    "id": 6678,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -127,38 +127,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Luke Skywalker",
+            "name": "•Luke Skywalker",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6675,
+                    "id": 7592,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6676,
+                    "id": 7593,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6677,
+                    "id": 7594,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6678,
+                    "id": 7595,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 6679,
+                    "id": 7596,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -175,21 +175,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 6679,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 6680,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 6681,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -214,32 +214,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Thane Kyrell",
+            "name": "•Thane Kyrell",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 7597,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 7598,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 7599,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 7600,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -256,21 +256,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5848,
+                    "id": 6682,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5849,
+                    "id": 6683,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5850,
+                    "id": 6684,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -296,32 +296,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Garven Dreis",
+            "name": "•Garven Dreis",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6684,
+                    "id": 7601,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6685,
+                    "id": 7602,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6686,
+                    "id": 7603,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6687,
+                    "id": 7604,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -338,21 +338,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5851,
+                    "id": 6685,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5852,
+                    "id": 6686,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5853,
+                    "id": 6687,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -377,32 +377,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Jek Porkins",
+            "name": "•Jek Porkins",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6688,
+                    "id": 7605,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6689,
+                    "id": 7606,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6690,
+                    "id": 7607,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6691,
+                    "id": 7608,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -419,21 +419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5854,
+                    "id": 6688,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5855,
+                    "id": 6689,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5856,
+                    "id": 6690,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -459,32 +459,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Kullbee Sperado",
+            "name": "•Kullbee Sperado",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6692,
+                    "id": 7609,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6693,
+                    "id": 7610,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6694,
+                    "id": 7611,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6695,
+                    "id": 7612,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -501,21 +501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5857,
+                    "id": 6691,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5858,
+                    "id": 6692,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5859,
+                    "id": 6693,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -540,32 +540,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Biggs Darklighter",
+            "name": "•Biggs Darklighter",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6696,
+                    "id": 7613,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6697,
+                    "id": 7614,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6698,
+                    "id": 7615,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6699,
+                    "id": 7616,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -582,21 +582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 6694,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 6695,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 6696,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -622,32 +622,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Leevan Tenza",
+            "name": "•Leevan Tenza",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 7617,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6701,
+                    "id": 7618,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 7619,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6703,
+                    "id": 7620,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -664,21 +664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5863,
+                    "id": 6697,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5864,
+                    "id": 6698,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5865,
+                    "id": 6699,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -703,32 +703,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Edrio Two Tubes",
+            "name": "•Edrio Two Tubes",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6704,
+                    "id": 7621,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6705,
+                    "id": 7622,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6706,
+                    "id": 7623,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6707,
+                    "id": 7624,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -745,21 +745,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5866,
+                    "id": 6700,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5867,
+                    "id": 6701,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5868,
+                    "id": 6702,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -793,25 +793,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6708,
+                    "id": 7625,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6709,
+                    "id": 7626,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6710,
+                    "id": 7627,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6711,
+                    "id": 7628,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -828,21 +828,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5869,
+                    "id": 6703,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5870,
+                    "id": 6704,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5871,
+                    "id": 6705,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -875,25 +875,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6712,
+                    "id": 7629,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6713,
+                    "id": 7630,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6714,
+                    "id": 7631,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6715,
+                    "id": 7632,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -910,21 +910,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5872,
+                    "id": 6706,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5873,
+                    "id": 6707,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5874,
+                    "id": 6708,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -956,25 +956,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6716,
+                    "id": 7633,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6717,
+                    "id": 7634,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6718,
+                    "id": 7635,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6719,
+                    "id": 7636,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -991,28 +991,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5875,
+                    "id": 6709,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5876,
+                    "id": 6710,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5877,
+                    "id": 6711,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5878,
+                    "id": 6712,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1039,32 +1039,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_13.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Norra Wexley",
+            "name": "•Norra Wexley",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6720,
+                    "id": 7637,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6721,
+                    "id": 7638,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6722,
+                    "id": 7639,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6723,
+                    "id": 7640,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1081,28 +1081,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5879,
+                    "id": 6713,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5880,
+                    "id": 6714,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5881,
+                    "id": 6715,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5882,
+                    "id": 6716,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1130,32 +1130,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_14.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "“Dutch” Vander",
+            "name": "•“Dutch” Vander",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6724,
+                    "id": 7641,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6725,
+                    "id": 7642,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6726,
+                    "id": 7643,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6727,
+                    "id": 7644,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1172,28 +1172,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5883,
+                    "id": 6717,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5884,
+                    "id": 6718,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5885,
+                    "id": 6719,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5886,
+                    "id": 6720,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1221,32 +1221,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Horton Salm",
+            "name": "•Horton Salm",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6728,
+                    "id": 7645,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6729,
+                    "id": 7646,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6730,
+                    "id": 7647,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6731,
+                    "id": 7648,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1263,28 +1263,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 6721,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 6722,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 6723,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 6724,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1311,32 +1311,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Evaan Verlaine",
+            "name": "•Evaan Verlaine",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 7649,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 7650,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 7651,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 7652,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1353,28 +1353,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5891,
+                    "id": 6725,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5892,
+                    "id": 6726,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5893,
+                    "id": 6727,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5894,
+                    "id": 6728,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1409,25 +1409,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6736,
+                    "id": 7653,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6737,
+                    "id": 7654,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6738,
+                    "id": 7655,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6739,
+                    "id": 7656,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1444,28 +1444,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 6729,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 6730,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "id": 6731,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "id": 6732,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1499,25 +1499,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 7657,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 7658,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6742,
+                    "id": 7659,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6743,
+                    "id": 7660,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1534,35 +1534,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5899,
+                    "id": 6733,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5900,
+                    "id": 6734,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5901,
+                    "id": 6735,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5902,
+                    "id": 6736,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5903,
+                    "id": 6737,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1584,32 +1584,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_19.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Jake Farrell",
+            "name": "•Jake Farrell",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6744,
+                    "id": 7661,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6745,
+                    "id": 7662,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6746,
+                    "id": 7663,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6747,
+                    "id": 7664,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1626,35 +1626,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
+                    "id": 6738,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5905,
+                    "id": 6739,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 6740,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
+                    "id": 6741,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 6742,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1676,32 +1676,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Arvel Crynyd",
+            "name": "•Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 7665,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 7666,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6750,
+                    "id": 7667,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 7668,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1718,35 +1718,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5909,
+                    "id": 6743,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5910,
+                    "id": 6744,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5911,
+                    "id": 6745,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5912,
+                    "id": 6746,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5913,
+                    "id": 6747,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1775,25 +1775,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6752,
+                    "id": 7669,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6753,
+                    "id": 7670,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6754,
+                    "id": 7671,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6755,
+                    "id": 7672,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1810,35 +1810,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5914,
+                    "id": 6748,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5915,
+                    "id": 6749,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5916,
+                    "id": 6750,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5917,
+                    "id": 6751,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5918,
+                    "id": 6752,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1866,25 +1866,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6756,
+                    "id": 7673,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6757,
+                    "id": 7674,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6758,
+                    "id": 7675,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6759,
+                    "id": 7676,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1901,21 +1901,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5919,
+                    "id": 6753,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5920,
+                    "id": 6754,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5921,
+                    "id": 6755,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1941,32 +1941,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Braylen Stramm",
+            "name": "•Braylen Stramm",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6760,
+                    "id": 7677,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6761,
+                    "id": 7678,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6762,
+                    "id": 7679,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6763,
+                    "id": 7680,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -1983,21 +1983,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5922,
+                    "id": 6756,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5923,
+                    "id": 6757,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5924,
+                    "id": 6758,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2023,32 +2023,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Ten Numb",
+            "name": "•Ten Numb",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6764,
+                    "id": 7681,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6765,
+                    "id": 7682,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6766,
+                    "id": 7683,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6767,
+                    "id": 7684,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2065,21 +2065,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5925,
+                    "id": 6759,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5926,
+                    "id": 6760,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5927,
+                    "id": 6761,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2112,25 +2112,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6768,
+                    "id": 7685,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6769,
+                    "id": 7686,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6770,
+                    "id": 7687,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6771,
+                    "id": 7688,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2147,21 +2147,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5928,
+                    "id": 6762,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5929,
+                    "id": 6763,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5930,
+                    "id": 6764,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2193,25 +2193,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6772,
+                    "id": 7689,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6773,
+                    "id": 7690,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6774,
+                    "id": 7691,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6775,
+                    "id": 7692,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2228,21 +2228,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5931,
+                    "id": 6765,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5932,
+                    "id": 6766,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5933,
+                    "id": 6767,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2265,32 +2265,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Airen Cracken",
+            "name": "•Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6776,
+                    "id": 7693,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6777,
+                    "id": 7694,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6778,
+                    "id": 7695,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6779,
+                    "id": 7696,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2307,21 +2307,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5934,
+                    "id": 6768,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5935,
+                    "id": 6769,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5936,
+                    "id": 6770,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2344,32 +2344,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Lieutenant Blount",
+            "name": "•Lieutenant Blount",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6780,
+                    "id": 7697,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6781,
+                    "id": 7698,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6782,
+                    "id": 7699,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6783,
+                    "id": 7700,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2386,21 +2386,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5937,
+                    "id": 6771,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5938,
+                    "id": 6772,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5939,
+                    "id": 6773,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2430,25 +2430,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6784,
+                    "id": 7701,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6785,
+                    "id": 7702,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6786,
+                    "id": 7703,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6787,
+                    "id": 7704,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2465,21 +2465,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5940,
+                    "id": 6774,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5941,
+                    "id": 6775,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5942,
+                    "id": 6776,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2508,25 +2508,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6788,
+                    "id": 7705,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6789,
+                    "id": 7706,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6790,
+                    "id": 7707,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6791,
+                    "id": 7708,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2543,21 +2543,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5943,
+                    "id": 6777,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5944,
+                    "id": 6778,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5945,
+                    "id": 6779,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2581,32 +2581,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Wullffwarro",
+            "name": "•Wullffwarro",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6792,
+                    "id": 7709,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6793,
+                    "id": 7710,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6794,
+                    "id": 7711,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6795,
+                    "id": 7712,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2623,21 +2623,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5946,
+                    "id": 6780,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5947,
+                    "id": 6781,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5948,
+                    "id": 6782,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2661,32 +2661,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Lowhhrick",
+            "name": "•Lowhhrick",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6796,
+                    "id": 7713,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6797,
+                    "id": 7714,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6798,
+                    "id": 7715,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6799,
+                    "id": 7716,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2703,21 +2703,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5949,
+                    "id": 6783,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5950,
+                    "id": 6784,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5951,
+                    "id": 6785,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2747,25 +2747,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6800,
+                    "id": 7717,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6801,
+                    "id": 7718,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6802,
+                    "id": 7719,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6803,
+                    "id": 7720,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2782,21 +2782,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5952,
+                    "id": 6786,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5953,
+                    "id": 6787,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5954,
+                    "id": 6788,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2821,32 +2821,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Hera Syndulla",
+            "name": "•Hera Syndulla",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6804,
+                    "id": 7721,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6805,
+                    "id": 7722,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6806,
+                    "id": 7723,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6807,
+                    "id": 7724,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2863,21 +2863,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5955,
+                    "id": 6789,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5956,
+                    "id": 6790,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5957,
+                    "id": 6791,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2902,32 +2902,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Sabine Wren",
+            "name": "•Sabine Wren",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6808,
+                    "id": 7725,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6809,
+                    "id": 7726,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6810,
+                    "id": 7727,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6811,
+                    "id": 7728,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2944,21 +2944,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5958,
+                    "id": 6792,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5959,
+                    "id": 6793,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5960,
+                    "id": 6794,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2983,38 +2983,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Ezra Bridger",
+            "name": "•Ezra Bridger",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6812,
+                    "id": 7729,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6813,
+                    "id": 7730,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6814,
+                    "id": 7731,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6815,
+                    "id": 7732,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6816,
+                    "id": 7733,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3031,21 +3031,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5961,
+                    "id": 6795,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5962,
+                    "id": 6796,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5963,
+                    "id": 6797,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -3069,32 +3069,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Zeb” Orrelios",
+            "name": "•“Zeb” Orrelios",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6817,
+                    "id": 7734,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6818,
+                    "id": 7735,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6819,
+                    "id": 7736,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6820,
+                    "id": 7737,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3111,14 +3111,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5964,
+                    "id": 6798,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5965,
+                    "id": 6799,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3143,38 +3143,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Fenn Rau",
+            "name": "•Fenn Rau",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6821,
+                    "id": 7738,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6822,
+                    "id": 7739,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6823,
+                    "id": 7740,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6824,
+                    "id": 7741,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6825,
+                    "id": 7742,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3191,14 +3191,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5966,
+                    "id": 6800,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5967,
+                    "id": 6801,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3223,44 +3223,44 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Ezra Bridger",
+            "name": "•Ezra Bridger",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6826,
+                    "id": 7743,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6827,
+                    "id": 7744,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6828,
+                    "id": 7745,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6829,
+                    "id": 7746,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6830,
+                    "id": 7747,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6831,
+                    "id": 7748,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3277,14 +3277,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5968,
+                    "id": 6802,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5969,
+                    "id": 6803,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3309,38 +3309,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Zeb” Orrelios",
+            "name": "•“Zeb” Orrelios",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6832,
+                    "id": 7749,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6833,
+                    "id": 7750,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6834,
+                    "id": 7751,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6835,
+                    "id": 7752,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6836,
+                    "id": 7753,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3357,14 +3357,14 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 5970,
+                    "id": 6804,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5971,
+                    "id": 6805,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3389,38 +3389,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
             "initiative": 1,
             "is_unique": true,
-            "name": "AP-5",
+            "name": "•AP-5",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6837,
+                    "id": 7754,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6838,
+                    "id": 7755,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6839,
+                    "id": 7756,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6840,
+                    "id": 7757,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6841,
+                    "id": 7758,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3437,35 +3437,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5972,
+                    "id": 6806,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5973,
+                    "id": 6807,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5974,
+                    "id": 6808,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5975,
+                    "id": 6809,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5976,
+                    "id": 6810,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3491,32 +3491,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Jan Ors",
+            "name": "•Jan Ors",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6842,
+                    "id": 7759,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6843,
+                    "id": 7760,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6844,
+                    "id": 7761,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6845,
+                    "id": 7762,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3533,35 +3533,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5977,
+                    "id": 6811,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5978,
+                    "id": 6812,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5979,
+                    "id": 6813,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5980,
+                    "id": 6814,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5981,
+                    "id": 6815,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3587,32 +3587,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Kyle Katarn",
+            "name": "•Kyle Katarn",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6846,
+                    "id": 7763,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6847,
+                    "id": 7764,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6848,
+                    "id": 7765,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6849,
+                    "id": 7766,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3629,35 +3629,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5982,
+                    "id": 6816,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5983,
+                    "id": 6817,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5984,
+                    "id": 6818,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5985,
+                    "id": 6819,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5986,
+                    "id": 6820,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3683,32 +3683,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Roark Garnet",
+            "name": "•Roark Garnet",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6850,
+                    "id": 7767,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6851,
+                    "id": 7768,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6852,
+                    "id": 7769,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6853,
+                    "id": 7770,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3725,35 +3725,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5987,
+                    "id": 6821,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5988,
+                    "id": 6822,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5989,
+                    "id": 6823,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5990,
+                    "id": 6824,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5991,
+                    "id": 6825,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3785,25 +3785,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6854,
+                    "id": 7771,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6855,
+                    "id": 7772,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6856,
+                    "id": 7773,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6857,
+                    "id": 7774,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3820,21 +3820,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5992,
+                    "id": 6826,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5993,
+                    "id": 6827,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5994,
+                    "id": 6828,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3856,32 +3856,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Ezra Bridger",
+            "name": "•Ezra Bridger",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6858,
+                    "id": 7775,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6859,
+                    "id": 7776,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6860,
+                    "id": 7777,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6861,
+                    "id": 7778,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3898,21 +3898,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5995,
+                    "id": 6829,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5996,
+                    "id": 6830,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5997,
+                    "id": 6831,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3934,26 +3934,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Sabine Wren",
+            "name": "•Sabine Wren",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6862,
+                    "id": 7779,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6863,
+                    "id": 7780,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6864,
+                    "id": 7781,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -3970,21 +3970,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5998,
+                    "id": 6832,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5999,
+                    "id": 6833,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6000,
+                    "id": 6834,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4005,26 +4005,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Captain Rex",
+            "name": "•Captain Rex",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6865,
+                    "id": 7782,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6866,
+                    "id": 7783,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6867,
+                    "id": 7784,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4041,21 +4041,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6001,
+                    "id": 6835,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6002,
+                    "id": 6836,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6003,
+                    "id": 6837,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4076,26 +4076,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Zeb” Orrelios",
+            "name": "•“Zeb” Orrelios",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6868,
+                    "id": 7785,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6869,
+                    "id": 7786,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6870,
+                    "id": 7787,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4112,35 +4112,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6004,
+                    "id": 6838,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6005,
+                    "id": 6839,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6006,
+                    "id": 6840,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6007,
+                    "id": 6841,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6008,
+                    "id": 6842,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4165,32 +4165,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Corran Horn",
+            "name": "•Corran Horn",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6871,
+                    "id": 7788,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6872,
+                    "id": 7789,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6873,
+                    "id": 7790,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6874,
+                    "id": 7791,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4207,35 +4207,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6009,
+                    "id": 6843,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6010,
+                    "id": 6844,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6011,
+                    "id": 6845,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6012,
+                    "id": 6846,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6013,
+                    "id": 6847,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4260,32 +4260,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Gavin Darklighter",
+            "name": "•Gavin Darklighter",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6875,
+                    "id": 7792,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6876,
+                    "id": 7793,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6877,
+                    "id": 7794,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6878,
+                    "id": 7795,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4302,35 +4302,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6014,
+                    "id": 6848,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6015,
+                    "id": 6849,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6016,
+                    "id": 6850,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6017,
+                    "id": 6851,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6018,
+                    "id": 6852,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4362,25 +4362,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6879,
+                    "id": 7796,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6880,
+                    "id": 7797,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6881,
+                    "id": 7798,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6882,
+                    "id": 7799,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4397,35 +4397,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6019,
+                    "id": 6853,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6020,
+                    "id": 6854,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6021,
+                    "id": 6855,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6022,
+                    "id": 6856,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6023,
+                    "id": 6857,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4456,25 +4456,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6883,
+                    "id": 7800,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6884,
+                    "id": 7801,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6885,
+                    "id": 7802,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6886,
+                    "id": 7803,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4491,21 +4491,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6024,
+                    "id": 6858,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6025,
+                    "id": 6859,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6026,
+                    "id": 6860,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4531,32 +4531,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Bodhi Rook",
+            "name": "•Bodhi Rook",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6887,
+                    "id": 7804,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6888,
+                    "id": 7805,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6889,
+                    "id": 7806,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6890,
+                    "id": 7807,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4573,21 +4573,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6861,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6862,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "id": 6863,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4614,32 +4614,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Saw Gerrera",
+            "name": "•Saw Gerrera",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6891,
+                    "id": 7808,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6892,
+                    "id": 7809,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6893,
+                    "id": 7810,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6894,
+                    "id": 7811,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4656,21 +4656,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6030,
+                    "id": 6864,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6031,
+                    "id": 6865,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6032,
+                    "id": 6866,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4696,32 +4696,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Cassian Andor",
+            "name": "•Cassian Andor",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6895,
+                    "id": 7812,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6896,
+                    "id": 7813,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6897,
+                    "id": 7814,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6898,
+                    "id": 7815,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4738,21 +4738,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6033,
+                    "id": 6867,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6034,
+                    "id": 6868,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6035,
+                    "id": 6869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4779,32 +4779,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Magva Yarro",
+            "name": "•Magva Yarro",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6899,
+                    "id": 7816,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6900,
+                    "id": 7817,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6901,
+                    "id": 7818,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6902,
+                    "id": 7819,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4821,21 +4821,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6036,
+                    "id": 6870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6037,
+                    "id": 6871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6038,
+                    "id": 6872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4861,32 +4861,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Benthic Two Tubes",
+            "name": "•Benthic Two Tubes",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6903,
+                    "id": 7820,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6904,
+                    "id": 7821,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6905,
+                    "id": 7822,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6906,
+                    "id": 7823,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4903,21 +4903,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6039,
+                    "id": 6873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6040,
+                    "id": 6874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6041,
+                    "id": 6875,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4943,32 +4943,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Heff Tobber",
+            "name": "•Heff Tobber",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6907,
+                    "id": 7824,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6908,
+                    "id": 7825,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6909,
+                    "id": 7826,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6910,
+                    "id": 7827,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4985,21 +4985,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6042,
+                    "id": 6876,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6043,
+                    "id": 6877,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6044,
+                    "id": 6878,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5031,25 +5031,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6911,
+                    "id": 7828,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6912,
+                    "id": 7829,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6913,
+                    "id": 7830,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6914,
+                    "id": 7831,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5066,21 +5066,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6045,
+                    "id": 6879,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6046,
+                    "id": 6880,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6047,
+                    "id": 6881,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5113,25 +5113,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6915,
+                    "id": 7832,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6916,
+                    "id": 7833,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6917,
+                    "id": 7834,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6918,
+                    "id": 7835,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5148,35 +5148,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6048,
+                    "id": 6882,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6049,
+                    "id": 6883,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6050,
+                    "id": 6884,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6051,
+                    "id": 6885,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6052,
+                    "id": 6886,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5204,32 +5204,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Miranda Doni",
+            "name": "•Miranda Doni",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6919,
+                    "id": 7836,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6920,
+                    "id": 7837,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6921,
+                    "id": 7838,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6922,
+                    "id": 7839,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5246,35 +5246,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6053,
+                    "id": 6887,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6054,
+                    "id": 6888,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6055,
+                    "id": 6889,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6056,
+                    "id": 6890,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6057,
+                    "id": 6891,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5302,32 +5302,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Esege Tuketu",
+            "name": "•Esege Tuketu",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6923,
+                    "id": 7840,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6924,
+                    "id": 7841,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6925,
+                    "id": 7842,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6926,
+                    "id": 7843,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5344,35 +5344,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6058,
+                    "id": 6892,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6059,
+                    "id": 6893,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6060,
+                    "id": 6894,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6061,
+                    "id": 6895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6062,
+                    "id": 6896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5407,25 +5407,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6927,
+                    "id": 7844,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6928,
+                    "id": 7845,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6929,
+                    "id": 7846,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6930,
+                    "id": 7847,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5442,21 +5442,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6063,
+                    "id": 6897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6064,
+                    "id": 6898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6065,
+                    "id": 6899,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5482,38 +5482,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Norra Wexley",
+            "name": "•Norra Wexley",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6931,
+                    "id": 7848,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6932,
+                    "id": 7849,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6933,
+                    "id": 7850,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6934,
+                    "id": 7851,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6935,
+                    "id": 7852,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5530,21 +5530,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6066,
+                    "id": 6900,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6067,
+                    "id": 6901,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6068,
+                    "id": 6902,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5570,38 +5570,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Garven Dreis",
+            "name": "•Garven Dreis",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6936,
+                    "id": 7853,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6937,
+                    "id": 7854,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6938,
+                    "id": 7855,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6939,
+                    "id": 7856,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6940,
+                    "id": 7857,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5618,21 +5618,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6069,
+                    "id": 6903,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6070,
+                    "id": 6904,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6071,
+                    "id": 6905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5658,38 +5658,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Shara Bey",
+            "name": "•Shara Bey",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6941,
+                    "id": 7858,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6942,
+                    "id": 7859,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6943,
+                    "id": 7860,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6944,
+                    "id": 7861,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6945,
+                    "id": 7862,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5706,21 +5706,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6072,
+                    "id": 6906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6073,
+                    "id": 6907,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6074,
+                    "id": 6908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5746,38 +5746,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Ibtisam",
+            "name": "•Ibtisam",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6946,
+                    "id": 7863,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6947,
+                    "id": 7864,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6948,
+                    "id": 7865,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6949,
+                    "id": 7866,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6950,
+                    "id": 7867,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5794,28 +5794,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6075,
+                    "id": 6909,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6076,
+                    "id": 6910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6077,
+                    "id": 6911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6078,
+                    "id": 6912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5843,32 +5843,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Han Solo",
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6951,
+                    "id": 7868,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6952,
+                    "id": 7869,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6953,
+                    "id": 7870,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6954,
+                    "id": 7871,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5885,28 +5885,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6079,
+                    "id": 6913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6080,
+                    "id": 6914,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6081,
+                    "id": 6915,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6082,
+                    "id": 6916,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5934,32 +5934,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_70.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Lando Calrissian",
+            "name": "•Lando Calrissian",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6955,
+                    "id": 7872,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6956,
+                    "id": 7873,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6957,
+                    "id": 7874,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6958,
+                    "id": 7875,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5976,28 +5976,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6083,
+                    "id": 6917,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6084,
+                    "id": 6918,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6085,
+                    "id": 6919,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6086,
+                    "id": 6920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6025,38 +6025,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Chewbacca",
+            "name": "•Chewbacca",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6959,
+                    "id": 7876,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6960,
+                    "id": 7877,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6961,
+                    "id": 7878,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6962,
+                    "id": 7879,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
                 },
                 {
-                    "id": 6963,
+                    "id": 7880,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -6073,28 +6073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6087,
+                    "id": 6921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6088,
+                    "id": 6922,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6089,
+                    "id": 6923,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6090,
+                    "id": 6924,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6128,25 +6128,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6964,
+                    "id": 7881,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6965,
+                    "id": 7882,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6966,
+                    "id": 7883,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6967,
+                    "id": 7884,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -6163,21 +6163,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6091,
+                    "id": 6925,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6092,
+                    "id": 6926,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6093,
+                    "id": 6927,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6205,32 +6205,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Hera Syndulla",
+            "name": "•Hera Syndulla",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6968,
+                    "id": 7885,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6969,
+                    "id": 7886,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6970,
+                    "id": 7887,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6971,
+                    "id": 7888,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6247,21 +6247,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6094,
+                    "id": 6928,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6095,
+                    "id": 6929,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6096,
+                    "id": 6930,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6289,38 +6289,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Kanan Jarrus",
+            "name": "•Kanan Jarrus",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6972,
+                    "id": 7889,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6973,
+                    "id": 7890,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6974,
+                    "id": 7891,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6975,
+                    "id": 7892,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 6976,
+                    "id": 7893,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -6337,21 +6337,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6097,
+                    "id": 6931,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6098,
+                    "id": 6932,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6099,
+                    "id": 6933,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6378,32 +6378,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Chopper”",
+            "name": "•“Chopper”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6977,
+                    "id": 7894,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6978,
+                    "id": 7895,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6979,
+                    "id": 7896,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6980,
+                    "id": 7897,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6420,21 +6420,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6100,
+                    "id": 6934,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6101,
+                    "id": 6935,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6102,
+                    "id": 6936,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6468,25 +6468,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6981,
+                    "id": 7898,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6982,
+                    "id": 7899,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6983,
+                    "id": 7900,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6984,
+                    "id": 7901,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6503,28 +6503,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6103,
+                    "id": 6937,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6104,
+                    "id": 6938,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6105,
+                    "id": 6939,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6106,
+                    "id": 6940,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6551,32 +6551,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_77.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Dash Rendar",
+            "name": "•Dash Rendar",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6985,
+                    "id": 7902,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6986,
+                    "id": 7903,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6987,
+                    "id": 7904,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6988,
+                    "id": 7905,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6593,28 +6593,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6107,
+                    "id": 6941,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6108,
+                    "id": 6942,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6109,
+                    "id": 6943,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6110,
+                    "id": 6944,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6640,32 +6640,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_78.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "“Leebo”",
+            "name": "•“Leebo”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6989,
+                    "id": 7906,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6990,
+                    "id": 7907,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6991,
+                    "id": 7908,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6992,
+                    "id": 7909,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6682,28 +6682,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6111,
+                    "id": 6945,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6112,
+                    "id": 6946,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6113,
+                    "id": 6947,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6114,
+                    "id": 6948,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6736,25 +6736,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6993,
+                    "id": 7910,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6994,
+                    "id": 7911,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6995,
+                    "id": 7912,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6996,
+                    "id": 7913,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6771,21 +6771,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6115,
+                    "id": 6949,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6116,
+                    "id": 6950,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6117,
+                    "id": 6951,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6808,26 +6808,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_80.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "“Mauler” Mithel",
+            "name": "•“Mauler” Mithel",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6997,
+                    "id": 7914,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6998,
+                    "id": 7915,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6999,
+                    "id": 7916,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6844,21 +6844,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6118,
+                    "id": 6952,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6119,
+                    "id": 6953,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6120,
+                    "id": 6954,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6881,26 +6881,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_81.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "“Howlrunner”",
+            "name": "•“Howlrunner”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7000,
+                    "id": 7917,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7001,
+                    "id": 7918,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7002,
+                    "id": 7919,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6917,21 +6917,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6121,
+                    "id": 6955,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6122,
+                    "id": 6956,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6123,
+                    "id": 6957,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6954,26 +6954,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_82.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "“Scourge” Skutu",
+            "name": "•“Scourge” Skutu",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7003,
+                    "id": 7920,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7004,
+                    "id": 7921,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7005,
+                    "id": 7922,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6990,21 +6990,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6124,
+                    "id": 6958,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6125,
+                    "id": 6959,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6126,
+                    "id": 6960,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7026,32 +7026,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_83.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Iden Versio",
+            "name": "•Iden Versio",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7006,
+                    "id": 7923,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7007,
+                    "id": 7924,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7008,
+                    "id": 7925,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7009,
+                    "id": 7926,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -7068,21 +7068,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6127,
+                    "id": 6961,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6128,
+                    "id": 6962,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6129,
+                    "id": 6963,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7104,26 +7104,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_84.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Gideon Hask",
+            "name": "•Gideon Hask",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7010,
+                    "id": 7927,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7011,
+                    "id": 7928,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7012,
+                    "id": 7929,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7140,21 +7140,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6130,
+                    "id": 6964,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6131,
+                    "id": 6965,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6132,
+                    "id": 6966,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7176,26 +7176,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_85.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Del Meeko",
+            "name": "•Del Meeko",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7013,
+                    "id": 7930,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7014,
+                    "id": 7931,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7015,
+                    "id": 7932,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7212,21 +7212,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6133,
+                    "id": 6967,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6134,
+                    "id": 6968,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6135,
+                    "id": 6969,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7248,26 +7248,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_86.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Seyn Marana",
+            "name": "•Seyn Marana",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7016,
+                    "id": 7933,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7017,
+                    "id": 7934,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7018,
+                    "id": 7935,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7284,21 +7284,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6136,
+                    "id": 6970,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6137,
+                    "id": 6971,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6138,
+                    "id": 6972,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7320,26 +7320,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_87.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Valen Rudor",
+            "name": "•Valen Rudor",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7019,
+                    "id": 7936,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7020,
+                    "id": 7937,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7021,
+                    "id": 7938,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7356,21 +7356,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6139,
+                    "id": 6973,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6140,
+                    "id": 6974,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6141,
+                    "id": 6975,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7391,26 +7391,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_88.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Night Beast”",
+            "name": "•“Night Beast”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7022,
+                    "id": 7939,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7023,
+                    "id": 7940,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7024,
+                    "id": 7941,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7427,21 +7427,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6142,
+                    "id": 6976,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6143,
+                    "id": 6977,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6144,
+                    "id": 6978,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7463,32 +7463,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_89.jpg",
             "initiative": 1,
             "is_unique": true,
-            "name": "“Wampa”",
+            "name": "•“Wampa”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7025,
+                    "id": 7942,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7026,
+                    "id": 7943,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7027,
+                    "id": 7944,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7028,
+                    "id": 7945,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -7505,21 +7505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6145,
+                    "id": 6979,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6146,
+                    "id": 6980,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6147,
+                    "id": 6981,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7550,19 +7550,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7029,
+                    "id": 7946,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7030,
+                    "id": 7947,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7031,
+                    "id": 7948,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7579,21 +7579,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6148,
+                    "id": 6982,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6149,
+                    "id": 6983,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6150,
+                    "id": 6984,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7623,19 +7623,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7032,
+                    "id": 7949,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7033,
+                    "id": 7950,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7034,
+                    "id": 7951,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7652,21 +7652,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6151,
+                    "id": 6985,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6152,
+                    "id": 6986,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6153,
+                    "id": 6987,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7696,19 +7696,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7035,
+                    "id": 7952,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7036,
+                    "id": 7953,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7037,
+                    "id": 7954,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7725,21 +7725,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6154,
+                    "id": 6988,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6155,
+                    "id": 6989,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6156,
+                    "id": 6990,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7764,38 +7764,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Darth Vader",
+            "name": "•Darth Vader",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7038,
+                    "id": 7955,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7039,
+                    "id": 7956,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7040,
+                    "id": 7957,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7041,
+                    "id": 7958,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7042,
+                    "id": 7959,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "3"
@@ -7812,21 +7812,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6157,
+                    "id": 6991,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6158,
+                    "id": 6992,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6159,
+                    "id": 6993,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7851,32 +7851,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_94.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Maarek Stele",
+            "name": "•Maarek Stele",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7043,
+                    "id": 7960,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7044,
+                    "id": 7961,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7045,
+                    "id": 7962,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7046,
+                    "id": 7963,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7893,21 +7893,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6160,
+                    "id": 6994,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6161,
+                    "id": 6995,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6162,
+                    "id": 6996,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7931,32 +7931,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_95.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Ved Foslo",
+            "name": "•Ved Foslo",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7047,
+                    "id": 7964,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7048,
+                    "id": 7965,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7049,
+                    "id": 7966,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7050,
+                    "id": 7967,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7973,21 +7973,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6163,
+                    "id": 6997,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6164,
+                    "id": 6998,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6165,
+                    "id": 6999,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8011,32 +8011,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_96.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Zertik Strom",
+            "name": "•Zertik Strom",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7051,
+                    "id": 7968,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7052,
+                    "id": 7969,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7053,
+                    "id": 7970,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7054,
+                    "id": 7971,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8053,21 +8053,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6166,
+                    "id": 7000,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6167,
+                    "id": 7001,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6168,
+                    "id": 7002,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8099,25 +8099,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7055,
+                    "id": 7972,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7056,
+                    "id": 7973,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7057,
+                    "id": 7974,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7058,
+                    "id": 7975,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8134,21 +8134,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6169,
+                    "id": 7003,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6170,
+                    "id": 7004,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6171,
+                    "id": 7005,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8179,25 +8179,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7059,
+                    "id": 7976,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7060,
+                    "id": 7977,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7061,
+                    "id": 7978,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7062,
+                    "id": 7979,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8214,35 +8214,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6172,
+                    "id": 7006,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6173,
+                    "id": 7007,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6174,
+                    "id": 7008,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6175,
+                    "id": 7009,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6176,
+                    "id": 7010,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8265,38 +8265,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_99.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Grand Inquisitor",
+            "name": "•Grand Inquisitor",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7063,
+                    "id": 7980,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7064,
+                    "id": 7981,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7065,
+                    "id": 7982,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7066,
+                    "id": 7983,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7067,
+                    "id": 7984,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8313,35 +8313,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6177,
+                    "id": 7011,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6178,
+                    "id": 7012,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6179,
+                    "id": 7013,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6180,
+                    "id": 7014,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6181,
+                    "id": 7015,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8364,38 +8364,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_100.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Seventh Sister",
+            "name": "•Seventh Sister",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7068,
+                    "id": 7985,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7069,
+                    "id": 7986,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7070,
+                    "id": 7987,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7071,
+                    "id": 7988,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7072,
+                    "id": 7989,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8412,35 +8412,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6182,
+                    "id": 7016,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6183,
+                    "id": 7017,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6184,
+                    "id": 7018,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6185,
+                    "id": 7019,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6186,
+                    "id": 7020,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8470,25 +8470,25 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7073,
+                    "id": 7990,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7074,
+                    "id": 7991,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7075,
+                    "id": 7992,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7076,
+                    "id": 7993,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8505,35 +8505,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6187,
+                    "id": 7021,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6188,
+                    "id": 7022,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6189,
+                    "id": 7023,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6190,
+                    "id": 7024,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6191,
+                    "id": 7025,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8563,31 +8563,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7994,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7078,
+                    "id": 7995,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7996,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7080,
+                    "id": 7997,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7081,
+                    "id": 7998,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -8604,28 +8604,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6192,
+                    "id": 7026,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6193,
+                    "id": 7027,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6194,
+                    "id": 7028,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6195,
+                    "id": 7029,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8648,26 +8648,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Soontir Fel",
+            "name": "•Soontir Fel",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7082,
+                    "id": 7999,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7083,
+                    "id": 8000,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7084,
+                    "id": 8001,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8684,28 +8684,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6196,
+                    "id": 7030,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6197,
+                    "id": 7031,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6198,
+                    "id": 7032,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6199,
+                    "id": 7033,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8728,26 +8728,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_104.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Turr Phennir",
+            "name": "•Turr Phennir",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7085,
+                    "id": 8002,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7086,
+                    "id": 8003,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7087,
+                    "id": 8004,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8764,28 +8764,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6200,
+                    "id": 7034,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6201,
+                    "id": 7035,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6202,
+                    "id": 7036,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6203,
+                    "id": 7037,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8815,19 +8815,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7088,
+                    "id": 8005,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7089,
+                    "id": 8006,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7090,
+                    "id": 8007,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8844,28 +8844,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6204,
+                    "id": 7038,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6205,
+                    "id": 7039,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6206,
+                    "id": 7040,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6207,
+                    "id": 7041,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8894,19 +8894,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7091,
+                    "id": 8008,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7092,
+                    "id": 8009,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7093,
+                    "id": 8010,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8923,28 +8923,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6208,
+                    "id": 7042,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6209,
+                    "id": 7043,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6210,
+                    "id": 7044,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6211,
+                    "id": 7045,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8972,26 +8972,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Tomax Bren",
+            "name": "•Tomax Bren",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7094,
+                    "id": 8011,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7095,
+                    "id": 8012,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7096,
+                    "id": 8013,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9008,28 +9008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6212,
+                    "id": 7046,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6213,
+                    "id": 7047,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6214,
+                    "id": 7048,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6215,
+                    "id": 7049,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9057,26 +9057,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_108.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Captain Jonus",
+            "name": "•Captain Jonus",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7097,
+                    "id": 8014,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7098,
+                    "id": 8015,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7099,
+                    "id": 8016,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9093,28 +9093,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6216,
+                    "id": 7050,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6217,
+                    "id": 7051,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6218,
+                    "id": 7052,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6219,
+                    "id": 7053,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9142,26 +9142,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_109.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Major Rhymer",
+            "name": "•Major Rhymer",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7100,
+                    "id": 8017,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7101,
+                    "id": 8018,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7102,
+                    "id": 8019,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9178,28 +9178,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6220,
+                    "id": 7054,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6221,
+                    "id": 7055,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6222,
+                    "id": 7056,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6223,
+                    "id": 7057,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9226,26 +9226,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Deathfire”",
+            "name": "•“Deathfire”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7103,
+                    "id": 8020,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7104,
+                    "id": 8021,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7105,
+                    "id": 8022,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9262,28 +9262,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6224,
+                    "id": 7058,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6225,
+                    "id": 7059,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6226,
+                    "id": 7060,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6227,
+                    "id": 7061,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9318,19 +9318,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7106,
+                    "id": 8023,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7107,
+                    "id": 8024,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7108,
+                    "id": 8025,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9347,28 +9347,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6228,
+                    "id": 7062,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6229,
+                    "id": 7063,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6230,
+                    "id": 7064,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6231,
+                    "id": 7065,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9402,19 +9402,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7109,
+                    "id": 8026,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7110,
+                    "id": 8027,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7111,
+                    "id": 8028,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9431,28 +9431,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6232,
+                    "id": 7066,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6233,
+                    "id": 7067,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6234,
+                    "id": 7068,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6235,
+                    "id": 7069,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9476,32 +9476,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_113.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Major Vermeil",
+            "name": "•Major Vermeil",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7112,
+                    "id": 8029,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7113,
+                    "id": 8030,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7114,
+                    "id": 8031,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7115,
+                    "id": 8032,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9518,28 +9518,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6236,
+                    "id": 7070,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6237,
+                    "id": 7071,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6238,
+                    "id": 7072,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6239,
+                    "id": 7073,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9563,32 +9563,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Captain Feroph",
+            "name": "•Captain Feroph",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7116,
+                    "id": 8033,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7117,
+                    "id": 8034,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7118,
+                    "id": 8035,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7119,
+                    "id": 8036,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9605,28 +9605,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6240,
+                    "id": 7074,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6241,
+                    "id": 7075,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6242,
+                    "id": 7076,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6243,
+                    "id": 7077,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9649,32 +9649,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_115.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Vizier”",
+            "name": "•“Vizier”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7120,
+                    "id": 8037,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7121,
+                    "id": 8038,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7122,
+                    "id": 8039,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7123,
+                    "id": 8040,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9691,28 +9691,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6244,
+                    "id": 7078,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6245,
+                    "id": 7079,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6246,
+                    "id": 7080,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6247,
+                    "id": 7081,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9742,25 +9742,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7124,
+                    "id": 8041,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7125,
+                    "id": 8042,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7126,
+                    "id": 8043,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7127,
+                    "id": 8044,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9777,21 +9777,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6248,
+                    "id": 7082,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6249,
+                    "id": 7083,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6250,
+                    "id": 7084,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9815,26 +9815,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_117.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "“Duchess”",
+            "name": "•“Duchess”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7128,
+                    "id": 8045,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7129,
+                    "id": 8046,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7130,
+                    "id": 8047,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9851,21 +9851,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6251,
+                    "id": 7085,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6252,
+                    "id": 7086,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6253,
+                    "id": 7087,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9889,26 +9889,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "“Countdown”",
+            "name": "•“Countdown”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7131,
+                    "id": 8048,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7132,
+                    "id": 8049,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7133,
+                    "id": 8050,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9925,21 +9925,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6254,
+                    "id": 7088,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6255,
+                    "id": 7089,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6256,
+                    "id": 7090,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9963,26 +9963,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_119.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "“Pure Sabacc”",
+            "name": "•“Pure Sabacc”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7134,
+                    "id": 8051,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7135,
+                    "id": 8052,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7136,
+                    "id": 8053,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9999,21 +9999,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6257,
+                    "id": 7091,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6258,
+                    "id": 7092,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6259,
+                    "id": 7093,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10044,19 +10044,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7137,
+                    "id": 8054,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7138,
+                    "id": 8055,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7139,
+                    "id": 8056,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10073,21 +10073,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6260,
+                    "id": 7094,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6261,
+                    "id": 7095,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6262,
+                    "id": 7096,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10117,19 +10117,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7140,
+                    "id": 8057,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7141,
+                    "id": 8058,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7142,
+                    "id": 8059,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10146,35 +10146,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6263,
+                    "id": 7097,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6264,
+                    "id": 7098,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6265,
+                    "id": 7099,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6266,
+                    "id": 7100,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6267,
+                    "id": 7101,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10198,32 +10198,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Rexler Brath",
+            "name": "•Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7143,
+                    "id": 8060,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7144,
+                    "id": 8061,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7145,
+                    "id": 8062,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7146,
+                    "id": 8063,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10240,35 +10240,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6268,
+                    "id": 7102,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6269,
+                    "id": 7103,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6270,
+                    "id": 7104,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6271,
+                    "id": 7105,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6272,
+                    "id": 7106,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10292,32 +10292,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_123.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Colonel Vessery",
+            "name": "•Colonel Vessery",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7147,
+                    "id": 8064,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7148,
+                    "id": 8065,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7149,
+                    "id": 8066,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7150,
+                    "id": 8067,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10334,35 +10334,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6273,
+                    "id": 7107,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6274,
+                    "id": 7108,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6275,
+                    "id": 7109,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6276,
+                    "id": 7110,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6277,
+                    "id": 7111,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10386,32 +10386,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_124.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Countess Ryad",
+            "name": "•Countess Ryad",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7151,
+                    "id": 8068,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7152,
+                    "id": 8069,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7153,
+                    "id": 8070,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7154,
+                    "id": 8071,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10428,35 +10428,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6278,
+                    "id": 7112,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6279,
+                    "id": 7113,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6280,
+                    "id": 7114,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6281,
+                    "id": 7115,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6282,
+                    "id": 7116,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10487,25 +10487,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7155,
+                    "id": 8072,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7156,
+                    "id": 8073,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7157,
+                    "id": 8074,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7158,
+                    "id": 8075,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10522,35 +10522,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6283,
+                    "id": 7117,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6284,
+                    "id": 7118,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6285,
+                    "id": 7119,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6286,
+                    "id": 7120,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6287,
+                    "id": 7121,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10580,25 +10580,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7159,
+                    "id": 8076,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7160,
+                    "id": 8077,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7161,
+                    "id": 8078,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7162,
+                    "id": 8079,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10615,21 +10615,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6288,
+                    "id": 7122,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6289,
+                    "id": 7123,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6290,
+                    "id": 7124,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10655,32 +10655,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_127.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Lieutenant Kestal",
+            "name": "•Lieutenant Kestal",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7163,
+                    "id": 8080,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7164,
+                    "id": 8081,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7165,
+                    "id": 8082,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7166,
+                    "id": 8083,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10697,21 +10697,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6291,
+                    "id": 7125,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6292,
+                    "id": 7126,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6293,
+                    "id": 7127,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10737,32 +10737,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_128.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "“Double Edge”",
+            "name": "•“Double Edge”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7167,
+                    "id": 8084,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7168,
+                    "id": 8085,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7169,
+                    "id": 8086,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7170,
+                    "id": 8087,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10779,21 +10779,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6294,
+                    "id": 7128,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6295,
+                    "id": 7129,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6296,
+                    "id": 7130,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10826,25 +10826,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7171,
+                    "id": 8088,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7172,
+                    "id": 8089,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7173,
+                    "id": 8090,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7174,
+                    "id": 8091,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10861,21 +10861,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6297,
+                    "id": 7131,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6298,
+                    "id": 7132,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6299,
+                    "id": 7133,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10907,25 +10907,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7175,
+                    "id": 8092,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7176,
+                    "id": 8093,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7177,
+                    "id": 8094,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7178,
+                    "id": 8095,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10942,28 +10942,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6300,
+                    "id": 7134,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6301,
+                    "id": 7135,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6302,
+                    "id": 7136,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6303,
+                    "id": 7137,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10987,32 +10987,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_131.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "“Whisper”",
+            "name": "•“Whisper”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7179,
+                    "id": 8096,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7180,
+                    "id": 8097,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7181,
+                    "id": 8098,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7182,
+                    "id": 8099,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11029,28 +11029,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6304,
+                    "id": 7138,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6305,
+                    "id": 7139,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6306,
+                    "id": 7140,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6307,
+                    "id": 7141,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11074,32 +11074,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_132.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "“Echo”",
+            "name": "•“Echo”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7183,
+                    "id": 8100,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7184,
+                    "id": 8101,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7185,
+                    "id": 8102,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7186,
+                    "id": 8103,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11116,28 +11116,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6308,
+                    "id": 7142,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6309,
+                    "id": 7143,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6310,
+                    "id": 7144,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6311,
+                    "id": 7145,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11168,25 +11168,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7187,
+                    "id": 8104,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7188,
+                    "id": 8105,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7189,
+                    "id": 8106,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7190,
+                    "id": 8107,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11203,28 +11203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6312,
+                    "id": 7146,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6313,
+                    "id": 7147,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6314,
+                    "id": 7148,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6315,
+                    "id": 7149,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11254,25 +11254,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7191,
+                    "id": 8108,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7192,
+                    "id": 8109,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7193,
+                    "id": 8110,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7194,
+                    "id": 8111,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11289,28 +11289,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6316,
+                    "id": 7150,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6317,
+                    "id": 7151,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6318,
+                    "id": 7152,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6319,
+                    "id": 7153,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11336,32 +11336,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_135.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Major Vynder",
+            "name": "•Major Vynder",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7195,
+                    "id": 8112,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7196,
+                    "id": 8113,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7197,
+                    "id": 8114,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7198,
+                    "id": 8115,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11378,28 +11378,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6320,
+                    "id": 7154,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6321,
+                    "id": 7155,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6322,
+                    "id": 7156,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6323,
+                    "id": 7157,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11425,32 +11425,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_136.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Lieutenant Karsabi",
+            "name": "•Lieutenant Karsabi",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7199,
+                    "id": 8116,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7200,
+                    "id": 8117,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7201,
+                    "id": 8118,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7202,
+                    "id": 8119,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11467,28 +11467,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6324,
+                    "id": 7158,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6325,
+                    "id": 7159,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6326,
+                    "id": 7160,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6327,
+                    "id": 7161,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11521,25 +11521,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7203,
+                    "id": 8120,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7204,
+                    "id": 8121,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7205,
+                    "id": 8122,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7206,
+                    "id": 8123,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11556,28 +11556,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6328,
+                    "id": 7162,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6329,
+                    "id": 7163,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6330,
+                    "id": 7164,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6331,
+                    "id": 7165,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11609,25 +11609,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7207,
+                    "id": 8124,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7208,
+                    "id": 8125,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7209,
+                    "id": 8126,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7210,
+                    "id": 8127,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11644,35 +11644,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6332,
+                    "id": 7166,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6333,
+                    "id": 7167,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6334,
+                    "id": 7168,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6335,
+                    "id": 7169,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6336,
+                    "id": 7170,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11700,32 +11700,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_139.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "“Redline”",
+            "name": "•“Redline”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7211,
+                    "id": 8128,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7212,
+                    "id": 8129,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7213,
+                    "id": 8130,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7214,
+                    "id": 8131,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11742,35 +11742,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6337,
+                    "id": 7171,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6338,
+                    "id": 7172,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6339,
+                    "id": 7173,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6340,
+                    "id": 7174,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6341,
+                    "id": 7175,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11798,32 +11798,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_140.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "“Deathrain”",
+            "name": "•“Deathrain”",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7215,
+                    "id": 8132,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7216,
+                    "id": 8133,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7217,
+                    "id": 8134,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7218,
+                    "id": 8135,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11840,35 +11840,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6342,
+                    "id": 7176,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6343,
+                    "id": 7177,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6344,
+                    "id": 7178,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6345,
+                    "id": 7179,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6346,
+                    "id": 7180,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11903,25 +11903,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7219,
+                    "id": 8136,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7220,
+                    "id": 8137,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7221,
+                    "id": 8138,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7222,
+                    "id": 8139,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11938,28 +11938,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6347,
+                    "id": 7181,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6348,
+                    "id": 7182,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6349,
+                    "id": 7183,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6350,
+                    "id": 7184,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11985,38 +11985,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Captain Kagi",
+            "name": "•Captain Kagi",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7223,
+                    "id": 8140,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7224,
+                    "id": 8141,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7225,
+                    "id": 8142,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7226,
+                    "id": 8143,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7227,
+                    "id": 8144,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12033,28 +12033,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6351,
+                    "id": 7185,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6352,
+                    "id": 7186,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6353,
+                    "id": 7187,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6354,
+                    "id": 7188,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12080,44 +12080,44 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_143.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Colonel Jendon",
+            "name": "•Colonel Jendon",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7228,
+                    "id": 8145,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7229,
+                    "id": 8146,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7230,
+                    "id": 8147,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7231,
+                    "id": 8148,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7232,
+                    "id": 8149,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7233,
+                    "id": 8150,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -12134,28 +12134,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6355,
+                    "id": 7189,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6356,
+                    "id": 7190,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6357,
+                    "id": 7191,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6358,
+                    "id": 7192,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12181,38 +12181,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_144.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Lieutenant Sai",
+            "name": "•Lieutenant Sai",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7234,
+                    "id": 8151,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7235,
+                    "id": 8152,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7236,
+                    "id": 8153,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7237,
+                    "id": 8154,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7238,
+                    "id": 8155,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12229,28 +12229,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6359,
+                    "id": 7193,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6360,
+                    "id": 7194,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6361,
+                    "id": 7195,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6362,
+                    "id": 7196,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12283,31 +12283,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7239,
+                    "id": 8156,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7240,
+                    "id": 8157,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7241,
+                    "id": 8158,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7242,
+                    "id": 8159,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7243,
+                    "id": 8160,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12324,35 +12324,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6363,
+                    "id": 7197,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6364,
+                    "id": 7198,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6365,
+                    "id": 7199,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6366,
+                    "id": 7200,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6367,
+                    "id": 7201,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12380,32 +12380,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Captain Oicunn",
+            "name": "•Captain Oicunn",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7244,
+                    "id": 8161,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7245,
+                    "id": 8162,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7246,
+                    "id": 8163,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7247,
+                    "id": 8164,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12422,35 +12422,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6368,
+                    "id": 7202,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6369,
+                    "id": 7203,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6370,
+                    "id": 7204,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6371,
+                    "id": 7205,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6372,
+                    "id": 7206,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12478,32 +12478,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Rear Admiral Chiraneau",
+            "name": "•Rear Admiral Chiraneau",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7248,
+                    "id": 8165,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7249,
+                    "id": 8166,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7250,
+                    "id": 8167,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7251,
+                    "id": 8168,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12520,35 +12520,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6373,
+                    "id": 7207,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6374,
+                    "id": 7208,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6375,
+                    "id": 7209,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6376,
+                    "id": 7210,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6377,
+                    "id": 7211,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12582,25 +12582,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7252,
+                    "id": 8169,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7253,
+                    "id": 8170,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7254,
+                    "id": 8171,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7255,
+                    "id": 8172,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12617,28 +12617,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6378,
+                    "id": 7212,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6379,
+                    "id": 7213,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6380,
+                    "id": 7214,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6381,
+                    "id": 7215,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12667,38 +12667,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_149.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Boba Fett",
+            "name": "•Boba Fett",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7256,
+                    "id": 8173,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7257,
+                    "id": 8174,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7258,
+                    "id": 8175,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7259,
+                    "id": 8176,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7260,
+                    "id": 8177,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12715,28 +12715,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6382,
+                    "id": 7216,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6383,
+                    "id": 7217,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6384,
+                    "id": 7218,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6385,
+                    "id": 7219,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12765,38 +12765,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_150.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Emon Azzameen",
+            "name": "•Emon Azzameen",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7261,
+                    "id": 8178,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7262,
+                    "id": 8179,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7263,
+                    "id": 8180,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7264,
+                    "id": 8181,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7265,
+                    "id": 8182,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12813,28 +12813,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6386,
+                    "id": 7220,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6387,
+                    "id": 7221,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6388,
+                    "id": 7222,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6389,
+                    "id": 7223,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12863,38 +12863,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Kath Scarlet",
+            "name": "•Kath Scarlet",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7266,
+                    "id": 8183,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7267,
+                    "id": 8184,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7268,
+                    "id": 8185,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7269,
+                    "id": 8186,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7270,
+                    "id": 8187,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12911,28 +12911,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6390,
+                    "id": 7224,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6391,
+                    "id": 7225,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6392,
+                    "id": 7226,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6393,
+                    "id": 7227,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12960,38 +12960,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_152.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Koshka Frost",
+            "name": "•Koshka Frost",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7271,
+                    "id": 8188,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7272,
+                    "id": 8189,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7273,
+                    "id": 8190,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7274,
+                    "id": 8191,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7275,
+                    "id": 8192,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13008,28 +13008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6394,
+                    "id": 7228,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6395,
+                    "id": 7229,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6396,
+                    "id": 7230,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6397,
+                    "id": 7231,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13058,38 +13058,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_153.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Krassis Trelix",
+            "name": "•Krassis Trelix",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7276,
+                    "id": 8193,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7277,
+                    "id": 8194,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7278,
+                    "id": 8195,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7279,
+                    "id": 8196,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7280,
+                    "id": 8197,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13106,28 +13106,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6398,
+                    "id": 7232,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6399,
+                    "id": 7233,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6400,
+                    "id": 7234,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6401,
+                    "id": 7235,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13162,31 +13162,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7281,
+                    "id": 8198,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7282,
+                    "id": 8199,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7283,
+                    "id": 8200,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7284,
+                    "id": 8201,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7285,
+                    "id": 8202,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13203,28 +13203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6402,
+                    "id": 7236,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6403,
+                    "id": 7237,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6404,
+                    "id": 7238,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6405,
+                    "id": 7239,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13247,26 +13247,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Fenn Rau",
+            "name": "•Fenn Rau",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7286,
+                    "id": 8203,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7287,
+                    "id": 8204,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7288,
+                    "id": 8205,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13283,28 +13283,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6406,
+                    "id": 7240,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6407,
+                    "id": 7241,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6408,
+                    "id": 7242,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6409,
+                    "id": 7243,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13327,26 +13327,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_156.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Old Teroch",
+            "name": "•Old Teroch",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7289,
+                    "id": 8206,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7290,
+                    "id": 8207,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7291,
+                    "id": 8208,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13363,28 +13363,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6410,
+                    "id": 7244,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6411,
+                    "id": 7245,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6412,
+                    "id": 7246,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6413,
+                    "id": 7247,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13406,26 +13406,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_157.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Joy Rekkoff",
+            "name": "•Joy Rekkoff",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7292,
+                    "id": 8209,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7293,
+                    "id": 8210,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7294,
+                    "id": 8211,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13442,28 +13442,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6414,
+                    "id": 7248,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6415,
+                    "id": 7249,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6416,
+                    "id": 7250,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6417,
+                    "id": 7251,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13486,26 +13486,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_158.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Kad Solus",
+            "name": "•Kad Solus",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7295,
+                    "id": 8212,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7296,
+                    "id": 8213,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7297,
+                    "id": 8214,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13522,28 +13522,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6418,
+                    "id": 7252,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6419,
+                    "id": 7253,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6420,
+                    "id": 7254,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6421,
+                    "id": 7255,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13573,19 +13573,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7298,
+                    "id": 8215,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7299,
+                    "id": 8216,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7300,
+                    "id": 8217,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13602,28 +13602,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6422,
+                    "id": 7256,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6423,
+                    "id": 7257,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6424,
+                    "id": 7258,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6425,
+                    "id": 7259,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13652,19 +13652,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7301,
+                    "id": 8218,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7302,
+                    "id": 8219,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7303,
+                    "id": 8220,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13681,21 +13681,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6426,
+                    "id": 7260,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6427,
+                    "id": 7261,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6428,
+                    "id": 7262,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13721,26 +13721,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_161.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Constable Zuvio",
+            "name": "•Constable Zuvio",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7304,
+                    "id": 8221,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7305,
+                    "id": 8222,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7306,
+                    "id": 8223,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13757,21 +13757,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6429,
+                    "id": 7263,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6430,
+                    "id": 7264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6431,
+                    "id": 7265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13796,26 +13796,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_162.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Sarco Plank",
+            "name": "•Sarco Plank",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7307,
+                    "id": 8224,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7308,
+                    "id": 8225,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7309,
+                    "id": 8226,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13832,21 +13832,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6432,
+                    "id": 7266,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6433,
+                    "id": 7267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6434,
+                    "id": 7268,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13871,26 +13871,26 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Unkar Plutt",
+            "name": "•Unkar Plutt",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7310,
+                    "id": 8227,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7311,
+                    "id": 8228,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7312,
+                    "id": 8229,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13907,21 +13907,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6435,
+                    "id": 7269,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6436,
+                    "id": 7270,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6437,
+                    "id": 7271,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13953,19 +13953,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7313,
+                    "id": 8230,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7314,
+                    "id": 8231,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7315,
+                    "id": 8232,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13982,28 +13982,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6438,
+                    "id": 7272,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6439,
+                    "id": 7273,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6440,
+                    "id": 7274,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6441,
+                    "id": 7275,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14031,32 +14031,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_165.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Kavil",
+            "name": "•Kavil",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7316,
+                    "id": 8233,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7317,
+                    "id": 8234,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7318,
+                    "id": 8235,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7319,
+                    "id": 8236,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14073,28 +14073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6442,
+                    "id": 7276,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6443,
+                    "id": 7277,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6444,
+                    "id": 7278,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6445,
+                    "id": 7279,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14122,32 +14122,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Drea Renthal",
+            "name": "•Drea Renthal",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7320,
+                    "id": 8237,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7321,
+                    "id": 8238,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7322,
+                    "id": 8239,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7323,
+                    "id": 8240,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14164,28 +14164,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6446,
+                    "id": 7280,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6447,
+                    "id": 7281,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6448,
+                    "id": 7282,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6449,
+                    "id": 7283,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14220,25 +14220,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7324,
+                    "id": 8241,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7325,
+                    "id": 8242,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7326,
+                    "id": 8243,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7327,
+                    "id": 8244,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14255,28 +14255,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6450,
+                    "id": 7284,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6451,
+                    "id": 7285,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6452,
+                    "id": 7286,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6453,
+                    "id": 7287,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14310,25 +14310,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7328,
+                    "id": 8245,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7329,
+                    "id": 8246,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7330,
+                    "id": 8247,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7331,
+                    "id": 8248,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14345,21 +14345,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6454,
+                    "id": 7288,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6455,
+                    "id": 7289,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6456,
+                    "id": 7290,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14383,32 +14383,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_169.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "N’dru Suhlak",
+            "name": "•N’dru Suhlak",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7332,
+                    "id": 8249,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7333,
+                    "id": 8250,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7334,
+                    "id": 8251,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7335,
+                    "id": 8252,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14425,21 +14425,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6457,
+                    "id": 7291,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6458,
+                    "id": 7292,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6459,
+                    "id": 7293,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14463,32 +14463,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_170.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Kaa’to Leeachos",
+            "name": "•Kaa’to Leeachos",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7336,
+                    "id": 8253,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7337,
+                    "id": 8254,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7338,
+                    "id": 8255,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7339,
+                    "id": 8256,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14505,21 +14505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6460,
+                    "id": 7294,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6461,
+                    "id": 7295,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6462,
+                    "id": 7296,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14542,32 +14542,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "<italic>Nashtah Pup</italic>",
+            "name": "•<italic>Nashtah Pup</italic>",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7340,
+                    "id": 8257,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7341,
+                    "id": 8258,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7342,
+                    "id": 8259,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7343,
+                    "id": 8260,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14584,21 +14584,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6463,
+                    "id": 7297,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6464,
+                    "id": 7298,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6465,
+                    "id": 7299,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14629,25 +14629,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7344,
+                    "id": 8261,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7345,
+                    "id": 8262,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7346,
+                    "id": 8263,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7347,
+                    "id": 8264,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14664,21 +14664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6466,
+                    "id": 7300,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6467,
+                    "id": 7301,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6468,
+                    "id": 7302,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14708,25 +14708,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7348,
+                    "id": 8265,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7349,
+                    "id": 8266,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7350,
+                    "id": 8267,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7351,
+                    "id": 8268,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14743,35 +14743,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6469,
+                    "id": 7303,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6470,
+                    "id": 7304,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6471,
+                    "id": 7305,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6472,
+                    "id": 7306,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6473,
+                    "id": 7307,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14797,38 +14797,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_174.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Dace Bonearm",
+            "name": "•Dace Bonearm",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7352,
+                    "id": 8269,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7353,
+                    "id": 8270,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7354,
+                    "id": 8271,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7355,
+                    "id": 8272,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7356,
+                    "id": 8273,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "3"
@@ -14845,35 +14845,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6474,
+                    "id": 7308,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6475,
+                    "id": 7309,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6476,
+                    "id": 7310,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6477,
+                    "id": 7311,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6478,
+                    "id": 7312,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14899,32 +14899,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Palob Godalhi",
+            "name": "•Palob Godalhi",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7357,
+                    "id": 8274,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7358,
+                    "id": 8275,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7359,
+                    "id": 8276,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7360,
+                    "id": 8277,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14941,35 +14941,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6479,
+                    "id": 7313,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6480,
+                    "id": 7314,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6481,
+                    "id": 7315,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6482,
+                    "id": 7316,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6483,
+                    "id": 7317,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14994,32 +14994,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_176.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Torkil Mux",
+            "name": "•Torkil Mux",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7361,
+                    "id": 8278,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7362,
+                    "id": 8279,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7363,
+                    "id": 8280,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7364,
+                    "id": 8281,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15036,35 +15036,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6484,
+                    "id": 7318,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6485,
+                    "id": 7319,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6486,
+                    "id": 7320,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6487,
+                    "id": 7321,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6488,
+                    "id": 7322,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15096,25 +15096,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7365,
+                    "id": 8282,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7366,
+                    "id": 8283,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7367,
+                    "id": 8284,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7368,
+                    "id": 8285,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15131,28 +15131,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6489,
+                    "id": 7323,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6490,
+                    "id": 7324,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6491,
+                    "id": 7325,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6492,
+                    "id": 7326,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 }
@@ -15177,32 +15177,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_178.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Guri",
+            "name": "•Guri",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7369,
+                    "id": 8286,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7370,
+                    "id": 8287,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7371,
+                    "id": 8288,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7372,
+                    "id": 8289,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15219,28 +15219,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6493,
+                    "id": 7327,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6494,
+                    "id": 7328,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6495,
+                    "id": 7329,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6496,
+                    "id": 7330,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15265,32 +15265,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Dalan Oberos",
+            "name": "•Dalan Oberos",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7373,
+                    "id": 8290,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7374,
+                    "id": 8291,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7375,
+                    "id": 8292,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7376,
+                    "id": 8293,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15307,28 +15307,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6497,
+                    "id": 7331,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6498,
+                    "id": 7332,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6499,
+                    "id": 7333,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6500,
+                    "id": 7334,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15353,32 +15353,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_180.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Prince Xizor",
+            "name": "•Prince Xizor",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7377,
+                    "id": 8294,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7378,
+                    "id": 8295,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7379,
+                    "id": 8296,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7380,
+                    "id": 8297,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15395,28 +15395,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6501,
+                    "id": 7335,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6502,
+                    "id": 7336,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6503,
+                    "id": 7337,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6504,
+                    "id": 7338,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15448,25 +15448,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7381,
+                    "id": 8298,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7382,
+                    "id": 8299,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7383,
+                    "id": 8300,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7384,
+                    "id": 8301,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15483,28 +15483,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6505,
+                    "id": 7339,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6506,
+                    "id": 7340,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6507,
+                    "id": 7341,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6508,
+                    "id": 7342,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15535,25 +15535,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7385,
+                    "id": 8302,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7386,
+                    "id": 8303,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7387,
+                    "id": 8304,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7388,
+                    "id": 8305,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15570,28 +15570,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6509,
+                    "id": 7343,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6510,
+                    "id": 7344,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6511,
+                    "id": 7345,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6512,
+                    "id": 7346,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15614,32 +15614,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Serissu",
+            "name": "•Serissu",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7389,
+                    "id": 8306,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7390,
+                    "id": 8307,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7391,
+                    "id": 8308,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7392,
+                    "id": 8309,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15656,28 +15656,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6513,
+                    "id": 7347,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6514,
+                    "id": 7348,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6515,
+                    "id": 7349,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6516,
+                    "id": 7350,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15700,32 +15700,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_184.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Genesis Red",
+            "name": "•Genesis Red",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7393,
+                    "id": 8310,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7394,
+                    "id": 8311,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7395,
+                    "id": 8312,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7396,
+                    "id": 8313,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15742,28 +15742,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6517,
+                    "id": 7351,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6518,
+                    "id": 7352,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6519,
+                    "id": 7353,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6520,
+                    "id": 7354,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15786,32 +15786,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_185.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Laetin A’shera",
+            "name": "•Laetin A’shera",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7397,
+                    "id": 8314,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7398,
+                    "id": 8315,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7399,
+                    "id": 8316,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7400,
+                    "id": 8317,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15828,28 +15828,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6521,
+                    "id": 7355,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6522,
+                    "id": 7356,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6523,
+                    "id": 7357,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6524,
+                    "id": 7358,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15872,32 +15872,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_186.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Quinn Jast",
+            "name": "•Quinn Jast",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7401,
+                    "id": 8318,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7402,
+                    "id": 8319,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7403,
+                    "id": 8320,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7404,
+                    "id": 8321,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15914,28 +15914,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6525,
+                    "id": 7359,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6526,
+                    "id": 7360,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6527,
+                    "id": 7361,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6528,
+                    "id": 7362,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15957,32 +15957,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "Inaldra",
+            "name": "•Inaldra",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7405,
+                    "id": 8322,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7406,
+                    "id": 8323,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7407,
+                    "id": 8324,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7408,
+                    "id": 8325,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15999,28 +15999,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6529,
+                    "id": 7363,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6530,
+                    "id": 7364,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6531,
+                    "id": 7365,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6532,
+                    "id": 7366,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16042,32 +16042,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_188.jpg",
             "initiative": 1,
             "is_unique": true,
-            "name": "Sunny Bounder",
+            "name": "•Sunny Bounder",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7409,
+                    "id": 8326,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7410,
+                    "id": 8327,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7411,
+                    "id": 8328,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7412,
+                    "id": 8329,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16084,28 +16084,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6533,
+                    "id": 7367,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6534,
+                    "id": 7368,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6535,
+                    "id": 7369,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6536,
+                    "id": 7370,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16135,25 +16135,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7413,
+                    "id": 8330,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7414,
+                    "id": 8331,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7415,
+                    "id": 8332,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7416,
+                    "id": 8333,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16170,28 +16170,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6537,
+                    "id": 7371,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6538,
+                    "id": 7372,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6539,
+                    "id": 7373,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6540,
+                    "id": 7374,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16220,25 +16220,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7417,
+                    "id": 8334,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7418,
+                    "id": 8335,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7419,
+                    "id": 8336,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7420,
+                    "id": 8337,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16255,21 +16255,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6541,
+                    "id": 7375,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6542,
+                    "id": 7376,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6543,
+                    "id": 7377,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16295,32 +16295,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Talonbane Cobra",
+            "name": "•Talonbane Cobra",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7421,
+                    "id": 8338,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7422,
+                    "id": 8339,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7423,
+                    "id": 8340,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7424,
+                    "id": 8341,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16337,21 +16337,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6544,
+                    "id": 7378,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6545,
+                    "id": 7379,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6546,
+                    "id": 7380,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16377,32 +16377,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_192.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Graz",
+            "name": "•Graz",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7425,
+                    "id": 8342,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7426,
+                    "id": 8343,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7427,
+                    "id": 8344,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7428,
+                    "id": 8345,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16419,21 +16419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6547,
+                    "id": 7381,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6548,
+                    "id": 7382,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6549,
+                    "id": 7383,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16459,32 +16459,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_193.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Viktor Hel",
+            "name": "•Viktor Hel",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7429,
+                    "id": 8346,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7430,
+                    "id": 8347,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7431,
+                    "id": 8348,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7432,
+                    "id": 8349,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16501,21 +16501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6550,
+                    "id": 7384,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6551,
+                    "id": 7385,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6552,
+                    "id": 7386,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16540,32 +16540,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_194.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Captain Jostero",
+            "name": "•Captain Jostero",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7433,
+                    "id": 8350,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7434,
+                    "id": 8351,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7435,
+                    "id": 8352,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7436,
+                    "id": 8353,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16582,21 +16582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6553,
+                    "id": 7387,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6554,
+                    "id": 7388,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6555,
+                    "id": 7389,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16629,25 +16629,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7437,
+                    "id": 8354,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7438,
+                    "id": 8355,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7439,
+                    "id": 8356,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7440,
+                    "id": 8357,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16664,21 +16664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6556,
+                    "id": 7390,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6557,
+                    "id": 7391,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6558,
+                    "id": 7392,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16710,25 +16710,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7441,
+                    "id": 8358,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7442,
+                    "id": 8359,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7443,
+                    "id": 8360,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7444,
+                    "id": 8361,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16745,28 +16745,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6559,
+                    "id": 7393,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6560,
+                    "id": 7394,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6561,
+                    "id": 7395,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6562,
+                    "id": 7396,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16794,32 +16794,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_197.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "IG-88A",
+            "name": "•IG-88A",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7445,
+                    "id": 8362,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7446,
+                    "id": 8363,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7447,
+                    "id": 8364,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7448,
+                    "id": 8365,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16836,28 +16836,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6563,
+                    "id": 7397,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6564,
+                    "id": 7398,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6565,
+                    "id": 7399,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6566,
+                    "id": 7400,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16885,32 +16885,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_198.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "IG-88B",
+            "name": "•IG-88B",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7449,
+                    "id": 8366,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7450,
+                    "id": 8367,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7451,
+                    "id": 8368,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7452,
+                    "id": 8369,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16927,28 +16927,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6567,
+                    "id": 7401,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6568,
+                    "id": 7402,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6569,
+                    "id": 7403,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6570,
+                    "id": 7404,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16976,32 +16976,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "IG-88C",
+            "name": "•IG-88C",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7453,
+                    "id": 8370,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7454,
+                    "id": 8371,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7455,
+                    "id": 8372,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7456,
+                    "id": 8373,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17018,28 +17018,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6571,
+                    "id": 7405,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6572,
+                    "id": 7406,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6573,
+                    "id": 7407,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6574,
+                    "id": 7408,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17067,32 +17067,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_200.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "IG-88D",
+            "name": "•IG-88D",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7457,
+                    "id": 8374,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7458,
+                    "id": 8375,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7459,
+                    "id": 8376,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7460,
+                    "id": 8377,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17109,21 +17109,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6575,
+                    "id": 7409,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6576,
+                    "id": 7410,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6577,
+                    "id": 7411,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17149,32 +17149,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_201.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "4-LOM",
+            "name": "•4-LOM",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7461,
+                    "id": 8378,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7462,
+                    "id": 8379,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7463,
+                    "id": 8380,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7464,
+                    "id": 8381,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17191,21 +17191,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6578,
+                    "id": 7412,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6579,
+                    "id": 7413,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6580,
+                    "id": 7414,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17231,32 +17231,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_202.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Zuckuss",
+            "name": "•Zuckuss",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7465,
+                    "id": 8382,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7466,
+                    "id": 8383,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7467,
+                    "id": 8384,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7468,
+                    "id": 8385,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17273,21 +17273,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6581,
+                    "id": 7415,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6582,
+                    "id": 7416,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6583,
+                    "id": 7417,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17319,25 +17319,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7469,
+                    "id": 8386,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7470,
+                    "id": 8387,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7471,
+                    "id": 8388,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7472,
+                    "id": 8389,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17354,21 +17354,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6584,
+                    "id": 7418,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6585,
+                    "id": 7419,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6586,
+                    "id": 7420,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17395,38 +17395,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_204.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Captain Nym",
+            "name": "•Captain Nym",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7473,
+                    "id": 8390,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7474,
+                    "id": 8391,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7475,
+                    "id": 8392,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7476,
+                    "id": 8393,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7477,
+                    "id": 8394,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -17443,21 +17443,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6587,
+                    "id": 7421,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6588,
+                    "id": 7422,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6589,
+                    "id": 7423,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17484,32 +17484,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_205.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Sol Sixxa",
+            "name": "•Sol Sixxa",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7478,
+                    "id": 8395,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7479,
+                    "id": 8396,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7480,
+                    "id": 8397,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7481,
+                    "id": 8398,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17526,21 +17526,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6590,
+                    "id": 7424,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6591,
+                    "id": 7425,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6592,
+                    "id": 7426,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17573,25 +17573,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7482,
+                    "id": 8399,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7483,
+                    "id": 8400,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7484,
+                    "id": 8401,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7485,
+                    "id": 8402,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17608,28 +17608,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6593,
+                    "id": 7427,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6594,
+                    "id": 7428,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6595,
+                    "id": 7429,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6596,
+                    "id": 7430,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17655,32 +17655,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Torani Kulda",
+            "name": "•Torani Kulda",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7486,
+                    "id": 8403,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7487,
+                    "id": 8404,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7488,
+                    "id": 8405,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7489,
+                    "id": 8406,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17697,28 +17697,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6597,
+                    "id": 7431,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6598,
+                    "id": 7432,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6599,
+                    "id": 7433,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6600,
+                    "id": 7434,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17744,38 +17744,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_208.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Dalan Oberos",
+            "name": "•Dalan Oberos",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 2,
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7490,
+                    "id": 8407,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7491,
+                    "id": 8408,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7492,
+                    "id": 8409,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7493,
+                    "id": 8410,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7494,
+                    "id": 8411,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -17792,28 +17792,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6601,
+                    "id": 7435,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6602,
+                    "id": 7436,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6603,
+                    "id": 7437,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6604,
+                    "id": 7438,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17846,25 +17846,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7495,
+                    "id": 8412,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7496,
+                    "id": 8413,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7497,
+                    "id": 8414,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7498,
+                    "id": 8415,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17881,21 +17881,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6605,
+                    "id": 7439,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6606,
+                    "id": 7440,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6607,
+                    "id": 7441,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17924,32 +17924,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_210.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Bossk",
+            "name": "•Bossk",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7499,
+                    "id": 8416,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7500,
+                    "id": 8417,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7501,
+                    "id": 8418,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7502,
+                    "id": 8419,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17966,21 +17966,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6608,
+                    "id": 7442,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6609,
+                    "id": 7443,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6610,
+                    "id": 7444,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18009,38 +18009,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Moralo Eval",
+            "name": "•Moralo Eval",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7503,
+                    "id": 8420,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7504,
+                    "id": 8421,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7505,
+                    "id": 8422,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7506,
+                    "id": 8423,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7507,
+                    "id": 8424,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -18057,21 +18057,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6611,
+                    "id": 7445,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6612,
+                    "id": 7446,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6613,
+                    "id": 7447,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18100,32 +18100,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_212.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Latts Razzi",
+            "name": "•Latts Razzi",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7508,
+                    "id": 8425,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7509,
+                    "id": 8426,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7510,
+                    "id": 8427,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7511,
+                    "id": 8428,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18142,21 +18142,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6614,
+                    "id": 7448,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6615,
+                    "id": 7449,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6616,
+                    "id": 7450,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18191,25 +18191,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7512,
+                    "id": 8429,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7513,
+                    "id": 8430,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7514,
+                    "id": 8431,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7515,
+                    "id": 8432,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18226,21 +18226,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6617,
+                    "id": 7451,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6618,
+                    "id": 7452,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6619,
+                    "id": 7453,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18266,38 +18266,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_214.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Dengar",
+            "name": "•Dengar",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7516,
+                    "id": 8433,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7517,
+                    "id": 8434,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7518,
+                    "id": 8435,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7519,
+                    "id": 8436,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7520,
+                    "id": 8437,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -18314,21 +18314,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6620,
+                    "id": 7454,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6621,
+                    "id": 7455,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6622,
+                    "id": 7456,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18346,7 +18346,7 @@
                 6
             ],
             "card_type_id": 1,
-            "cost": "54",
+            "cost": "56",
             "faction_id": 3,
             "ffg_id": "XW_P_215",
             "force_side": null,
@@ -18354,32 +18354,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Manaroo",
+            "name": "•Manaroo",
             "restrictions": [],
-            "ship_ability_text": null,
+            "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7521,
+                    "id": 8438,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7522,
+                    "id": 8439,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7523,
+                    "id": 8440,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7524,
+                    "id": 8441,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18396,21 +18396,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6623,
+                    "id": 7457,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6624,
+                    "id": 7458,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6625,
+                    "id": 7459,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18436,38 +18436,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_216.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Tel Trevura",
+            "name": "•Tel Trevura",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7525,
+                    "id": 8442,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7526,
+                    "id": 8443,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7527,
+                    "id": 8444,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7528,
+                    "id": 8445,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7529,
+                    "id": 8446,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -18484,21 +18484,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6626,
+                    "id": 7460,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6627,
+                    "id": 7461,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6628,
+                    "id": 7462,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18530,25 +18530,25 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7530,
+                    "id": 8447,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7531,
+                    "id": 8448,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7532,
+                    "id": 8449,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7533,
+                    "id": 8450,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18565,28 +18565,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6629,
+                    "id": 7463,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6630,
+                    "id": 7464,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6631,
+                    "id": 7465,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6632,
+                    "id": 7466,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18612,38 +18612,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_218.jpg",
             "initiative": 5,
             "is_unique": true,
-            "name": "Ketsu Onyo",
+            "name": "•Ketsu Onyo",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7534,
+                    "id": 8451,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7535,
+                    "id": 8452,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7536,
+                    "id": 8453,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7537,
+                    "id": 8454,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7538,
+                    "id": 8455,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18660,28 +18660,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6633,
+                    "id": 7467,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6634,
+                    "id": 7468,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6635,
+                    "id": 7469,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6636,
+                    "id": 7470,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18707,44 +18707,44 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_219.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Asajj Ventress",
+            "name": "•Asajj Ventress",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7539,
+                    "id": 8456,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7540,
+                    "id": 8457,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7541,
+                    "id": 8458,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7542,
+                    "id": 8459,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7543,
+                    "id": 8460,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7544,
+                    "id": 8461,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -18761,28 +18761,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6637,
+                    "id": 7471,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6638,
+                    "id": 7472,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6639,
+                    "id": 7473,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6640,
+                    "id": 7474,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18808,38 +18808,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_220.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Sabine Wren",
+            "name": "•Sabine Wren",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 3,
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7545,
+                    "id": 8462,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7546,
+                    "id": 8463,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7547,
+                    "id": 8464,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7548,
+                    "id": 8465,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7549,
+                    "id": 8466,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18856,28 +18856,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6641,
+                    "id": 7475,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6642,
+                    "id": 7476,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6643,
+                    "id": 7477,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6644,
+                    "id": 7478,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18909,31 +18909,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7550,
+                    "id": 8467,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7551,
+                    "id": 8468,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7552,
+                    "id": 8469,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7553,
+                    "id": 8470,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7554,
+                    "id": 8471,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18950,28 +18950,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6645,
+                    "id": 7479,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6646,
+                    "id": 7480,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6647,
+                    "id": 7481,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6648,
+                    "id": 7482,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18999,32 +18999,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
             "initiative": 6,
             "is_unique": true,
-            "name": "Han Solo",
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7555,
+                    "id": 8472,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7556,
+                    "id": 8473,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7557,
+                    "id": 8474,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7558,
+                    "id": 8475,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19041,28 +19041,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6649,
+                    "id": 7483,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6650,
+                    "id": 7484,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6651,
+                    "id": 7485,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6652,
+                    "id": 7486,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19090,32 +19090,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Lando Calrissian",
+            "name": "•Lando Calrissian",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7559,
+                    "id": 8476,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7560,
+                    "id": 8477,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7561,
+                    "id": 8478,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7562,
+                    "id": 8479,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19132,28 +19132,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6653,
+                    "id": 7487,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6654,
+                    "id": 7488,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6655,
+                    "id": 7489,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6656,
+                    "id": 7490,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19180,32 +19180,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_224.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "L3-37",
+            "name": "•L3-37",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7563,
+                    "id": 8480,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7564,
+                    "id": 8481,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7565,
+                    "id": 8482,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7566,
+                    "id": 8483,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19222,28 +19222,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 7491,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 7492,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 7493,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 7494,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19277,25 +19277,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 8484,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 8485,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 8486,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 8487,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19312,21 +19312,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6661,
+                    "id": 7495,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6662,
+                    "id": 7496,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6663,
+                    "id": 7497,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19349,32 +19349,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_226.jpg",
             "initiative": 4,
             "is_unique": true,
-            "name": "Lando Calrissian",
+            "name": "•Lando Calrissian",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 1,
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7571,
+                    "id": 8488,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7572,
+                    "id": 8489,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7573,
+                    "id": 8490,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7574,
+                    "id": 8491,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19391,21 +19391,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6664,
+                    "id": 7498,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6665,
+                    "id": 7499,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6666,
+                    "id": 7500,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19428,32 +19428,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Outer Rim Pioneer",
+            "name": "•Outer Rim Pioneer",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 1,
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7575,
+                    "id": 8492,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7576,
+                    "id": 8493,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7577,
+                    "id": 8494,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7578,
+                    "id": 8495,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19470,21 +19470,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6667,
+                    "id": 7501,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6668,
+                    "id": 7502,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6669,
+                    "id": 7503,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19507,32 +19507,32 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
             "initiative": 2,
             "is_unique": true,
-            "name": "L3-37",
+            "name": "•L3-37",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 1,
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 8496,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7580,
+                    "id": 8497,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7581,
+                    "id": 8498,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7582,
+                    "id": 8499,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19549,21 +19549,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6670,
+                    "id": 7504,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6671,
+                    "id": 7505,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6672,
+                    "id": 7506,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19582,38 +19582,38 @@
             "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_229.jpg",
             "initiative": 1,
             "is_unique": true,
-            "name": "Autopilot Drone",
+            "name": "•Autopilot Drone",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 1,
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7583,
+                    "id": 8500,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7584,
+                    "id": 8501,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7585,
+                    "id": 8502,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7586,
+                    "id": 8503,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7587,
+                    "id": 8504,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "3"
@@ -20685,7 +20685,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
@@ -20724,7 +20724,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, all <hit>/<crit> results inflict jam tokens instead of damage.",
@@ -20763,7 +20763,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, all <hit>/<crit> results inflict tractor tokens instead of damage.",
@@ -20802,7 +20802,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack</smallcaps>",
@@ -20849,7 +20849,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
@@ -20897,7 +20897,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. Change 1<nonbreak><hit> result to a <crit> result.",
@@ -20989,7 +20989,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. Change 1<nonbreak><hit> result to a <crit> result.",
@@ -21036,7 +21036,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack (<focus>):</smallcaps> Spend 1<nonbreak><standardcharge>. If the defender is in your <bullseye>, you may spend 1 or more <standardcharge> to reroll that many attack dice.",
@@ -21080,7 +21080,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. After this attack, you may perform this attack as a bonus attack against a different target at range 0–1 of the defender, ignoring the <targetlock> requirement.",
@@ -21126,7 +21126,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. After this attack hits, each ship at range 0–1 of the defender exposes 1 of its damage cards.",
@@ -21172,7 +21172,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. After you declare the defender, the defender may choose to suffer 1<nonbreak><hit> damage. If it does, skip the Attack and Defense Dice steps and the attack is treated as hitting.",
@@ -21217,7 +21217,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
@@ -21262,7 +21262,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attack (<focus>):</smallcaps> Spend 1<nonbreak><standardcharge>.",
@@ -21307,7 +21307,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "While you defend, before attack dice are rolled, you may spend a lock you have on the attacker to roll 1 attack die. If you do, the attacker gains 1 jam token. Then, on a <hit> or <crit> result, gain 1 jam token.",

--- a/translation_helper/api_export_en.json
+++ b/translation_helper/api_export_en.json
@@ -1,6 +1,745 @@
 {
     "cards": [
         {
+            "ability_text": "While you perform an attack, the defender rolls 1 fewer defense die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5839,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5840,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5841,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_1",
+            "force_side": null,
+            "id": 1,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "Wedge Antilles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6671,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6672,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6673,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6674,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Two",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you become the defender (before dice are rolled), you may recover 1<nonbreak><forcecharge>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5842,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5843,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5844,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                17,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "62",
+            "faction_id": 1,
+            "ffg_id": "XW_P_2",
+            "force_side": 2,
+            "id": 2,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Luke Skywalker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6675,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6676,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6677,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6678,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 6679,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Five",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform an attack, you may spend 1<nonbreak><focus>, <hit>, or <crit> result to look at the defender’s facedown damage cards, choose 1, and expose it.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5845,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5846,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5847,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_set_ids": [
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_3",
+            "force_side": null,
+            "id": 3,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Thane Kyrell",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6680,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6681,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6682,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6683,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Corona Four",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you spend a focus token, you may choose 1 friendly ship at range 1–3. That ship gains 1 focus token.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5848,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5849,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5850,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_4",
+            "force_side": null,
+            "id": 4,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6684,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6685,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6686,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6687,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you receive a stress token, you may roll 1 attack die to remove it. On a <hit> result, suffer 1<nonbreak><hit> damage.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5851,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5852,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5853,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_5",
+            "force_side": null,
+            "id": 5,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Jek Porkins",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6688,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6689,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6690,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6691,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Six",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform a <barrelroll> or <boost> action, you may flip your equipped <config> upgrade card.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5854,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5855,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5856,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_6",
+            "force_side": null,
+            "id": 6,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Kullbee Sperado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6692,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6693,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6694,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6695,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Enigmatic Gunslinger",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While another friendly ship at range 0–1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1<nonbreak><hit> or <crit> to cancel 1 matching result.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5857,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5858,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5859,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_7",
+            "force_side": null,
+            "id": 7,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Biggs Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6696,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6697,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6698,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6699,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Three",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform a <barrelroll> or <boost> action, you may perform a red <evade> action.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5860,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5861,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5862,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_8",
+            "force_side": null,
+            "id": 8,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Leevan Tenza",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6700,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6701,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6702,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6703,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rebel Alliance Defector",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Before you activate, if you are focused, you may perform an action.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5863,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5864,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5865,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_9",
+            "force_side": null,
+            "id": 9,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "Edrio Two Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6704,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6705,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6706,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6707,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Cavern Angels Veteran",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Created as an elite starfighter squad, Red Squadron includes some of the best pilots in the Rebel Alliance.</flavor>",
             "available_actions": [
                 {
@@ -84,164 +823,164 @@
             "weapon_range": null
         },
         {
-            "ability_text": "While you perform an attack, the defender rolls 1 fewer defense die.",
+            "ability_text": "<flavor>Designed by Incom Corporation, the T-65 X-wing quickly proved to be one of the most effective and versatile military vehicles in the galaxy and a boon to the Rebellion.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 5869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 5870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 5871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
             "card_set_ids": [
+                1,
                 4,
                 7
             ],
             "card_type_id": 1,
-            "cost": "52",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_1",
+            "ffg_id": "XW_P_11",
             "force_side": null,
-            "id": 1,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "Wedge Antilles",
+            "id": 11,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Blue Squadron Escort",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 6712,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 6713,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 6714,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 6715,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Red Two",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "While you perform an attack, you may spend 1<nonbreak><focus>, <hit>, or <crit> result to look at the defender’s facedown damage cards, choose 1, and expose it.",
+            "ability_text": "<flavor>Unlike most Rebel cells, Saw Gerrera’s partisans are willing to use extreme methods to undermine the Galactic Empire’s objectives in brutal battles that rage from Geonosis to Jedha.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 5872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 5873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 5874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
+                13,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
             "card_set_ids": [
-                7
+                2
             ],
             "card_type_id": 1,
-            "cost": "48",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_3",
+            "ffg_id": "XW_P_12",
             "force_side": null,
-            "id": 3,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Thane Kyrell",
+            "id": 12,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Cavern Angels Zealot",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 6716,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 6717,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 6718,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 6719,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Corona Four",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -332,343 +1071,6 @@
                 }
             ],
             "subtitle": "Gold Nine",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you spend a focus token, you may choose 1 friendly ship at range 1–3. That ship gains 1 focus token.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5848,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5849,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5850,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_4",
-            "force_side": null,
-            "id": 4,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6684,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6685,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6686,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6687,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Designed by Incom Corporation, the T-65 X-wing quickly proved to be one of the most effective and versatile military vehicles in the galaxy and a boon to the Rebellion.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5869,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5870,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5871,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_11",
-            "force_side": null,
-            "id": 11,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Blue Squadron Escort",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6712,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6713,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6714,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6715,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform an attack, you may reroll 1 attack die for each other friendly ship at range 0–1 of the defender.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5883,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5884,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5885,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5886,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
-            "card_set_ids": [
-                4,
-                8
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_15",
-            "force_side": null,
-            "id": 15,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Horton Salm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 6728,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6729,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6730,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6731,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gray Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a <barrelroll> or <boost> action, you may flip your equipped <config> upgrade card.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5854,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5855,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5856,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_6",
-            "force_side": null,
-            "id": 6,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Kullbee Sperado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6692,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6693,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6694,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6695,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Enigmatic Gunslinger",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -765,42 +1167,183 @@
             "weapon_range": null
         },
         {
-            "ability_text": "At the start of the End Phase, you may spend 1 focus token to repair 1 of your faceup damage cards.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+            "ability_text": "While you perform an attack, you may reroll 1 attack die for each other friendly ship at range 0–1 of the defender.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5883,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5884,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5885,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5886,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
             "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_157",
-            "force_side": null,
-            "id": 382,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Chewbacca",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
+                4,
                 8
             ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_15",
+            "force_side": null,
+            "id": 15,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Horton Salm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6728,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6729,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6730,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6731,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gray Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, you may spend 1 focus token to choose a friendly ship at range 0–1. If you do, that ship rolls 1 additional defense die while defending until the end of the round.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5887,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5888,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5889,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5890,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_set_ids": [
+                8
+            ],
+            "card_type_id": 1,
+            "cost": "36",
+            "faction_id": 1,
+            "ffg_id": "XW_P_16",
+            "force_side": null,
+            "id": 16,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Evaan Verlaine",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6732,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6733,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6734,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6735,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gold Three",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -896,39 +1439,38 @@
             "weapon_range": null
         },
         {
-            "ability_text": "At the start of the Engagement Phase, you may spend 1 focus token to choose a friendly ship at range 0–1. If you do, that ship rolls 1 additional defense die while defending until the end of the round.",
+            "ability_text": "<flavor>Long after the Y-wing was phased out by the Galactic Empire, its durability, dependability, and heavy armament help it remain a staple in the Rebel fleet.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 5895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 5896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 5897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 5898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 4,
                 5,
                 10,
@@ -936,51 +1478,52 @@
                 14,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
             "card_set_ids": [
+                4,
                 8
             ],
             "card_type_id": 1,
-            "cost": "36",
+            "cost": "32",
             "faction_id": 1,
-            "ffg_id": "XW_P_16",
+            "ffg_id": "XW_P_18",
             "force_side": null,
-            "id": 16,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Evaan Verlaine",
+            "id": 18,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Gray Squadron Bomber",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 6740,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 6741,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 6742,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 6743,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Gold Three",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1078,167 +1621,179 @@
             "weapon_range": null
         },
         {
-            "ability_text": "After you perform a <barrelroll> or <boost> action, you may perform a red <evade> action.",
+            "ability_text": "<smallbody>You can perform primary attacks at range 0.<return>If you would fail a <boost> action by overlapping another ship, resolve it as though you were partially executing a maneuver instead.</smallbody><return><sasmall><sabold>Vectored Thrusters:</sabold> After you perform an action, you may perform a red <boost> action.</sasmall>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 5904,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 5906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 5907,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                5,
-                10,
-                13,
-                14,
-                18
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
             "card_set_ids": [
-                2
+                4
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_8",
+            "ffg_id": "XW_P_20",
             "force_side": null,
-            "id": 8,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "id": 20,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "Leevan Tenza",
+            "name": "Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 33,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 6748,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6701,
-                    "recurring": false,
-                    "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 6749,
                     "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
+                    "statistic_id": 1,
+                    "value": "3"
                 },
                 {
-                    "id": 6703,
+                    "id": 6750,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6751,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Rebel Alliance Defector",
+            "subtitle": "Green Leader",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Long after the Y-wing was phased out by the Galactic Empire, its durability, dependability, and heavy armament help it remain a staple in the Rebel fleet.</flavor>",
+            "ability_text": "<flavor>Due to its sensitive controls and high maneuverability, only the most talented pilots belong in an A-wing cockpit.</flavor><return><sasmall><sabold>Vectored Thrusters:</sabold> After you perform an action, you may perform a red <boost> action.</sasmall>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 5909,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 5911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "base_action_side_effect": null,
+                    "id": 5912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
+                1,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
             "card_set_ids": [
-                4,
-                8
+                4
             ],
             "card_type_id": 1,
-            "cost": "32",
+            "cost": "34",
             "faction_id": 1,
-            "ffg_id": "XW_P_18",
+            "ffg_id": "XW_P_21",
             "force_side": null,
-            "id": 18,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-            "initiative": 2,
+            "id": 21,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
+            "initiative": 3,
             "is_unique": false,
-            "name": "Gray Squadron Bomber",
+            "name": "Green Squadron Pilot",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 12,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 6752,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 6753,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "1"
+                    "value": "3"
                 },
                 {
-                    "id": 6742,
+                    "id": 6754,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "6"
+                    "value": "2"
                 },
                 {
-                    "id": 6743,
+                    "id": 6755,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1246,46 +1801,6 @@
             ],
             "subtitle": "",
             "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you have exactly 1 disarm token, you can still perform <torpedo> and <missile> attacks against targets you have locked. If you do, you cannot spend your lock during the attack.<return>Add <torpedo> and <missile> slots.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_125",
-            "force_side": null,
-            "id": 350,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Os-1 Arsenal Loadout",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 14,
-                            "raw_name": "Alpha-class Star Wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -1381,93 +1896,3985 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallbody>You can perform primary attacks at range 0.<return>If you would fail a <boost> action by overlapping another ship, resolve it as though you were partially executing a maneuver instead.</smallbody><return><sasmall><sabold>Vectored Thrusters:</sabold> After you perform an action, you may perform a red <boost> action.</sasmall>",
+            "ability_text": "While you defend or perform an attack, if you are stressed, you may reroll up to 2 of your dice.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5905,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
+                    "id": 5919,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 5920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 5921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                6
+                2,
+                3,
+                3,
+                5,
+                14
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_23",
+            "force_side": null,
+            "id": 23,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Braylen Stramm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6760,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6761,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6762,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6763,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Blade Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you defend or perform an attack, you may spend 1 stress token to change all of your <focus> results to <evade> or <hit> results.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5922,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5923,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5924,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_24",
+            "force_side": null,
+            "id": 24,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Ten Numb",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6764,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6765,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6766,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6767,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Blue Five",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>A unique gyrostabilization system surrounds the B-wing’s cockpit, ensuring that the pilot always remains stationary during flight.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5925,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5926,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5927,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 1,
+            "ffg_id": "XW_P_25",
+            "force_side": null,
+            "id": 25,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Blade Squadron Veteran",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6768,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6769,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6770,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6771,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Due to its heavy weapons array and resilient shielding, the B-wing has solidified itself as the Rebel Alliance’s most innovative assault fighter.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5928,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5929,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5930,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_26",
+            "force_side": null,
+            "id": 26,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Blue Squadron Pilot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6772,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6773,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6774,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6775,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform an attack, you may choose 1 friendly ship at range 1. That ship may perform an action, treating it as red.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5931,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5932,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5933,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 1,
             "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_20",
+            "ffg_id": "XW_P_27",
             "force_side": null,
-            "id": 20,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-            "initiative": 3,
+            "id": 27,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
+            "initiative": 5,
             "is_unique": true,
-            "name": "Arvel Crynyd",
+            "name": "Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 35,
+            "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 6776,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 6777,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "3"
+                    "value": "2"
                 },
                 {
-                    "id": 6750,
+                    "id": 6778,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 6779,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Green Leader",
+            "subtitle": "Intelligence Chief",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform a primary attack, if there is at least 1 other friendly ship at range 0–1 of the defender, you may roll 1 additional attack die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5934,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5935,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5936,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_28",
+            "force_side": null,
+            "id": 28,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Lieutenant Blount",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6780,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6781,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6782,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6783,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Team Player",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The AF4 series is the latest in a long line of Headhunter designs. Cheap and relatively durable, it is a favorite among independent outfits like the Rebellion.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5937,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5938,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5939,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "25",
+            "faction_id": 1,
+            "ffg_id": "XW_P_29",
+            "force_side": null,
+            "id": 29,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Tala Squadron Pilot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6784,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6785,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6786,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6787,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The Z-95 Headhunter was the primary inspiration for Incom Corporation’s exemplary T-65 X-wing starfighter. Though it is considered outdated by modern standards, it remains a versatile and potent snub fighter.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5940,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5941,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5942,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "23",
+            "faction_id": 1,
+            "ffg_id": "XW_P_30",
+            "force_side": null,
+            "id": 30,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Bandit Squadron Pilot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6788,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6789,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6790,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6791,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform a primary attack, if you are damaged, you may roll 1 additional attack die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5943,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5944,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5945,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "56",
+            "faction_id": 1,
+            "ffg_id": "XW_P_31",
+            "force_side": null,
+            "id": 31,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Wullffwarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6792,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6793,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6794,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6795,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Wookiee Chief",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After a friendly ship at range 0–1 becomes the defender, you may spend 1 reinforce token. If you do, that ship gains 1 evade token.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5946,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5947,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5948,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_32",
+            "force_side": null,
+            "id": 32,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Lowhhrick",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6796,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6797,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6798,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6799,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Escaped Gladiator",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Equipped with three wide-range Sureggi twin laser cannons, the Auzituck gunship acts as a powerful deterrent to slaver operations in the Kashyyyk system.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5949,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5950,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5951,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_33",
+            "force_side": null,
+            "id": 33,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Kashyyyk Defender",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6800,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6801,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6802,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6803,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>After you reveal a red or blue maneuver, you may set your dial to another maneuver of the same difficulty.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5952,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5953,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5954,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "39",
+            "faction_id": 1,
+            "ffg_id": "XW_P_34",
+            "force_side": null,
+            "id": 34,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6804,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6805,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6806,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6807,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>Before you activate, you may perform a <barrelroll> or <boost> action.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5955,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5956,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5957,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_35",
+            "force_side": null,
+            "id": 35,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6808,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6809,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6810,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6811,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>While you defend or perform an attack, if you are stressed, you may spend 1<nonbreak><forcecharge> to change up to 2 of your <focus> results to <evade> or <hit> results.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5958,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5959,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5960,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "41",
+            "faction_id": 1,
+            "ffg_id": "XW_P_36",
+            "force_side": 2,
+            "id": 36,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6812,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6813,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6814,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6815,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6816,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>While you defend, <crit> results are neutralized before <hit> results.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5961,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5962,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5963,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 1,
+            "ffg_id": "XW_P_37",
+            "force_side": null,
+            "id": 37,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6817,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6818,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6819,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6820,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>After an enemy ship in your firing arc engages, if you are not stressed, you may gain 1 stress token. If you do, that ship cannot spend tokens to modify dice while it performs an attack during this phase.</smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5964,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5965,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_38",
+            "force_side": null,
+            "id": 38,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6821,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6822,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6823,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6824,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6825,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Reluctant Rebel",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>While you defend or perform an attack, if you are stressed, you may spend 1<nonbreak><forcecharge> to change up to 2 of your <focus> results to <evade> /<hit> results. </smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5966,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5967,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                10,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_39",
+            "force_side": 2,
+            "id": 39,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6826,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6827,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6828,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6829,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6830,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6831,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>While you defend, <crit> results are neutralized before <hit> results.</smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5968,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5969,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_40",
+            "force_side": null,
+            "id": 40,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6832,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6833,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6834,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6835,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6836,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>While you coordinate, if you chose a ship with exactly 1 stress token, it can perform actions.</smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall> ",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5970,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5971,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_41",
+            "force_side": null,
+            "id": 41,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
+            "initiative": 1,
+            "is_unique": true,
+            "name": "AP-5",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6837,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6838,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6839,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6840,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6841,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Escaped Analyst Droid",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While a friendly ship in your firing arc performs a primary attack, if you are not stressed, you may gain 1 stress token. If you do, that ship may roll 1 additional attack die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5972,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5973,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5974,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5975,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5976,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_42",
+            "force_side": null,
+            "id": 42,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Jan Ors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6842,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6843,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6844,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6845,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Espionage Expert",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, you may transfer 1 of your focus tokens to a friendly ship in your firing arc.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5977,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5978,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5979,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5980,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5981,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_43",
+            "force_side": null,
+            "id": 43,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Kyle Katarn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6846,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6847,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6848,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6849,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Relentless Operative",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc. If you do, it engages at initiative 7 instead of its standard initiative value this phase.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5982,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5983,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5984,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5985,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5986,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_44",
+            "force_side": null,
+            "id": 44,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Roark Garnet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6850,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6851,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6852,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6853,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Good-Hearted Smuggler",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Designed to look like a bird in flight by the Corellian Engineering Corporation, “hawk” series ships are exemplary transport craft. Swift and rugged, the HWK-290 is often employed by Rebel agents as a mobile base of operations.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5987,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5988,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5989,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5990,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5991,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_45",
+            "force_side": null,
+            "id": 45,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebel Scout",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6854,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6855,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6856,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6857,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you defend or perform an attack, if you are stressed, you may spend 1<nonbreak><forcecharge> to change up to 2 of your <focus> results to <evade> or <hit> results.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5992,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5993,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5994,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_46",
+            "force_side": 2,
+            "id": 46,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6858,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6859,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6860,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6861,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Before you activate, you may perform a <barrelroll> or <boost> action.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5995,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5996,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5997,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 1,
+            "ffg_id": "XW_P_47",
+            "force_side": null,
+            "id": 47,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6862,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6863,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6864,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform an attack, assign the <smallcaps>Suppressive Fire</smallcaps> condition to the defender.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5998,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5999,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6000,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_48",
+            "force_side": null,
+            "id": 48,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "Captain Rex",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6865,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6866,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6867,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Clone Wars Veteran",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you defend, <crit> results are neutralized before <hit> results.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6001,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6002,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6003,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "26",
+            "faction_id": 1,
+            "ffg_id": "XW_P_49",
+            "force_side": null,
+            "id": 49,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6868,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6869,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6870,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>At initiative 0, you may perform a bonus primary attack against an enemy ship in your <bullseye>. If you do, at the start of the next Planning Phase, gain 1 disarm token.</smallbody><return><sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6004,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6005,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6006,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6007,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6008,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 1,
+            "ffg_id": "XW_P_50",
+            "force_side": null,
+            "id": 50,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Corran Horn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6871,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6872,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6873,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6874,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Tenacious Investigator",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>While a friendly ship performs an attack, if the defender is in your <frontarc>, the attacker may change 1<nonbreak><hit> result to a <crit> result.</smallbody><return><sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6009,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6010,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6011,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6012,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6013,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 1,
+            "ffg_id": "XW_P_51",
+            "force_side": null,
+            "id": 51,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Gavin Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6875,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6876,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6877,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6878,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Bold Wingman",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The elite pilots of Rogue Squadron are among the Rebellion’s very best.</flavor> <return> <sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6014,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6015,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6016,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6017,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6018,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "63",
+            "faction_id": 1,
+            "ffg_id": "XW_P_52",
+            "force_side": null,
+            "id": 52,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Rogue Squadron Escort",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6879,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6880,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6881,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6882,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Designed to combine the best features of the X-wing series with the A-wing series, the E-wing boasts superior firepower, speed, and maneuverability.</flavor><return> <sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6019,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6020,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6021,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6022,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6023,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "61",
+            "faction_id": 1,
+            "ffg_id": "XW_P_53",
+            "force_side": null,
+            "id": 53,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Knave Squadron Escort",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6883,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6884,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6885,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6886,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Friendly ships can acquire locks onto objects at range 0–3 of any friendly ship.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6024,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6025,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6026,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 1,
+            "ffg_id": "XW_P_54",
+            "force_side": null,
+            "id": 54,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Bodhi Rook",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6887,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6888,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6889,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6890,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Imperial Defector",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While a damaged friendly ship at range 0–3 performs an attack, it may reroll 1 attack die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6027,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6028,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6029,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_55",
+            "force_side": null,
+            "id": 55,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Saw Gerrera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6891,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6892,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6893,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6894,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Obsessive Outlaw",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Activation Phase, you may choose 1 friendly ship at range 1–3. If you do, that ship removes 1 stress token.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6030,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6031,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6032,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_56",
+            "force_side": null,
+            "id": 56,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Cassian Andor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6895,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6896,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6897,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6898,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Raised by the Rebellion",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While a friendly ship at range 0–2 defends, the attacker cannot reroll more than 1 attack die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6033,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6034,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6035,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_57",
+            "force_side": null,
+            "id": 57,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Magva Yarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6899,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6900,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6901,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6902,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Cavern Angels Spotter",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform a <focus> action, you may transfer 1 of your focus tokens to a friendly ship at range 1–2.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6036,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6037,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6038,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_58",
+            "force_side": null,
+            "id": 58,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "Benthic Two Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6903,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6904,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6905,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6906,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Cavern Angels Marksman",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After an enemy ship executes a maneuver, if it is at range 0, you may perform an action.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6039,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6040,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6041,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_59",
+            "force_side": null,
+            "id": 59,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "Heff Tobber",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6907,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6908,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6909,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6910,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Blue Eight",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Used for deploying troops under the cover of darkness or into the heat of battle, the UT-60D U-wing fulfills the Rebellion’s need for a swift and hardy troop transport.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6042,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6043,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6044,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_60",
+            "force_side": null,
+            "id": 60,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Blue Squadron Scout",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6911,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6912,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6913,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6914,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Saw Gerrera’s partisans were first established to oppose Separatist forces on Onderon during the Clone Wars, and continued to wage war against galactic tyranny as the Empire rose to power.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6045,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6046,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6047,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_61",
+            "force_side": null,
+            "id": 61,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Partisan Renegade",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6915,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6916,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6917,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6918,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform a primary attack, you may either spend 1 shield to roll 1 additional attack die or, if you are not shielded, you may roll 1 fewer attack die to recover 1 shield.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6048,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6049,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6050,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6051,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6052,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_62",
+            "force_side": null,
+            "id": 62,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Miranda Doni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6919,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6920,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6921,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6922,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Heavy Hitter",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While a friendly ship at range 0–2 defends or performs an attack, it may spend your focus tokens as if that ship has them.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6053,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6054,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6055,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6056,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6057,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_63",
+            "force_side": null,
+            "id": 63,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Esege Tuketu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6923,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6924,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6925,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6926,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Selfless Hero",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Koensayr Manufacturing’s K-wing boasts an advanced SubLight Acceleration Motor and an unprecedented 18 hard points, granting it unrivaled speed and firepower.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6058,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6059,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6060,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6061,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6062,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 1,
+            "ffg_id": "XW_P_64",
+            "force_side": null,
+            "id": 64,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Warden Squadron Pilot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6927,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6928,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6929,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6930,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you defend, if there is an enemy ship at range 0–1, you may add 1<nonbreak><evade> result to your dice results.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6063,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6064,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6065,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "55",
+            "faction_id": 1,
+            "ffg_id": "XW_P_65",
+            "force_side": null,
+            "id": 65,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Norra Wexley",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6931,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6932,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6933,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6934,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6935,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Gold Nine",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you spend a focus token, you may choose 1 friendly ship at range 1–3. That ship gains 1 focus token.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6066,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6067,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6068,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "51",
+            "faction_id": 1,
+            "ffg_id": "XW_P_66",
+            "force_side": null,
+            "id": 66,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6936,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6937,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6938,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6939,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6940,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Red Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you defend or perform a primary attack, you may spend 1 lock you have on the enemy ship to add 1<nonbreak><focus> result to your dice results.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6069,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6070,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6071,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "53",
+            "faction_id": 1,
+            "ffg_id": "XW_P_67",
+            "force_side": null,
+            "id": 67,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Shara Bey",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6941,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6942,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6943,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6944,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6945,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Green Four",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you fully execute a maneuver, if you are stressed, you may roll 1 attack die. On a <hit> or <crit> result, remove 1 stress token.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6072,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6073,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6074,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_68",
+            "force_side": null,
+            "id": 68,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Ibtisam",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6946,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6947,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6948,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6949,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6950,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Survivor of Endor",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you roll dice, if you are at range 0–1 of an obstacle, you may reroll all of your dice. This does not count as rerolling for the purpose of other effects.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6075,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6076,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6077,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6078,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "92",
+            "faction_id": 1,
+            "ffg_id": "XW_P_69",
+            "force_side": null,
+            "id": 69,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "Han Solo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6951,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6952,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6953,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6954,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Scoundrel for Hire",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1559,6 +5966,533 @@
                 }
             ],
             "subtitle": "General of the Alliance",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Before you would be dealt a faceup damage card, you may spend 1<nonbreak><standardcharge> to be dealt the card facedown instead.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6083,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6084,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6085,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6086,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 1,
+            "ffg_id": "XW_P_71",
+            "force_side": null,
+            "id": 71,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Chewbacca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6959,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6960,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6961,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6962,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                },
+                {
+                    "id": 6963,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "The Mighty",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Known for its durability and modular design, the YT-1300 is one of the most popular, widely used, and extensively customized freighters in the galaxy.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6087,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6088,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6089,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6090,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "78",
+            "faction_id": 1,
+            "ffg_id": "XW_P_72",
+            "force_side": null,
+            "id": 72,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Outer Rim Smuggler",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6964,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6965,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6966,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6967,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you reveal a red or blue maneuver, you may set your dial to another maneuver of the same difficulty.<return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6091,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6092,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6093,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "76",
+            "faction_id": 1,
+            "ffg_id": "XW_P_73",
+            "force_side": null,
+            "id": 73,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6968,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6969,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6970,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6971,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While a friendly ship in your firing arc defends, you may spend 1<nonbreak><forcecharge>. If you do, the attacker rolls 1 fewer attack die.<return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6094,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6095,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6096,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "90",
+            "faction_id": 1,
+            "ffg_id": "XW_P_74",
+            "force_side": 2,
+            "id": 74,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Kanan Jarrus",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6972,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6973,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6974,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6975,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                },
+                {
+                    "id": 6976,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Spectre-1",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, each enemy ship at range 0 gains 2 jam tokens. <return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6097,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6098,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6099,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 1,
+            "ffg_id": "XW_P_75",
+            "force_side": null,
+            "id": 75,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "“Chopper”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6977,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6978,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6979,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6980,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-3",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Another successful Corellian Engineering Corporation freighter design, the VCX-100 is larger than the ubiquitous YT-series, boasting more living space and customizability.</flavor><return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6100,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6101,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6102,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 1,
+            "ffg_id": "XW_P_76",
+            "force_side": null,
+            "id": 76,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Lothal Rebel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6981,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6982,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6983,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6984,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1973,87 +6907,6 @@
                 }
             ],
             "subtitle": "Obsidian Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Unlike most Rebel cells, Saw Gerrera’s partisans are willing to use extreme methods to undermine the Galactic Empire’s objectives in brutal battles that rage from Geonosis to Jedha.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5872,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5873,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5874,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_12",
-            "force_side": null,
-            "id": 12,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Cavern Angels Zealot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6716,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6717,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6718,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6719,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -2647,9455 +7500,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallbody>After you perform an action, you may spend 1<nonbreak><forcecharge> to perform an action.</smallbody><return><sasmall><sabold>Advanced Targeting Computer:</sabold> While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1<nonbreak><hit> result to a <crit> result.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6154,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6155,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6156,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 2,
-            "ffg_id": "XW_P_93",
-            "force_side": 1,
-            "id": 93,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "Darth Vader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7038,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7039,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7040,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7041,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7042,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Black Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The TIE Advanced x1 was produced in limited quantities, but Sienar engineers incorporated many of its best qualities into their next TIE model: the TIE Interceptor.</flavor><return><sasmall><sabold>Advanced Targeting Computer:</sabold> While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1<nonbreak><hit> result to a <crit> result.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6166,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6167,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6168,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 2,
-            "ffg_id": "XW_P_97",
-            "force_side": null,
-            "id": 97,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Storm Squadron Ace",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7055,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7056,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7057,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7058,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Sienar Fleet System’s TIE Advanced v1 is a groundbreaking starfighter design, featuring upgraded engines, a missile launcher, and folding s-foils.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6182,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6183,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6184,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6185,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6186,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_101",
-            "force_side": null,
-            "id": 101,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Baron of the Empire",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 25,
-            "statistics": [
-                {
-                    "id": 7073,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7074,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7075,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7076,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a <reload> action, you may recover 1<nonbreak><standardcharge> token on 1 of your equipped <talent> upgrade cards. <return><shipability><sabold>Nimble Bomber:</sabold> If you would drop a device using a <straight> template, you may use a <leftbank> or <rightbank> template of the same speed instead.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6208,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6209,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6210,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6211,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_107",
-            "force_side": null,
-            "id": 107,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Tomax Bren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7094,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7095,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7096,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Brash Maverick",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you are destroyed, before you are removed, you may perform an attack and drop or launch 1 device.<return><shipability><sabold>Nimble Bomber:</sabold> If you would drop a device using a <straight> template, you may use a <leftbank> or <rightbank> template of the same speed instead.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6220,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6221,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6222,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6223,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_110",
-            "force_side": null,
-            "id": 110,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "“Deathfire”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7103,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7104,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7105,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Unflinching Diehard",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you defend, if the attacker does not have any green tokens, you may change 1 of your blank or <focus> results to an <evade> result.</smallbody><return><sasmall><sabold>Adaptive Ailerons:</sabold> Before you reveal your dial, if you are not stressed, you <bold>must</bold> execute a white [1<nonbreak><leftbank>], [1<nonbreak><straight>], or [1<nonbreak><rightbank>] maneuver.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6236,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6237,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6238,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6239,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 2,
-            "ffg_id": "XW_P_114",
-            "force_side": null,
-            "id": 114,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Captain Feroph",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 43,
-            "statistics": [
-                {
-                    "id": 7116,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7117,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7118,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7119,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Imperial Courier",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you defend, after the Neutralize Results step, if you are not stressed, you may suffer 1<nonbreak><hit> damage and gain 1 stress token. If you do, cancel all dice results.</smallbody><return><sasmall><sabold>Adaptive Ailerons:</sabold> Before you reveal your dial, if you are not stressed, you <bold>must</bold> execute a white [1<nonbreak><leftbank>], [1<nonbreak><straight>], or [1<nonbreak><rightbank>] maneuver.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6251,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6252,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6253,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_118",
-            "force_side": null,
-            "id": 118,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "“Countdown”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 16,
-            "statistics": [
-                {
-                    "id": 7131,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7132,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7133,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Death Defier",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform an attack that hits, if you are evading, expose 1 of the defender’s damage cards.<return><shipability><sabold>Full Throttle:</sabold> After you fully execute a speed 3–5 maneuver, you may perform an <evade> action.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6263,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6264,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6265,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6266,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6267,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_122",
-            "force_side": null,
-            "id": 122,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Rexler Brath",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 18,
-            "statistics": [
-                {
-                    "id": 7143,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7144,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7145,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7146,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Onyx Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>During the development of the TIE aggressor, Sienar Fleet Systems valued performance and versatility over raw cost efficiency.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6297,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6298,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6299,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 2,
-            "ffg_id": "XW_P_130",
-            "force_side": null,
-            "id": 130,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Sienar Specialist",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7175,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7176,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7177,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7178,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The primary result of a hidden research facility on Imdaar Alpha, the TIE phantom achieves what many thought was impossible: a small starfighter equipped with an advanced cloaking device.</flavor><return><shipability><sabold>Stygium Array:</sabold> After you decloak, you may perform an <evade> action. At the start of the End Phase, you may spend 1 evade token to gain 1 cloak token.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6312,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6313,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6314,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 7,
-                    "base_action_side_effect": null,
-                    "id": 6315,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_134",
-            "force_side": null,
-            "id": 134,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Imdaar Test Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 27,
-            "statistics": [
-                {
-                    "id": 7191,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7192,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7193,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7194,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>With a design inspired by other Cygnus Spaceworks vessels, the <untalic>Alpha</untalic>-class star wing is a versatile craft assigned to Imperial Navy specialist units that need a starfighter they can outfit for multiple roles.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6328,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6329,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6330,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6331,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                6,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "35",
-            "faction_id": 2,
-            "ffg_id": "XW_P_138",
-            "force_side": null,
-            "id": 138,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Nu Squadron Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 14,
-            "statistics": [
-                {
-                    "id": 7207,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7208,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7209,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7210,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, you may choose 1 or more friendly ships at range 0–3. If you do, transfer all enemy lock tokens from the chosen ships to you.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6347,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6348,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 6349,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6350,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                8,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 2,
-            "ffg_id": "XW_P_142",
-            "force_side": null,
-            "id": 142,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Captain Kagi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 26,
-            "statistics": [
-                {
-                    "id": 7223,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7224,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 7225,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7226,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7227,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "The Emperor’s Shuttle Pilot",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform an attack, if you are reinforced and the defender is in the <fullfront> or <fullrear> matching your reinforce token, you may change 1 of your <focus> results to a <crit> result.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6368,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6369,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6370,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6371,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6372,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "88",
-            "faction_id": 2,
-            "ffg_id": "XW_P_147",
-            "force_side": null,
-            "id": 147,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Rear Admiral Chiraneau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7248,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7249,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7250,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7251,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Advisor to Admiral Piett",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a primary attack, if there is at least 1 friendly non-limited ship at range 0 of the defender, roll 1 additional attack die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6386,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6387,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": "stress",
-                    "id": 6388,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6389,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
-            "card_set_ids": [
-                6,
-                11
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 3,
-            "ffg_id": "XW_P_151",
-            "force_side": null,
-            "id": 151,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Kath Scarlet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 10,
-            "statistics": [
-                {
-                    "id": 7266,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7267,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "3"
-                },
-                {
-                    "id": 7268,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7269,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7270,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Captain of the Binayre Pirates",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you defend or perform an attack, if the attack range is 1, you may roll 1 additional die.</smallbody><return><sasmall><sabold>Concordia Faceoff:</sabold> While you defend, if the attack range is 1 and you are in the attacker’s <frontarc>, change 1 result to an <evade> result.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6402,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6403,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6404,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6405,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 3,
-            "ffg_id": "XW_P_155",
-            "force_side": null,
-            "id": 155,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7286,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7287,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7288,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Skull Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Due to its sensitive controls and high maneuverability, only the most talented pilots belong in an A-wing cockpit.</flavor><return><sasmall><sabold>Vectored Thrusters:</sabold> After you perform an action, you may perform a red <boost> action.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5909,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5910,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5911,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5912,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5913,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_21",
-            "force_side": null,
-            "id": 21,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Green Squadron Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 35,
-            "statistics": [
-                {
-                    "id": 6752,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6753,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6754,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6755,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The aces of Skull Squadron favor an aggressive approach, using their craft’s pivot wing technology to achieve unmatched agility in the pursuit of their quarry.</flavor> <return> <sasmall><sabold>Concordia Faceoff:</sabold> While you defend, if the attack range is 1 and you are in the attacker’s <frontarc>, change 1 result to an <evade> result.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6418,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6419,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6420,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6421,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_159",
-            "force_side": null,
-            "id": 159,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Skull Squadron Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7298,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7299,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7300,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, if there are one or more other ships at range 0, you and each other ship at range 0 gain 1 tractor token.<return><shipability><sabold>Spacetug Tractor Array:</sabold> <smallcaps>Action:</smallcaps> Choose a ship in your <frontarc> at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in your <bullseye> at range 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6432,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6433,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6434,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 3,
-            "ffg_id": "XW_P_163",
-            "force_side": null,
-            "id": 163,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "Unkar Plutt",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7310,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7311,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7312,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Miserly Portion Master",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While a friendly non-limited ship performs an attack, if the defender is in your firing arc, the attacker may reroll 1 attack die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6442,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6443,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6444,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6445,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 3,
-            "ffg_id": "XW_P_166",
-            "force_side": null,
-            "id": 166,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Drea Renthal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7320,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7321,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7322,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7323,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Pirate Lord",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Just the mention of Imperial credits can bring a host of less-than-trustworthy individuals to your side.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6446,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6447,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6448,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6449,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 3,
-            "ffg_id": "XW_P_167",
-            "force_side": null,
-            "id": 167,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Hired Gun",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7324,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7325,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7326,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7327,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "You can deploy only via emergency deployment, and you have the name, initiative, pilot ability, and ship <standardcharge> of the friendly, destroyed <smallcaps>Hound’s Tooth</smallcaps>.<return><shipability><sabold>Escape Craft:</sabold> <smallcaps>Setup:</smallcaps>Requires the <smallcaps>Hound’s Tooth</smallcaps>. You <bold>must</bold> begin the game docked with the <smallcaps>Hound’s Tooth</smallcaps>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6460,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6461,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6462,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "6",
-            "faction_id": 3,
-            "ffg_id": "XW_P_171",
-            "force_side": null,
-            "id": 171,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "<italic>Nashtah Pup</italic>",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 7340,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7341,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7342,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7343,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Contingency Plan",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, you may choose 1 enemy ship in your firing arc at range 0–2. If you do, transfer 1 focus or evade token from that ship to yourself.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6474,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6475,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6476,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6477,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6478,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 3,
-            "ffg_id": "XW_P_175",
-            "force_side": null,
-            "id": 175,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Palob Godalhi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 7357,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7358,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7359,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7360,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Tethan Resister",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>After you fully execute a maneuver, you may gain 1 stress token to rotate your ship 90º.</smallbody><return> <sasmall><sabold>Microthrusters:</sabold> While you perform a barrel roll, you <bold>must</bold> use the <leftbank> or <rightbank> template instead of the <straight> template.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6493,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6494,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6495,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6496,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_179",
-            "force_side": null,
-            "id": 179,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Dalan Oberos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 3,
-            "statistics": [
-                {
-                    "id": 7373,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7374,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7375,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7376,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Elite Bounty Hunter",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While a friendly ship at range 0–1 defends, it may reroll 1 of its dice.<return><shipability><sabold>Weapon Hardpoint:</sabold> You can equip 1 <cannon>, <torpedo>, or <missile> upgrade.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6509,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6510,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6511,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6512,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_183",
-            "force_side": null,
-            "id": 183,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Serissu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7389,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7390,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7391,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7392,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Flight Instructor",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend or perform an attack, you may suffer 1<nonbreak><hit> damage to reroll any number of your dice.<return><shipability><sabold>Weapon Hardpoint:</sabold> You can equip 1 <cannon>, <torpedo>, or <missile> upgrade. </shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6525,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6526,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6527,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6528,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 3,
-            "ffg_id": "XW_P_187",
-            "force_side": null,
-            "id": 187,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "Inaldra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7405,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7406,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7407,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7408,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Tansarii Point Boss",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend at attack range 3 or perform an attack at attack range 1, roll 1 additional die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6541,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6542,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6543,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_191",
-            "force_side": null,
-            "id": 191,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Talonbane Cobra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7421,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7422,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7423,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7424,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Scourge of Tansarii Point",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The Kihraxz assault fighter was developed specifically for the Black Sun crime syndicate, whose highly paid ace pilots demanded a nimble, powerful ship to match their skills.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6553,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6554,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6555,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 3,
-            "ffg_id": "XW_P_195",
-            "force_side": null,
-            "id": 195,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Black Sun Ace",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7437,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7438,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7439,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7440,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a <boost> action, you may perform an <evade> action.<return><shipability><sabold>Advanced Droid Brain:</sabold> After you perform a <calculate> action, gain 1 calculate token.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6567,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6568,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6569,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6570,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 3,
-            "ffg_id": "XW_P_199",
-            "force_side": null,
-            "id": 199,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "IG-88C",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 21,
-            "statistics": [
-                {
-                    "id": 7453,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7454,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7455,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7456,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Conniving Contraption",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The legendary Findsmen of Gand worship the enshrouding mists of their home planet, using signs, augurs, and mystical rituals to track their quarry.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6581,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6582,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6583,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_203",
-            "force_side": null,
-            "id": 203,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Gand Findsman",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 22,
-            "statistics": [
-                {
-                    "id": 7469,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7470,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7471,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7472,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>After you perform an attack, each enemy ship in your <bullseye> suffers 1<nonbreak><hit> damage unless it removes 1 green token.</smallbody><return><sasmall><sabold>Dead to Rights:</sabold> While you perform an attack, if the defender is in your <bullseye>, defense dice cannot be modified using green tokens.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6593,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6594,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6595,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6596,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                10,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_207",
-            "force_side": null,
-            "id": 207,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Torani Kulda",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 39,
-            "statistics": [
-                {
-                    "id": 7486,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7487,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7488,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "7"
-                },
-                {
-                    "id": 7489,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rodian Freelancer",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend or perform an attack, if you are stressed, you may reroll up to 2 of your dice.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5919,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5920,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5921,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_23",
-            "force_side": null,
-            "id": 23,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Braylen Stramm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6760,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6761,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6762,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6763,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Blade Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "If you would flee, you may spend 1<nonbreak><standardcharge>. If you do, place yourself in reserves instead. At the start of the next Planning Phase, place yourself within range 1 of the edge of the play area that you fled from.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6608,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6609,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6610,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                8,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 3,
-            "ffg_id": "XW_P_211",
-            "force_side": null,
-            "id": 211,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Moralo Eval",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 24,
-            "statistics": [
-                {
-                    "id": 7503,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 7504,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7505,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "9"
-                },
-                {
-                    "id": 7506,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                },
-                {
-                    "id": 7507,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Criminal Mastermind",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, you may choose a friendly ship at range 0–1. If you do, transfer all green tokens assigned to you to that ship.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6620,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6621,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6622,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_215",
-            "force_side": null,
-            "id": 215,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Manaroo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 45,
-            "statistics": [
-                {
-                    "id": 7521,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7522,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7523,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7524,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Graceful Aruzan",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Due to its heavy weapons array and resilient shielding, the B-wing has solidified itself as the Rebel Alliance’s most innovative assault fighter.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5928,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5929,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5930,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_26",
-            "force_side": null,
-            "id": 26,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Blue Squadron Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6772,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6773,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6774,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6775,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend or perform an attack, you may spend 1 stress token to change all of your <focus> results to <evade> or <hit> results.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5922,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5923,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5924,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_24",
-            "force_side": null,
-            "id": 24,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Ten Numb",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6764,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6765,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6766,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6767,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Blue Five",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A unique gyrostabilization system surrounds the B-wing’s cockpit, ensuring that the pilot always remains stationary during flight.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5925,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5926,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5927,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 1,
-            "ffg_id": "XW_P_25",
-            "force_side": null,
-            "id": 25,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Blade Squadron Veteran",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6768,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6769,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6770,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6771,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend or perform a primary attack, if the attack is obstructed by an obstacle, you may roll 1 additional die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6645,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6646,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6647,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6648,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_222",
-            "force_side": null,
-            "id": 222,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "Han Solo",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7555,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7556,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7557,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7558,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "The Corellian Kid",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a primary attack, if there is at least 1 other friendly ship at range 0–1 of the defender, you may roll 1 additional attack die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5934,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5935,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5936,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_28",
-            "force_side": null,
-            "id": 28,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Lieutenant Blount",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6780,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6781,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6782,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6783,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Team Player",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Designed for extended engagements, the TIE/ag is flown primarily by elite pilots trained to leverage both its unique weapons loadout and its maneuverability to full effect.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6294,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6295,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6296,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_129",
-            "force_side": null,
-            "id": 129,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Onyx Squadron Scout",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7171,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7172,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7173,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7174,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Friendly ships at range 0–1 can perform attacks at range 0 of obstacles.<return><shipability><sabold>Co-Pilot:</sabold> While you are docked, your carrier ship has your pilot ability in addition to its own.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6664,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6665,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6666,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "24",
-            "faction_id": 3,
-            "ffg_id": "XW_P_227",
-            "force_side": null,
-            "id": 227,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Outer Rim Pioneer",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
-            "statistics": [
-                {
-                    "id": 7575,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7576,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7577,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7578,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Skillful Outlaw",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The Z-95 Headhunter was the primary inspiration for Incom Corporation’s exemplary T-65 X-wing starfighter. Though it is considered outdated by modern standards, it remains a versatile and potent snub fighter.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5940,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5941,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5942,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "23",
-            "faction_id": 1,
-            "ffg_id": "XW_P_30",
-            "force_side": null,
-            "id": 30,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Bandit Squadron Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6788,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6789,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6790,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6791,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you roll dice, if you are not stressed, you may gain 1 stress token to reroll all of your blank results.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6649,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6650,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6651,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6652,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 3,
-            "ffg_id": "XW_P_223",
-            "force_side": null,
-            "id": 223,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Lando Calrissian",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7559,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7560,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7561,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7562,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Smooth-talking Gambler",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While another friendly ship at range 0–1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1<nonbreak><hit> or <crit> to cancel 1 matching result.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5857,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5858,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5859,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_7",
-            "force_side": null,
-            "id": 7,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Biggs Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6696,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6697,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6698,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6699,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Three",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Before you activate, if you are focused, you may perform an action.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5863,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5864,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5865,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_9",
-            "force_side": null,
-            "id": 9,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "Edrio Two Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6704,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6705,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6706,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6707,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Cavern Angels Veteran",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After a friendly ship at range 0–1 becomes the defender, you may spend 1 reinforce token. If you do, that ship gains 1 evade token.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5946,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5947,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5948,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_32",
-            "force_side": null,
-            "id": 32,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Lowhhrick",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6796,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6797,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6798,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6799,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Escaped Gladiator",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The AF4 series is the latest in a long line of Headhunter designs. Cheap and relatively durable, it is a favorite among independent outfits like the Rebellion.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5937,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5938,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5939,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "25",
-            "faction_id": 1,
-            "ffg_id": "XW_P_29",
-            "force_side": null,
-            "id": 29,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Tala Squadron Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6784,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6785,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6786,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6787,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a primary attack, if you are damaged, you may roll 1 additional attack die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5943,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5944,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5945,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "56",
-            "faction_id": 1,
-            "ffg_id": "XW_P_31",
-            "force_side": null,
-            "id": 31,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Wullffwarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6792,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6793,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6794,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6795,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Wookiee Chief",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform an attack, you may choose 1 friendly ship at range 1. That ship may perform an action, treating it as red.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5931,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5932,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5933,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "36",
-            "faction_id": 1,
-            "ffg_id": "XW_P_27",
-            "force_side": null,
-            "id": 27,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Airen Cracken",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6776,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6777,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6778,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6779,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Intelligence Chief",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>Before you activate, you may perform a <barrelroll> or <boost> action.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5955,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5956,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5957,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_35",
-            "force_side": null,
-            "id": 35,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6808,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6809,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6810,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6811,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The Quadrijet transfer spacetug, commonly called a \"Quadjumper,\" is nimble in space and atmosphere alike, making it popular among both smugglers and explorers.</flavor> <return><shipability><sabold>Spacetug Tractor Array:</sabold> <smallcaps>Action:</smallcaps> Choose a ship in your <frontarc> at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in your <bullseye> at range 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6435,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6436,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6437,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 3,
-            "ffg_id": "XW_P_164",
-            "force_side": null,
-            "id": 164,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Jakku Gunrunner",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7313,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7314,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7315,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Equipped with three wide-range Sureggi twin laser cannons, the Auzituck gunship acts as a powerful deterrent to slaver operations in the Kashyyyk system.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5949,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5950,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5951,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_33",
-            "force_side": null,
-            "id": 33,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Kashyyyk Defender",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6800,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6801,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6802,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6803,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you defend or perform an attack, if you are stressed, you may spend 1<nonbreak><forcecharge> to change up to 2 of your <focus> results to <evade> or <hit> results.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5958,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5959,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5960,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_36",
-            "force_side": 2,
-            "id": 36,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6812,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6813,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6814,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6815,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6816,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a primary attack, you may either spend 1 shield to roll 1 additional attack die or, if you are not shielded, you may roll 1 fewer attack die to recover 1 shield.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6048,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6049,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6050,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6051,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6052,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_62",
-            "force_side": null,
-            "id": 62,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Miranda Doni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6919,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6920,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6921,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6922,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Heavy Hitter",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "During the Perform Action step, you may perform 1 action, even while stressed. After you perform an action while stressed, suffer 1<nonbreak><hit> damage unless you expose 1 of your damage cards.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_83",
-            "force_side": null,
-            "id": 307,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Action:</smallcaps> Spend 1<nonbreak><standardcharge> from another equipped upgrade to recover 1 shield. <return><smallcaps>Action:</smallcaps> Spend 2 shields to recover 1 non-recurring <standardcharge> on an equipped upgrade.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_99",
-            "force_side": null,
-            "id": 323,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you fully execute a maneuver, if you have not dropped or launched a device this round, you may drop 1 bomb.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_143",
-            "force_side": null,
-            "id": 368,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "“Genius”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "You can dock 1 attack shuttle or <italic>Sheathipede</italic>-class shuttle.<return>Your docked ships can deploy only from your rear guides.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_102",
-            "force_side": null,
-            "id": 326,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "<italic>Ghost</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 23,
-                            "raw_name": "VCX-100 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "1 Z-95-AF4 headhunter can dock with you.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_148",
-            "force_side": null,
-            "id": 373,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "<italic>Hound’s Tooth</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 24,
-                            "raw_name": "YV-666 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "You can dock at range 0–1.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_106",
-            "force_side": null,
-            "id": 330,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "<italic>Phantom</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 32,
-                            "raw_name": "Attack Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    },
-                    {
-                        "kwargs": {
-                            "pk": 8,
-                            "raw_name": "Sheathipede-class Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a primary attack, if the defender is in your <frontarc>, roll 1 additional attack die.<return>Remove <crew> slot. Add <astro> slot.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_152",
-            "force_side": null,
-            "id": 377,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "<italic>Punishing One</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 45,
-                            "raw_name": "JumpMaster 5000"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, you may choose 1 enemy ship at range 0–1. If you do, you gain 1 calculate token unless that ship chooses to gain 1 stress token.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_127",
-            "force_side": null,
-            "id": 352,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "0-0-0",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 338
-                        },
-                        "type": "CARD_INCLUDED"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 93
-                        },
-                        "type": "CARD_INCLUDED"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After another friendly ship at range 0–3 defends, if it is destroyed, the attacker gains 2 stress tokens.<return>While a friendly ship at range 0–3 performs an attack against a stressed ship, it may reroll 1 attack die.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_109",
-            "force_side": null,
-            "id": 335,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Admiral Sloane",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a primary attack, if you are focused, you may perform a bonus <turretarc> attack against a ship you have not already attacked this round.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "14",
-            "faction_id": null,
-            "ffg_id": "XW_U_95",
-            "force_side": null,
-            "id": 319,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Bistan",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a primary attack that misses, if you are not stressed, you <bold>must</bold> receive 1 stress token to perform a bonus primary attack against the same target.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_139",
-            "force_side": null,
-            "id": 364,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Bossk",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a <focus> action, you may treat it as red. If you do, gain 1 additional focus token for each enemy ship at range 0–1, to a maximum of 2.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_79",
-            "force_side": null,
-            "id": 303,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Baze Malbus",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "During the End Phase, you may choose 2 <illicit> upgrades equipped to friendly ships at range 0–1. If you do, you may exchange these upgrades.<return><smallcaps>End of Game:</smallcaps> Return all <illicit> upgrades to their original ships.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_131",
-            "force_side": null,
-            "id": 356,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Cikatro Vizago",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Action:</smallcaps> Spend 1<nonbreak><standardcharge> to perform a <cloak> action.<return>At the start of the Planning Phase, roll 1 attack die. On a <focus> result, decloak or discard your cloak token.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_57",
-            "force_side": null,
-            "id": 286,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Cloaking Device",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6594,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "During the Activation Phase, enemy ships at range 0–1 cannot remove stress tokens.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_113",
-            "force_side": null,
-            "id": 339,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Death Troopers",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8,
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "During the System Phase, you may spend 2 <standardcharge>. If you do, each friendly ship may acquire a lock on a ship that you have locked.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_117",
-            "force_side": null,
-            "id": 343,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Grand Moff Tarkin",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "STRESS"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6601,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Setup:</smallcaps> After placing forces, choose 1 enemy ship and assign the <smallcaps>Listening Device</smallcaps> condition to it.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_44",
-            "force_side": null,
-            "id": 273,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Informant",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "If a friendly ship at range 0–3 would gain a focus token, it may gain 1 evade token instead.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_85",
-            "force_side": null,
-            "id": 309,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Jyn Erso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend, if the attacker is stressed, you may remove 1 stress from the attacker to change 1 of your blank/<focus> results to an <evade> result.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_135",
-            "force_side": null,
-            "id": 360,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Latts Razzi",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend or perform an attack, if there are no other friendly ships at range 0–2, you may spend 1<nonbreak><standardcharge> to reroll 1 of your dice.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_9",
-            "force_side": null,
-            "id": 238,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Lone Wolf",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6606,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you defend, if the attack hit, you may acquire a lock on the attacker.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_89",
-            "force_side": null,
-            "id": 313,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Magva Yarro",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you coordinate, the ship you choose can perform an action only if that action is also on your action bar.",
-            "available_actions": [
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 5830,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_16",
-            "force_side": null,
-            "id": 245,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Squad Leader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Before you would suffer damage from an obstacle or from a friendly bomb detonating, you may spend 1<nonbreak><standardcharge>. If you do, prevent 1 damage.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_68",
-            "force_side": null,
-            "id": 292,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ablative Plating",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "LARGE"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6614,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. Change 1<nonbreak><hit> result to a <crit> result.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_33",
-            "force_side": null,
-            "id": 262,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Adv. Proton Torpedoes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6615,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "5"
-                },
-                {
-                    "id": 6617,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                5
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1"
-        },
-        {
-            "ability_text": "After you reveal your dial, you may perform 1 action.<return>If you do, you cannot perform another action during your activation.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_23",
-            "force_side": null,
-            "id": 252,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Advanced Sensors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a <slam> action, if you fully executed the maneuver, you may perform a white action on your action bar, treating that action as red.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_69",
-            "force_side": null,
-            "id": 293,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Advanced SLAM",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Slam",
-                            "pk": 13,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody><bitalic>Bomb</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Bomblet with the [1<nonbreak><straight>] template.<return>At the start of the Activation Phase, you may spend 1 shield to recover 2 <standardcharge>.</smallbody>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_63",
-            "force_side": null,
-            "id": 392,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Bomblet Generator",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6622,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12,
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. After this attack, you may perform this attack as a bonus attack against a different target at range 0–1 of the defender, ignoring the <targetlock> requirement.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_37",
-            "force_side": null,
-            "id": 266,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Cluster Missiles",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6623,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6625,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "4"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                6
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<flavor>Used for deploying troops under the cover of darkness or into the heat of battle, the UT-60D U-wing fulfills the Rebellion’s need for a swift and hardy troop transport.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6042,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6043,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6044,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_60",
-            "force_side": null,
-            "id": 60,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Blue Squadron Scout",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6911,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6912,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6913,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6914,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you boost or barrel roll, you can move through and overlap obstacles.<return>After you move through or overlap an obstacle, you may spend 1<nonbreak><standardcharge> to ignore its effects until the end of the round.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_24",
-            "force_side": null,
-            "id": 253,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Collision Detector",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6626,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Before you activate, you may spend 1<nonbreak><standardcharge>. If you do, until the end of the round, you can perform actions and execute red maneuvers, even while stressed.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_58",
-            "force_side": null,
-            "id": 287,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Contraband Cybernetics",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6631,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a white <boost> action, you may treat it as red to use the [1<nonbreak><leftturn>] or [1<nonbreak><rightturn>] template instead.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                12
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_2",
-            "force_side": null,
-            "id": 231,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Daredevil",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Boost",
-                            "pk": 1,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Setup:</smallcaps> Lose 1<nonbreak><standardcharge>.<return><smallcaps>Action:</smallcaps> Recover 1<nonbreak><standardcharge>.<return><smallcaps>Action:</smallcaps> Spend 1<nonbreak><standardcharge> to recover 1 shield.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_43",
-            "force_side": null,
-            "id": 272,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "GNK “Gonk” Droid",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6636,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform a <turretarc> attack, after the Modify Defense Dice step, the defender removes 1 focus or calculate token.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_49",
-            "force_side": null,
-            "id": 278,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Hotshot Gunner",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>For those who cannot afford an enhanced shield generator, bolting additional plates onto the hull of a ship can serve as an adequate substitute.</flavor>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "*",
-            "faction_id": null,
-            "ffg_id": "XW_U_73",
-            "force_side": null,
-            "id": 297,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Hull Upgrade",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6642,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_28",
-            "force_side": null,
-            "id": 257,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ion Cannon",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6643,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                3
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
-        },
-        {
-            "ability_text": "While you perform a <frontarc> attack, if you are not in the defender’s firing arc, the defender rolls 1 fewer defense die.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_11",
-            "force_side": null,
-            "id": 240,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Outmaneuver",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you reveal your dial, you may spend 1<nonbreak><standardcharge> and gain 1 disarm token to recover 1 shield.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-            "card_set_ids": [
-                1,
-                4,
-                6,
-                7
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_53",
-            "force_side": null,
-            "id": 282,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "R2 Astromech",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6663,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you defend, <crit> results are neutralized before <hit> results.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5961,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5962,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5963,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_37",
-            "force_side": null,
-            "id": 37,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6817,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6818,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6819,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6820,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>After an enemy ship in your firing arc engages, if you are not stressed, you may gain 1 stress token. If you do, that ship cannot spend tokens to modify dice while it performs an attack during this phase.</smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5964,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5965,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_38",
-            "force_side": null,
-            "id": 38,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6821,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6822,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6823,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6824,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6825,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Reluctant Rebel",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Designed to look like a bird in flight by the Corellian Engineering Corporation, “hawk” series ships are exemplary transport craft. Swift and rugged, the HWK-290 is often employed by Rebel agents as a mobile base of operations.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5987,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5988,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5989,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5990,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5991,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_45",
-            "force_side": null,
-            "id": 45,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebel Scout",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6854,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6855,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6856,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6857,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you defend or perform an attack, if you are stressed, you may spend 1<nonbreak><forcecharge> to change up to 2 of your <focus> results to <evade> /<hit> results. </smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5966,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5967,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                10,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_39",
-            "force_side": 2,
-            "id": 39,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6826,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6827,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6828,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6829,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6830,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6831,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you defend, <crit> results are neutralized before <hit> results.</smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5968,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5969,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_40",
-            "force_side": null,
-            "id": 40,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6832,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6833,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6834,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6835,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6836,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While you coordinate, if you chose a ship with exactly 1 stress token, it can perform actions.</smallbody><return><sasmall><sabold>Comms Shuttle:</sabold> While you are docked, your carrier ship gains <coordinate>. Before your carrier ship activates, it may perform a <coordinate> action.</sasmall> ",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5970,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5971,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_41",
-            "force_side": null,
-            "id": 41,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-            "initiative": 1,
-            "is_unique": true,
-            "name": "AP-5",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6837,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6838,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6839,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6840,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6841,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Escaped Analyst Droid",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While a friendly ship in your firing arc performs a primary attack, if you are not stressed, you may gain 1 stress token. If you do, that ship may roll 1 additional attack die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5972,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5973,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5974,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5975,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5976,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_42",
-            "force_side": null,
-            "id": 42,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Jan Ors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6842,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6843,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6844,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6845,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Espionage Expert",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, you may transfer 1 of your focus tokens to a friendly ship in your firing arc.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5977,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5978,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5979,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5980,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5981,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_43",
-            "force_side": null,
-            "id": 43,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Kyle Katarn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6846,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6847,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6848,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6849,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Relentless Operative",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, you may choose 1 ship in your firing arc. If you do, it engages at initiative 7 instead of its standard initiative value this phase.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5982,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5983,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5984,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5985,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5986,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_44",
-            "force_side": null,
-            "id": 44,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Roark Garnet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6850,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6851,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6852,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6853,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Good-Hearted Smuggler",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Before you activate, you may perform a <barrelroll> or <boost> action.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5995,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5996,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5997,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 1,
-            "ffg_id": "XW_P_47",
-            "force_side": null,
-            "id": 47,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6862,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6863,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6864,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you become the defender (before dice are rolled), you may recover 1<nonbreak><forcecharge>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5842,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5843,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5844,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                17,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "62",
-            "faction_id": 1,
-            "ffg_id": "XW_P_2",
-            "force_side": 2,
-            "id": 2,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Luke Skywalker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6675,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6676,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6677,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6678,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 6679,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Five",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>While a friendly ship performs an attack, if the defender is in your <frontarc>, the attacker may change 1<nonbreak><hit> result to a <crit> result.</smallbody><return><sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6009,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6010,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6011,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6012,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6013,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 1,
-            "ffg_id": "XW_P_51",
-            "force_side": null,
-            "id": 51,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Gavin Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6875,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6876,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6877,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6878,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Bold Wingman",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The elite pilots of Rogue Squadron are among the Rebellion’s very best.</flavor> <return> <sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6014,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6015,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6016,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6017,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6018,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "63",
-            "faction_id": 1,
-            "ffg_id": "XW_P_52",
-            "force_side": null,
-            "id": 52,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Rogue Squadron Escort",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6879,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6880,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6881,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6882,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Designed to combine the best features of the X-wing series with the A-wing series, the E-wing boasts superior firepower, speed, and maneuverability.</flavor><return> <sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6019,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6020,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6021,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6022,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6023,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "61",
-            "faction_id": 1,
-            "ffg_id": "XW_P_53",
-            "force_side": null,
-            "id": 53,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Knave Squadron Escort",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6883,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6884,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6885,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6886,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>After you reveal a red or blue maneuver, you may set your dial to another maneuver of the same difficulty.</smallbody><return><sasmall><sabold>Locked and Loaded:</sabold> While you are docked, after your carrier ship performs a primary <frontarc> or <turret> attack, it may perform a bonus primary <reararc> attack.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5952,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5953,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5954,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "39",
-            "faction_id": 1,
-            "ffg_id": "XW_P_34",
-            "force_side": null,
-            "id": 34,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6804,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6805,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6806,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6807,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After an enemy ship executes a maneuver, if it is at range 0, you may perform an action.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6039,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6040,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6041,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_59",
-            "force_side": null,
-            "id": 59,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "Heff Tobber",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6907,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6908,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6909,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6910,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Blue Eight",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Saw Gerrera’s partisans were first established to oppose Separatist forces on Onderon during the Clone Wars, and continued to wage war against galactic tyranny as the Empire rose to power.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6045,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6046,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6047,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_61",
-            "force_side": null,
-            "id": 61,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Partisan Renegade",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6915,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6916,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6917,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6918,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Koensayr Manufacturing’s K-wing boasts an advanced SubLight Acceleration Motor and an unprecedented 18 hard points, granting it unrivaled speed and firepower.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6058,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6059,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6060,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6061,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6062,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 1,
-            "ffg_id": "XW_P_64",
-            "force_side": null,
-            "id": 64,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Warden Squadron Pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6927,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6928,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6929,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6930,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend or perform an attack, if you are stressed, you may spend 1<nonbreak><forcecharge> to change up to 2 of your <focus> results to <evade> or <hit> results.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5992,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5993,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5994,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_46",
-            "force_side": 2,
-            "id": 46,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6858,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6859,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6860,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6861,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform an attack, assign the <smallcaps>Suppressive Fire</smallcaps> condition to the defender.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5998,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5999,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6000,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_48",
-            "force_side": null,
-            "id": 48,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "Captain Rex",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6865,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6866,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6867,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Clone Wars Veteran",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend, <crit> results are neutralized before <hit> results.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6001,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6002,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6003,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "26",
-            "faction_id": 1,
-            "ffg_id": "XW_P_49",
-            "force_side": null,
-            "id": 49,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6868,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6869,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6870,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>At initiative 0, you may perform a bonus primary attack against an enemy ship in your <bullseye>. If you do, at the start of the next Planning Phase, gain 1 disarm token.</smallbody><return><sasmall><sabold>Experimental Scanners:</sabold> You can acquire locks beyond range 3. You cannot acquire locks at range 1.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6004,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6005,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6006,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6007,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6008,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 1,
-            "ffg_id": "XW_P_50",
-            "force_side": null,
-            "id": 50,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Corran Horn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6871,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6872,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6873,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6874,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Tenacious Investigator",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend, if there is an enemy ship at range 0–1, you may add 1<nonbreak><evade> result to your dice results.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6063,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6064,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6065,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "55",
-            "faction_id": 1,
-            "ffg_id": "XW_P_65",
-            "force_side": null,
-            "id": 65,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Norra Wexley",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6931,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6932,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6933,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6934,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6935,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Gold Nine",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Friendly ships can acquire locks onto objects at range 0–3 of any friendly ship.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6024,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6025,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6026,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 1,
-            "ffg_id": "XW_P_54",
-            "force_side": null,
-            "id": 54,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Bodhi Rook",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6887,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6888,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6889,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6890,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Imperial Defector",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Activation Phase, you may choose 1 friendly ship at range 1–3. If you do, that ship removes 1 stress token.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6030,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6031,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6032,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_56",
-            "force_side": null,
-            "id": 56,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Cassian Andor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6895,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6896,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6897,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6898,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Raised by the Rebellion",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While a friendly ship at range 0–2 defends, the attacker cannot reroll more than 1 attack die.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6033,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6034,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6035,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_57",
-            "force_side": null,
-            "id": 57,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Magva Yarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6899,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6900,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6901,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6902,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Cavern Angels Spotter",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a <focus> action, you may transfer 1 of your focus tokens to a friendly ship at range 1–2.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6036,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6037,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6038,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_58",
-            "force_side": null,
-            "id": 58,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "Benthic Two Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6903,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6904,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6905,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6906,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Cavern Angels Marksman",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While a friendly ship at range 0–2 defends or performs an attack, it may spend your focus tokens as if that ship has them.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6053,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6054,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6055,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6056,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6057,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_63",
-            "force_side": null,
-            "id": 63,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Esege Tuketu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6923,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6924,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6925,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6926,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Selfless Hero",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you spend a focus token, you may choose 1 friendly ship at range 1–3. That ship gains 1 focus token.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6066,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6067,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6068,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "51",
-            "faction_id": 1,
-            "ffg_id": "XW_P_66",
-            "force_side": null,
-            "id": 66,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6936,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6937,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6938,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6939,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6940,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Red Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you defend or perform a primary attack, you may spend 1 lock you have on the enemy ship to add 1<nonbreak><focus> result to your dice results.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6069,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6070,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6071,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "53",
-            "faction_id": 1,
-            "ffg_id": "XW_P_67",
-            "force_side": null,
-            "id": 67,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Shara Bey",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6941,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6942,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6943,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6944,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6945,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Green Four",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you fully execute a maneuver, if you are stressed, you may roll 1 attack die. On a <hit> or <crit> result, remove 1 stress token.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6072,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6073,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6074,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_68",
-            "force_side": null,
-            "id": 68,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Ibtisam",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6946,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6947,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6948,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6949,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6950,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Survivor of Endor",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you roll dice, if you are at range 0–1 of an obstacle, you may reroll all of your dice. This does not count as rerolling for the purpose of other effects.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6075,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6076,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6077,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6078,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "92",
-            "faction_id": 1,
-            "ffg_id": "XW_P_69",
-            "force_side": null,
-            "id": 69,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "Han Solo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6951,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6952,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6953,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6954,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Scoundrel for Hire",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Before you would be dealt a faceup damage card, you may spend 1<nonbreak><standardcharge> to be dealt the card facedown instead.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6083,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6084,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6085,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6086,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 1,
-            "ffg_id": "XW_P_71",
-            "force_side": null,
-            "id": 71,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Chewbacca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6959,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6960,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6961,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6962,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                },
-                {
-                    "id": 6963,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "The Mighty",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Known for its durability and modular design, the YT-1300 is one of the most popular, widely used, and extensively customized freighters in the galaxy.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6087,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6088,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6089,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6090,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "78",
-            "faction_id": 1,
-            "ffg_id": "XW_P_72",
-            "force_side": null,
-            "id": 72,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Outer Rim Smuggler",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6964,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6965,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6966,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6967,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you reveal a red or blue maneuver, you may set your dial to another maneuver of the same difficulty.<return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6091,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6092,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6093,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "76",
-            "faction_id": 1,
-            "ffg_id": "XW_P_73",
-            "force_side": null,
-            "id": 73,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6968,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6969,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6970,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6971,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While a friendly ship in your firing arc defends, you may spend 1<nonbreak><forcecharge>. If you do, the attacker rolls 1 fewer attack die.<return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6094,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6095,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6096,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "90",
-            "faction_id": 1,
-            "ffg_id": "XW_P_74",
-            "force_side": 2,
-            "id": 74,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Kanan Jarrus",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6972,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6973,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6974,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6975,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                },
-                {
-                    "id": 6976,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Spectre-1",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "At the start of the Engagement Phase, each enemy ship at range 0 gains 2 jam tokens. <return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6097,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6098,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6099,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 1,
-            "ffg_id": "XW_P_75",
-            "force_side": null,
-            "id": 75,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "“Chopper”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6977,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6978,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6979,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6980,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-3",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Another successful Corellian Engineering Corporation freighter design, the VCX-100 is larger than the ubiquitous YT-series, boasting more living space and customizability.</flavor><return><shipability><sabold>Tail Gun:</sabold> While you have a docked ship, you have a primary <reararc> weapon with an attack value equal to your docked ship’s primary <frontarc> attack value.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6100,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6101,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6102,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 1,
-            "ffg_id": "XW_P_76",
-            "force_side": null,
-            "id": 76,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Lothal Rebel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6981,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6982,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6983,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6984,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>The elite TIE/ln pilots of Black Squadron accompanied Darth Vader on a devastating strike against the Rebel forces at the Battle of Yavin.</flavor>",
             "available_actions": [
                 {
@@ -12311,6 +7715,93 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>After you perform an action, you may spend 1<nonbreak><forcecharge> to perform an action.</smallbody><return><sasmall><sabold>Advanced Targeting Computer:</sabold> While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1<nonbreak><hit> result to a <crit> result.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6154,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6155,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6156,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 2,
+            "ffg_id": "XW_P_93",
+            "force_side": 1,
+            "id": 93,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "Darth Vader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7038,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7039,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7040,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7041,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7042,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Black Leader",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12552,6 +8043,87 @@
                 }
             ],
             "subtitle": "Pitiless Administrator",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The TIE Advanced x1 was produced in limited quantities, but Sienar engineers incorporated many of its best qualities into their next TIE model: the TIE Interceptor.</flavor><return><sasmall><sabold>Advanced Targeting Computer:</sabold> While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1<nonbreak><hit> result to a <crit> result.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6166,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6167,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6168,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 2,
+            "ffg_id": "XW_P_97",
+            "force_side": null,
+            "id": 97,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Storm Squadron Ace",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7055,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7056,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7057,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7058,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12835,6 +8407,278 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Sienar Fleet System’s TIE Advanced v1 is a groundbreaking starfighter design, featuring upgraded engines, a missile launcher, and folding s-foils.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6182,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6183,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6184,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6185,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6186,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_101",
+            "force_side": null,
+            "id": 101,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Baron of the Empire",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7073,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7074,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7075,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7076,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The fearsome Inquisitors are given a great deal of autonomy and access to the Empire’s latest technology, like the prototype TIE Advanced v1.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6187,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6188,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6189,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6190,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6191,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 2,
+            "ffg_id": "XW_P_102",
+            "force_side": 1,
+            "id": 102,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Inquisitor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7077,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7078,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7079,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7080,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7081,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, if there is an enemy ship in your <bullseye>, gain 1 focus token.<return><shipability><sabold>Autothrusters:</sabold> After you perform an action, you may perform a red <barrelroll> or red <boost> action.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6192,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6193,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6194,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6195,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 2,
+            "ffg_id": "XW_P_103",
+            "force_side": null,
+            "id": 103,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "Soontir Fel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 41,
+            "statistics": [
+                {
+                    "id": 7082,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7083,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7084,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Ace of Legend",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "After you perform an attack, you may perform a <barrelroll> or <boost> action, even if you are stressed.<return><shipability><sabold>Autothrusters:</sabold> After you perform an action, you may perform a red <barrelroll> or red <boost> action.</shipability>",
             "available_actions": [
                 {
@@ -12995,86 +8839,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "At the start of the Engagement Phase, if there is an enemy ship in your <bullseye>, gain 1 focus token.<return><shipability><sabold>Autothrusters:</sabold> After you perform an action, you may perform a red <barrelroll> or red <boost> action.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6192,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6193,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6194,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6195,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 2,
-            "ffg_id": "XW_P_103",
-            "force_side": null,
-            "id": 103,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "Soontir Fel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 41,
-            "statistics": [
-                {
-                    "id": 7082,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7083,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7084,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Ace of Legend",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>Sienar Fleet Systems designed the TIE interceptor with four wing-mounted laser cannons, a dramatic increase in firepower over its predecessors.</flavor><return><shipability><sabold>Autothrusters:</sabold> After you perform an action, you may perform a red <barrelroll> or red <boost> action.</shipability>",
             "available_actions": [
                 {
@@ -13149,6 +8913,91 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform a <reload> action, you may recover 1<nonbreak><standardcharge> token on 1 of your equipped <talent> upgrade cards. <return><shipability><sabold>Nimble Bomber:</sabold> If you would drop a device using a <straight> template, you may use a <leftbank> or <rightbank> template of the same speed instead.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6208,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6209,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6210,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6211,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_107",
+            "force_side": null,
+            "id": 107,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Tomax Bren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7094,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7095,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7096,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Brash Maverick",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13319,6 +9168,90 @@
                 }
             ],
             "subtitle": "Scimitar Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you are destroyed, before you are removed, you may perform an attack and drop or launch 1 device.<return><shipability><sabold>Nimble Bomber:</sabold> If you would drop a device using a <straight> template, you may use a <leftbank> or <rightbank> template of the same speed instead.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6220,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6221,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6222,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6223,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_110",
+            "force_side": null,
+            "id": 110,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "“Deathfire”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7103,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7104,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7105,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Unflinching Diehard",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13580,6 +9513,93 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallbody>While you defend, if the attacker does not have any green tokens, you may change 1 of your blank or <focus> results to an <evade> result.</smallbody><return><sasmall><sabold>Adaptive Ailerons:</sabold> Before you reveal your dial, if you are not stressed, you <bold>must</bold> execute a white [1<nonbreak><leftbank>], [1<nonbreak><straight>], or [1<nonbreak><rightbank>] maneuver.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6236,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6237,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6238,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6239,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 2,
+            "ffg_id": "XW_P_114",
+            "force_side": null,
+            "id": 114,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Captain Feroph",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 43,
+            "statistics": [
+                {
+                    "id": 7116,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7117,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7118,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7119,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Imperial Courier",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallbody>After you fully execute a speed 1 maneuver using your <smallcaps>Adaptive Ailerons</smallcaps> ship ability, you may perform a <coordinate> action. If you do, skip your Perform Action step.</smallbody><return><sasmall><sabold>Adaptive Ailerons:</sabold> Before you reveal your dial, if you are not stressed, you <bold>must</bold> execute a white [1<nonbreak><leftbank>], [1<nonbreak><straight>], or [1<nonbreak><rightbank>] maneuver.</sasmall>",
             "available_actions": [
                 {
@@ -13826,6 +9846,80 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallbody>While you defend, after the Neutralize Results step, if you are not stressed, you may suffer 1<nonbreak><hit> damage and gain 1 stress token. If you do, cancel all dice results.</smallbody><return><sasmall><sabold>Adaptive Ailerons:</sabold> Before you reveal your dial, if you are not stressed, you <bold>must</bold> execute a white [1<nonbreak><leftbank>], [1<nonbreak><straight>], or [1<nonbreak><rightbank>] maneuver.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6251,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6252,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6253,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_118",
+            "force_side": null,
+            "id": 118,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "“Countdown”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 16,
+            "statistics": [
+                {
+                    "id": 7131,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7132,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7133,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Death Defier",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallbody>While you perform an attack, if you have 1 or fewer damage cards, you may roll 1 additional attack die.</smallbody><return><sasmall><sabold>Adaptive Ailerons:</sabold> Before you reveal your dial, if you are not stressed, you <bold>must</bold> execute a white [1<nonbreak><leftbank>], [1<nonbreak><straight>], or [1<nonbreak><rightbank>] maneuver.</sasmall>",
             "available_actions": [
                 {
@@ -14047,26 +10141,40 @@
             "weapon_range": null
         },
         {
-            "ability_text": "While a damaged friendly ship at range 0–3 performs an attack, it may reroll 1 attack die.",
+            "ability_text": "After you perform an attack that hits, if you are evading, expose 1 of the defender’s damage cards.<return><shipability><sabold>Full Throttle:</sabold> After you fully execute a speed 3–5 maneuver, you may perform an <evade> action.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6263,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6266,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14074,156 +10182,54 @@
             "available_upgrades": [
                 1,
                 2,
-                8,
-                8,
-                13,
-                14,
-                18
+                3,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_55",
-            "force_side": null,
-            "id": 55,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Saw Gerrera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6891,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6892,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6893,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6894,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Obsessive Outlaw",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>The fearsome Inquisitors are given a great deal of autonomy and access to the Empire’s latest technology, like the prototype TIE Advanced v1.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6187,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6188,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6189,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6190,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6191,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 1,
-            "cost": "40",
+            "cost": "84",
             "faction_id": 2,
-            "ffg_id": "XW_P_102",
-            "force_side": 1,
-            "id": 102,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Inquisitor",
+            "ffg_id": "XW_P_122",
+            "force_side": null,
+            "id": 122,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 25,
+            "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7143,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7078,
+                    "id": 7144,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7145,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7080,
+                    "id": 7146,
                     "recurring": false,
                     "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7081,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
+                    "value": "4"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Onyx Leader",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -14768,6 +10774,169 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Designed for extended engagements, the TIE/ag is flown primarily by elite pilots trained to leverage both its unique weapons loadout and its maneuverability to full effect.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6294,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6295,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6296,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_129",
+            "force_side": null,
+            "id": 129,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Onyx Squadron Scout",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7171,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7172,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7173,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7174,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>During the development of the TIE aggressor, Sienar Fleet Systems valued performance and versatility over raw cost efficiency.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6297,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6298,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6299,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 2,
+            "ffg_id": "XW_P_130",
+            "force_side": null,
+            "id": 130,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Sienar Specialist",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7175,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7176,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7177,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7178,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "After you perform an attack that hits, gain 1 evade token.<return><shipability><sabold>Stygium Array:</sabold> After you decloak, you may perform an <evade> action. At the start of the End Phase, you may spend 1 evade token to gain 1 cloak token.</shipability>",
             "available_actions": [
                 {
@@ -15018,6 +11187,92 @@
                 },
                 {
                     "id": 7190,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The primary result of a hidden research facility on Imdaar Alpha, the TIE phantom achieves what many thought was impossible: a small starfighter equipped with an advanced cloaking device.</flavor><return><shipability><sabold>Stygium Array:</sabold> After you decloak, you may perform an <evade> action. At the start of the End Phase, you may spend 1 evade token to gain 1 cloak token.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6312,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6313,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6314,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 7,
+                    "base_action_side_effect": null,
+                    "id": 6315,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_134",
+            "force_side": null,
+            "id": 134,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Imdaar Test Pilot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 27,
+            "statistics": [
+                {
+                    "id": 7191,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7192,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7193,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7194,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15285,6 +11540,94 @@
                 },
                 {
                     "id": 7206,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>With a design inspired by other Cygnus Spaceworks vessels, the <untalic>Alpha</untalic>-class star wing is a versatile craft assigned to Imperial Navy specialist units that need a starfighter they can outfit for multiple roles.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6328,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6329,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6330,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6331,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                6,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "35",
+            "faction_id": 2,
+            "ffg_id": "XW_P_138",
+            "force_side": null,
+            "id": 138,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Nu Squadron Pilot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 14,
+            "statistics": [
+                {
+                    "id": 7207,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7208,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7209,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7210,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -15590,6 +11933,101 @@
             "weapon_range": null
         },
         {
+            "ability_text": "At the start of the Engagement Phase, you may choose 1 or more friendly ships at range 0–3. If you do, transfer all enemy lock tokens from the chosen ships to you.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6347,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6348,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 6349,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6350,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                8,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 2,
+            "ffg_id": "XW_P_142",
+            "force_side": null,
+            "id": 142,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Captain Kagi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 26,
+            "statistics": [
+                {
+                    "id": 7223,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7224,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 7225,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7226,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7227,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "The Emperor’s Shuttle Pilot",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "At the start of the Activation Phase, you may spend 1<nonbreak><standardcharge>. If you do, while friendly ships acquire locks this round, they must acquire locks beyond range 3 instead of at range 0–3.",
             "available_actions": [
                 {
@@ -15876,6 +12314,202 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "You can perform primary attacks at range 0.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6363,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6364,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6365,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6366,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6367,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 2,
+            "ffg_id": "XW_P_146",
+            "force_side": null,
+            "id": 146,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Captain Oicunn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7244,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7245,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7246,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7247,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Inspired Tactician",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform an attack, if you are reinforced and the defender is in the <fullfront> or <fullrear> matching your reinforce token, you may change 1 of your <focus> results to a <crit> result.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6368,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6369,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6370,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6371,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6372,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "88",
+            "faction_id": 2,
+            "ffg_id": "XW_P_147",
+            "force_side": null,
+            "id": 147,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Rear Admiral Chiraneau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7248,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7249,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7250,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7251,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Advisor to Admiral Piett",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -16174,6 +12808,104 @@
             "weapon_range": null
         },
         {
+            "ability_text": "While you perform a primary attack, if there is at least 1 friendly non-limited ship at range 0 of the defender, roll 1 additional attack die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6386,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6387,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": "stress",
+                    "id": 6388,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6389,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
+            "card_set_ids": [
+                6,
+                11
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 3,
+            "ffg_id": "XW_P_151",
+            "force_side": null,
+            "id": 151,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Kath Scarlet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 10,
+            "statistics": [
+                {
+                    "id": 7266,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7267,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "3"
+                },
+                {
+                    "id": 7268,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7269,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7270,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Captain of the Binayre Pirates",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you defend or perform an attack, if the enemy ship is stressed, you may reroll 1 of your dice.",
             "available_actions": [
                 {
@@ -16466,6 +13198,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallbody>While you defend or perform an attack, if the attack range is 1, you may roll 1 additional die.</smallbody><return><sasmall><sabold>Concordia Faceoff:</sabold> While you defend, if the attack range is 1 and you are in the attacker’s <frontarc>, change 1 result to an <evade> result.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6402,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6403,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6404,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6405,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 3,
+            "ffg_id": "XW_P_155",
+            "force_side": null,
+            "id": 155,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7286,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7287,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7288,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Skull Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallbody>At the start of the Engagement Phase, you may choose 1 enemy ship at range 1. If you do and you are in its <frontarc>, it removes all of its green tokens.</smallbody><return><sasmall><sabold>Concordia Faceoff:</sabold> While you defend, if the attack range is 1 and you are in the attacker’s <frontarc>, change 1 result to an <evade> result.</sasmall>",
             "available_actions": [
                 {
@@ -16705,6 +13517,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>The aces of Skull Squadron favor an aggressive approach, using their craft’s pivot wing technology to achieve unmatched agility in the pursuit of their quarry.</flavor> <return> <sasmall><sabold>Concordia Faceoff:</sabold> While you defend, if the attack range is 1 and you are in the attacker’s <frontarc>, change 1 result to an <evade> result.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6418,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6419,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6420,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6421,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_159",
+            "force_side": null,
+            "id": 159,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Skull Squadron Pilot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7298,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7299,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7300,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Mandalorian Fang fighter pilots must master the Concordia Faceoff maneuver, leveraging their ships’ narrow attack profile to execute deadly head-on charges.</flavor> <return> <sasmall><sabold>Concordia Faceoff:</sabold> While you defend, if the attack range is 1 and you are in the attacker’s <frontarc>, change 1 result to an <evade> result.</sasmall>",
             "available_actions": [
                 {
@@ -16935,6 +13827,156 @@
             "weapon_range": null
         },
         {
+            "ability_text": "At the start of the Engagement Phase, if there are one or more other ships at range 0, you and each other ship at range 0 gain 1 tractor token.<return><shipability><sabold>Spacetug Tractor Array:</sabold> <smallcaps>Action:</smallcaps> Choose a ship in your <frontarc> at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in your <bullseye> at range 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6432,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6433,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6434,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 3,
+            "ffg_id": "XW_P_163",
+            "force_side": null,
+            "id": 163,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "Unkar Plutt",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7310,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7311,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7312,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Miserly Portion Master",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The Quadrijet transfer spacetug, commonly called a \"Quadjumper,\" is nimble in space and atmosphere alike, making it popular among both smugglers and explorers.</flavor> <return><shipability><sabold>Spacetug Tractor Array:</sabold> <smallcaps>Action:</smallcaps> Choose a ship in your <frontarc> at range 1. That ship gains 1 tractor token, or 2 tractor tokens if it is in your <bullseye> at range 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6435,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6436,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6437,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 3,
+            "ffg_id": "XW_P_164",
+            "force_side": null,
+            "id": 164,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Jakku Gunrunner",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7313,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7314,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7315,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you perform a non-<frontarc> attack, roll 1 additional attack die.",
             "available_actions": [
                 {
@@ -17021,6 +14063,188 @@
                 }
             ],
             "subtitle": "Callous Corsair",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While a friendly non-limited ship performs an attack, if the defender is in your firing arc, the attacker may reroll 1 attack die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6442,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6443,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6444,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6445,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 3,
+            "ffg_id": "XW_P_166",
+            "force_side": null,
+            "id": 166,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Drea Renthal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7320,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7321,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7322,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7323,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Pirate Lord",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Just the mention of Imperial credits can bring a host of less-than-trustworthy individuals to your side.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6446,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6447,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6448,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6449,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 3,
+            "ffg_id": "XW_P_167",
+            "force_side": null,
+            "id": 167,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Hired Gun",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7324,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7325,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7326,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7327,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17271,6 +14495,85 @@
                 }
             ],
             "subtitle": "Imposing Marauder",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "You can deploy only via emergency deployment, and you have the name, initiative, pilot ability, and ship <standardcharge> of the friendly, destroyed <smallcaps>Hound’s Tooth</smallcaps>.<return><shipability><sabold>Escape Craft:</sabold> <smallcaps>Setup:</smallcaps>Requires the <smallcaps>Hound’s Tooth</smallcaps>. You <bold>must</bold> begin the game docked with the <smallcaps>Hound’s Tooth</smallcaps>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6460,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6461,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6462,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "6",
+            "faction_id": 3,
+            "ffg_id": "XW_P_171",
+            "force_side": null,
+            "id": 171,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "<italic>Nashtah Pup</italic>",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 7340,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7341,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7342,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7343,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Contingency Plan",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17532,6 +14835,102 @@
                 }
             ],
             "subtitle": "Outer Rim Mercenary",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, you may choose 1 enemy ship in your firing arc at range 0–2. If you do, transfer 1 focus or evade token from that ship to yourself.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6474,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6475,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6476,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6477,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6478,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 3,
+            "ffg_id": "XW_P_175",
+            "force_side": null,
+            "id": 175,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Palob Godalhi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 7357,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7358,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7359,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7360,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Tethan Resister",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17815,6 +15214,94 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallbody>After you fully execute a maneuver, you may gain 1 stress token to rotate your ship 90º.</smallbody><return> <sasmall><sabold>Microthrusters:</sabold> While you perform a barrel roll, you <bold>must</bold> use the <leftbank> or <rightbank> template instead of the <straight> template.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6493,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6494,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6495,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6496,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_179",
+            "force_side": null,
+            "id": 179,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Dalan Oberos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 3,
+            "statistics": [
+                {
+                    "id": 7373,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7374,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7375,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7376,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Elite Bounty Hunter",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallbody>While you defend, after the Neutralize Results step, another friendly ship at range 0–1 and in the attack arc may suffer 1<nonbreak><hit> or <crit> damage. If it does, cancel 1 matching result.</smallbody><return><sasmall><sabold>Microthrusters:</sabold> While you perform a barrel roll, you <bold>must</bold> use the <leftbank> or <rightbank> template instead of the <straight> template.</sasmall>",
             "available_actions": [
                 {
@@ -18078,6 +15565,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "While a friendly ship at range 0–1 defends, it may reroll 1 of its dice.<return><shipability><sabold>Weapon Hardpoint:</sabold> You can equip 1 <cannon>, <torpedo>, or <missile> upgrade.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6509,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6510,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6511,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6512,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_183",
+            "force_side": null,
+            "id": 183,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Serissu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7389,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7390,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7391,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7392,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Flight Instructor",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "After you acquire a lock, you must remove all of your focus and evade tokens. Then, gain the same number of focus and evade tokens that the locked ship has.<return><shipability><sabold>Weapon Hardpoint:</sabold> You can equip 1 <cannon>, <torpedo>, or <missile> upgrade.</shipability>",
             "available_actions": [
                 {
@@ -18331,6 +15904,91 @@
                 }
             ],
             "subtitle": "Fortune Seeker",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you defend or perform an attack, you may suffer 1<nonbreak><hit> damage to reroll any number of your dice.<return><shipability><sabold>Weapon Hardpoint:</sabold> You can equip 1 <cannon>, <torpedo>, or <missile> upgrade. </shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6525,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6526,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6527,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6528,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 3,
+            "ffg_id": "XW_P_187",
+            "force_side": null,
+            "id": 187,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "Inaldra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7405,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7406,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7407,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7408,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Tansarii Point Boss",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -18592,6 +16250,88 @@
             "weapon_range": null
         },
         {
+            "ability_text": "While you defend at attack range 3 or perform an attack at attack range 1, roll 1 additional die.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6541,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6542,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6543,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_191",
+            "force_side": null,
+            "id": 191,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "Talonbane Cobra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7421,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7422,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7423,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7424,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Scourge of Tansarii Point",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you defend, if you are behind the attacker, roll 1 additional defense die.<return>While you perform an attack, if you are behind the defender, roll 1 additional attack die.",
             "available_actions": [
                 {
@@ -18832,6 +16572,88 @@
                 }
             ],
             "subtitle": "Aggressive Opportunist",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>The Kihraxz assault fighter was developed specifically for the Black Sun crime syndicate, whose highly paid ace pilots demanded a nimble, powerful ship to match their skills.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6553,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6554,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6555,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 3,
+            "ffg_id": "XW_P_195",
+            "force_side": null,
+            "id": 195,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Black Sun Ace",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7437,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7438,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7439,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7440,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19100,6 +16922,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "After you perform a <boost> action, you may perform an <evade> action.<return><shipability><sabold>Advanced Droid Brain:</sabold> After you perform a <calculate> action, gain 1 calculate token.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6567,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6568,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6569,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6570,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 3,
+            "ffg_id": "XW_P_199",
+            "force_side": null,
+            "id": 199,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "IG-88C",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 21,
+            "statistics": [
+                {
+                    "id": 7453,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7454,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7455,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7456,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Conniving Contraption",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you execute a Segnor’s Loop (<leftsloop> or <rightsloop>) maneuver, you may use another template of the same speed instead: either the turn (<leftturn> or <rightturn>) of the same direction or the straight (<straight>) template.<return><shipability><sabold>Advanced Droid Brain:</sabold> After you perform a <calculate> action, gain 1 calculate token.</shipability>",
             "available_actions": [
                 {
@@ -19355,6 +17268,87 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>The legendary Findsmen of Gand worship the enshrouding mists of their home planet, using signs, augurs, and mystical rituals to track their quarry.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6581,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6582,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6583,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_203",
+            "force_side": null,
+            "id": 203,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Gand Findsman",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 22,
+            "statistics": [
+                {
+                    "id": 7469,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7470,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7471,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7472,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Before a friendly bomb or mine would detonate, you may spend 1<nonbreak><standardcharge> to prevent it from detonating.<return> While you defend against an attack obstructed by a bomb or mine, roll 1 additional defense die.",
             "available_actions": [
                 {
@@ -19604,6 +17598,95 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>After you perform an attack, each enemy ship in your <bullseye> suffers 1<nonbreak><hit> damage unless it removes 1 green token.</smallbody><return><sasmall><sabold>Dead to Rights:</sabold> While you perform an attack, if the defender is in your <bullseye>, defense dice cannot be modified using green tokens.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6593,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6594,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6595,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6596,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                10,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_207",
+            "force_side": null,
+            "id": 207,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Torani Kulda",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 39,
+            "statistics": [
+                {
+                    "id": 7486,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7487,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7488,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "7"
+                },
+                {
+                    "id": 7489,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rodian Freelancer",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19878,6 +17961,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "If you would flee, you may spend 1<nonbreak><standardcharge>. If you do, place yourself in reserves instead. At the start of the next Planning Phase, place yourself within range 1 of the edge of the play area that you fled from.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6608,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6609,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6610,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                8,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 3,
+            "ffg_id": "XW_P_211",
+            "force_side": null,
+            "id": 211,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Moralo Eval",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 24,
+            "statistics": [
+                {
+                    "id": 7503,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 7504,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7505,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "9"
+                },
+                {
+                    "id": 7506,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                },
+                {
+                    "id": 7507,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Criminal Mastermind",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "At the start of the Engagement Phase, you may choose a ship at range 1 and spend a lock you have on that ship. If you do, that ship gains 1 tractor token.",
             "available_actions": [
                 {
@@ -20130,6 +18304,88 @@
                 }
             ],
             "subtitle": "Vengeful Corellian",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, you may choose a friendly ship at range 0–1. If you do, transfer all green tokens assigned to you to that ship.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6620,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6621,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6622,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_215",
+            "force_side": null,
+            "id": 215,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Manaroo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 45,
+            "statistics": [
+                {
+                    "id": 7521,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7522,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7523,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7524,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Graceful Aruzan",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20689,38 +18945,39 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Many spacers make a living traveling the Outer Rim, where the difference between smuggler and legitimate merchant is often murky. On the outskirts of civilization, buyers are rarely so discerning to ask where merchandise came from, at least as long as the price is low enough.</flavor>",
+            "ability_text": "While you defend or perform a primary attack, if the attack is obstructed by an obstacle, you may roll 1 additional die.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 6645,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 6646,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 6647,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 6648,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
+                1,
                 6,
                 8,
                 8,
@@ -20729,51 +18986,142 @@
                 15,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "54",
             "faction_id": 3,
-            "ffg_id": "XW_P_225",
+            "ffg_id": "XW_P_222",
             "force_side": null,
-            "id": 225,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Freighter Captain",
+            "id": 222,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 7555,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 7556,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 7557,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 7558,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "The Corellian Kid",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you roll dice, if you are not stressed, you may gain 1 stress token to reroll all of your blank results.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6649,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6650,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6651,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6652,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 3,
+            "ffg_id": "XW_P_223",
+            "force_side": null,
+            "id": 223,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "Lando Calrissian",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7559,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7560,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7561,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7562,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Smooth-talking Gambler",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20869,6 +19217,96 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Many spacers make a living traveling the Outer Rim, where the difference between smuggler and legitimate merchant is often murky. On the outskirts of civilization, buyers are rarely so discerning to ask where merchandise came from, at least as long as the price is low enough.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6657,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6658,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6659,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6660,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 3,
+            "ffg_id": "XW_P_225",
+            "force_side": null,
+            "id": 225,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Freighter Captain",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7567,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7568,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7569,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7570,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "After you roll dice, if you are not stressed, you may gain 1 stress token to reroll all of your blank results.<return><shipability><sabold>Co-Pilot:</sabold> While you are docked, your carrier ship has your pilot ability in addition to its own.",
             "available_actions": [
                 {
@@ -20948,42 +19386,160 @@
             "weapon_range": null
         },
         {
-            "ability_text": "While you perform a primary attack, if the defender is in your <bullseye>, before the Neutralize Results step, you may spend 1<nonbreak><standardcharge> to cancel 1<nonbreak><evade> result.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                9
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_1",
-            "force_side": null,
-            "id": 230,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Crack Shot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
+            "ability_text": "Friendly ships at range 0–1 can perform attacks at range 0 of obstacles.<return><shipability><sabold>Co-Pilot:</sabold> While you are docked, your carrier ship has your pilot ability in addition to its own.</shipability>",
+            "available_actions": [
                 {
-                    "id": 6632,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6664,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6665,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6666,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
                 }
             ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+            "available_upgrades": [
+                1,
+                8,
+                14
             ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "24",
+            "faction_id": 3,
+            "ffg_id": "XW_P_227",
+            "force_side": null,
+            "id": 227,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "Outer Rim Pioneer",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7575,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7576,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7577,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7578,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Skillful Outlaw",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "If you are not shielded, decrease the difficulty of your bank (<leftbank> and <rightbank>) maneuvers.<return><shipability><sabold>Co-Pilot:</sabold> While you are docked, your carrier ship has your pilot ability in addition to its own.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6667,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6668,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6669,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "22",
+            "faction_id": 3,
+            "ffg_id": "XW_P_228",
+            "force_side": null,
+            "id": 228,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "L3-37",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7579,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7580,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7581,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7582,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Droid Revolutionary",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21069,81 +19625,94 @@
             "weapon_range": null
         },
         {
-            "ability_text": "If you are not shielded, decrease the difficulty of your bank (<leftbank> and <rightbank>) maneuvers.<return><shipability><sabold>Co-Pilot:</sabold> While you are docked, your carrier ship has your pilot ability in addition to its own.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6667,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6668,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6669,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "ability_text": "While you perform a primary attack, if the defender is in your <bullseye>, before the Neutralize Results step, you may spend 1<nonbreak><standardcharge> to cancel 1<nonbreak><evade> result.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
             "card_set_ids": [
-                13
+                4,
+                5,
+                6,
+                9
             ],
-            "card_type_id": 1,
-            "cost": "22",
-            "faction_id": 3,
-            "ffg_id": "XW_P_228",
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_1",
             "force_side": null,
-            "id": 228,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "L3-37",
+            "id": 230,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Crack Shot",
             "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 6632,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7580,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7581,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7582,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
+                    "statistic_id": 7,
+                    "value": "1"
                 }
             ],
-            "subtitle": "Droid Revolutionary",
-            "upgrade_types": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform a white <boost> action, you may treat it as red to use the [1<nonbreak><leftturn>] or [1<nonbreak><rightturn>] template instead.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                12
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_2",
+            "force_side": null,
+            "id": 231,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Daredevil",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Boost",
+                            "pk": 1,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21351,6 +19920,39 @@
             "weapon_range": null
         },
         {
+            "ability_text": "While an enemy ship at range 0 defends, it rolls 1 fewer defense die.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_7",
+            "force_side": null,
+            "id": 236,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Intimidation",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you perform an attack, if you are evading, you may change 1 of the defender’s <evade> results to a <focus> result.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21400,6 +20002,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "While you defend or perform an attack, if there are no other friendly ships at range 0–2, you may spend 1<nonbreak><standardcharge> to reroll 1 of your dice.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_9",
+            "force_side": null,
+            "id": 238,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Lone Wolf",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6606,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you perform an attack, if the defender is in your <bullseye>, you may change 1<nonbreak><hit> result to a <crit> result.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21420,6 +20062,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Marksmanship",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform a <frontarc> attack, if you are not in the defender’s firing arc, the defender rolls 1 fewer defense die.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_11",
+            "force_side": null,
+            "id": 240,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Outmaneuver",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21558,37 +20233,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "At the start of the Engagement Phase, you may spend 1<nonbreak><forcecharge>. If you do, engage at initiative 7 instead of your standard initiative value this phase.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-            "card_set_ids": [
-                1,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_19",
-            "force_side": null,
-            "id": 248,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Heightened Perception",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                17
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "While another friendly ship at range 0–1 defends, before the Neutralize Results step, if you are in the attack arc, you may suffer 1<nonbreak><crit> damage to cancel 1<nonbreak><crit> result.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21630,6 +20274,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "While you coordinate, the ship you choose can perform an action only if that action is also on your action bar.",
+            "available_actions": [
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 5830,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_16",
+            "force_side": null,
+            "id": 245,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Squad Leader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "At the start of the Engagement Phase, you may choose 1 friendly ship at range 1. If you do, that ship treats its initiative as equal to yours until the end of the round.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21658,6 +20343,70 @@
             "subtitle": null,
             "upgrade_types": [
                 1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform an attack that is obstructed by an obstacle, roll 1 additional attack die.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_18",
+            "force_side": null,
+            "id": 247,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Trick Shot",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, you may spend 1<nonbreak><forcecharge>. If you do, engage at initiative 7 instead of your standard initiative value this phase.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+            "card_set_ids": [
+                1,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_19",
+            "force_side": null,
+            "id": 248,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Heightened Perception",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                17
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -21763,6 +20512,78 @@
             "weapon_range": null
         },
         {
+            "ability_text": "After you reveal your dial, you may perform 1 action.<return>If you do, you cannot perform another action during your activation.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_23",
+            "force_side": null,
+            "id": 252,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Advanced Sensors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you boost or barrel roll, you can move through and overlap obstacles.<return>After you move through or overlap an obstacle, you may spend 1<nonbreak><standardcharge> to ignore its effects until the end of the round.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_24",
+            "force_side": null,
+            "id": 253,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Collision Detector",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6626,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you perform an attack, if you have a lock on the defender, you may reroll 1 attack die. If you do, you cannot spend your lock during this attack.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21783,6 +20604,37 @@
             "initiative": null,
             "is_unique": false,
             "name": "Fire-Control System",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "During the System Phase, if you would drop or launch a bomb, you may launch it using the [5<nonbreak><straight>] template instead.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_set_ids": [
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_26",
+            "force_side": null,
+            "id": 255,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Trajectory Simulator",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21836,83 +20688,43 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "During the System Phase, if you would drop or launch a bomb, you may launch it using the [5<nonbreak><straight>] template instead.",
+            "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
             "card_set_ids": [
+                4,
                 5,
                 6
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "5",
             "faction_id": null,
-            "ffg_id": "XW_U_26",
+            "ffg_id": "XW_U_28",
             "force_side": null,
-            "id": 255,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "id": 257,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Trajectory Simulator",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5835,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_32",
-            "force_side": null,
-            "id": 261,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ion Cannon Turret",
+            "name": "Ion Cannon",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6645,
+                    "id": 6643,
                     "recurring": false,
-                    "statistic_id": 12,
+                    "statistic_id": 10,
                     "value": "3"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
-                4
+                3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 - 3"
         },
         {
             "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, all <hit>/<crit> results inflict jam tokens instead of damage.",
@@ -21993,48 +20805,144 @@
             "weapon_range": "1 - 3"
         },
         {
-            "ability_text": "<smallcaps>Attack (<focus>):</smallcaps> Spend 1<nonbreak><standardcharge>. If the defender is in your <bullseye>, you may spend 1 or more <standardcharge> to reroll that many attack dice.",
-            "available_actions": [],
+            "ability_text": "<smallcaps>Attack</smallcaps>",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5832,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
             "card_set_ids": [
-                5
+                4,
+                5,
+                6
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_36",
+            "ffg_id": "XW_U_31",
             "force_side": null,
-            "id": 265,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "id": 260,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Barrage Rockets",
+            "name": "Dorsal Turret",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6619,
+                    "id": 6633,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6621,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "5"
+                    "statistic_id": 12,
+                    "value": "2"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Attack:</smallcaps> If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5835,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+            "card_set_ids": [
+                4,
+                5,
                 6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_32",
+            "force_side": null,
+            "id": 261,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ion Cannon Turret",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6645,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. Change 1<nonbreak><hit> result to a <crit> result.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+            "card_set_ids": [
+                4,
+                5,
                 6
             ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_33",
+            "force_side": null,
+            "id": 262,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Adv. Proton Torpedoes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6615,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "5"
+                },
+                {
+                    "id": 6617,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                5
+            ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "1"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. If this attack hits, spend 1<nonbreak><hit> or <crit> result to cause the defender to suffer 1<nonbreak><hit> damage. All remaining <hit>/<crit> results inflict ion tokens instead of damage.",
@@ -22129,6 +21037,96 @@
             ],
             "weapon_no_bonus": true,
             "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Attack (<focus>):</smallcaps> Spend 1<nonbreak><standardcharge>. If the defender is in your <bullseye>, you may spend 1 or more <standardcharge> to reroll that many attack dice.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_36",
+            "force_side": null,
+            "id": 265,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Barrage Rockets",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6619,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6621,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "5"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6,
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. After this attack, you may perform this attack as a bonus attack against a different target at range 0–1 of the defender, ignoring the <targetlock> requirement.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_37",
+            "force_side": null,
+            "id": 266,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cluster Missiles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6623,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6625,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "4"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "1 - 2"
         },
         {
             "ability_text": "<smallcaps>Attack (<targetlock>):</smallcaps> Spend 1<nonbreak><standardcharge>. After this attack hits, each ship at range 0–1 of the defender exposes 1 of its damage cards.",
@@ -22267,38 +21265,6 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "While you defend, before attack dice are rolled, you may spend a lock you have on the attacker to roll 1 attack die. If you do, the attacker gains 1 jam token. Then, on a <hit> or <crit> result, gain 1 jam token.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_42",
-            "force_side": null,
-            "id": 271,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Freelance Slicer",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Attack (<focus>):</smallcaps> Spend 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22344,6 +21310,109 @@
             "weapon_range": "1 - 2"
         },
         {
+            "ability_text": "While you defend, before attack dice are rolled, you may spend a lock you have on the attacker to roll 1 attack die. If you do, the attacker gains 1 jam token. Then, on a <hit> or <crit> result, gain 1 jam token.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_42",
+            "force_side": null,
+            "id": 271,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Freelance Slicer",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Setup:</smallcaps> Lose 1<nonbreak><standardcharge>.<return><smallcaps>Action:</smallcaps> Recover 1<nonbreak><standardcharge>.<return><smallcaps>Action:</smallcaps> Spend 1<nonbreak><standardcharge> to recover 1 shield.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_43",
+            "force_side": null,
+            "id": 272,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "GNK “Gonk” Droid",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6636,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Setup:</smallcaps> After placing forces, choose 1 enemy ship and assign the <smallcaps>Listening Device</smallcaps> condition to it.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_44",
+            "force_side": null,
+            "id": 273,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Informant",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "At the end of the round, you may roll 1 attack die to repair 1 faceup damage card. Then on a <hit> result, expose 1 damage card.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22363,6 +21432,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Novice Technician",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform a <focus> action, gain 1 focus token.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_46",
+            "force_side": null,
+            "id": 275,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Perceptive Copilot",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -22456,6 +21558,38 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform a <turretarc> attack, after the Modify Defense Dice step, the defender removes 1 focus or calculate token.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_49",
+            "force_side": null,
+            "id": 278,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Hotshot Gunner",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -22587,6 +21721,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "After you reveal your dial, you may spend 1<nonbreak><standardcharge> and gain 1 disarm token to recover 1 shield.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+            "card_set_ids": [
+                1,
+                4,
+                6,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_53",
+            "force_side": null,
+            "id": 282,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "R2 Astromech",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6663,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "You can maintain up to 2 locks. Each lock must be on a different object.<return>After you perform a <targetlock> action, you may acquire a lock.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22702,6 +21876,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallcaps>Action:</smallcaps> Spend 1<nonbreak><standardcharge> to perform a <cloak> action.<return>At the start of the Planning Phase, roll 1 attack die. On a <focus> result, decloak or discard your cloak token.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_57",
+            "force_side": null,
+            "id": 286,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Cloaking Device",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6594,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Before you activate, you may spend 1<nonbreak><standardcharge>. If you do, until the end of the round, you can perform actions and execute red maneuvers, even while stressed.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_58",
+            "force_side": null,
+            "id": 287,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Contraband Cybernetics",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6631,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "After you are destroyed, each other ship at range 0–1 suffers 1<nonbreak><hit> damage.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22797,45 +22062,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mine</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Conner Net using the [1<nonbreak><straight>] template.<return>This card’s <standardcharge> cannot be recovered.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_64",
-            "force_side": null,
-            "id": 393,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Conner Nets",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6630,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Action:</smallcaps> Spend 1<nonbreak><standardcharge>. Drop 1 loose cargo using the [1<nonbreak><straight>] template.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22890,18 +22116,10 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Attack</smallcaps>",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5832,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
+            "ability_text": "Before you would suffer damage from an obstacle or from a friendly bomb detonating, you may spend 1<nonbreak><standardcharge>. If you do, prevent 1 damage.",
+            "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
             "card_set_ids": [
                 4,
                 5,
@@ -22910,60 +22128,35 @@
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_31",
+            "ffg_id": "XW_U_68",
             "force_side": null,
-            "id": 260,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+            "id": 292,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Dorsal Turret",
-            "restrictions": [],
+            "name": "Ablative Plating",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "LARGE"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6633,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                4
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<bitalic>Bomb</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Proton Bomb using the [1<nonbreak><straight>] template.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_65",
-            "force_side": null,
-            "id": 394,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Proton Bombs",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6655,
+                    "id": 6614,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -22971,88 +22164,50 @@
             ],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mine</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Proximity Mine using the [1<nonbreak><straight>] template.<return>This card’s <standardcharge> cannot be recovered.",
+            "ability_text": "After you perform a <slam> action, if you fully executed the maneuver, you may perform a white action on your action bar, treating that action as red.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
             "card_set_ids": [
                 4,
                 5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_66",
-            "force_side": null,
-            "id": 395,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Proximity Mines",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6662,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomb</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Seismic Charge with the [1<nonbreak><straight>] template.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8,
-                11
+                6
             ],
             "card_type_id": 2,
             "cost": "3",
             "faction_id": null,
-            "ffg_id": "XW_U_67",
+            "ffg_id": "XW_U_69",
             "force_side": null,
-            "id": 396,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "id": 293,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Seismic Charges",
-            "restrictions": [],
+            "name": "Advanced SLAM",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Slam",
+                            "pk": 13,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6666,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23187,6 +22342,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>For those who cannot afford an enhanced shield generator, bolting additional plates onto the hull of a ship can serve as an adequate substitute.</flavor>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "*",
+            "faction_id": null,
+            "ffg_id": "XW_U_73",
+            "force_side": null,
+            "id": 297,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Hull Upgrade",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6642,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "+1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you perform a <torpedo> or <missile> attack, after rolling attack dice, you may cancel all dice results to recover 1<nonbreak><standardcharge> you spent as a cost for the attack.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23291,54 +22486,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallbody>Before rolling defense dice, you may spend 1 calculate token to guess aloud a number 1 or higher. If you do and you roll exactly that many <evade> results, add 1<nonbreak><evade> result.</smallbody><return><smallbody>After you perform the <calculate> action, gain 1 calculate token.</smallbody>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5827,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_80",
-            "force_side": null,
-            "id": 304,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "C-3PO",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "While you defend, if your <standardcharge> is active, roll 1 additional defense die.<return>After you suffer damage, lose 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23422,6 +22569,94 @@
             "subtitle": null,
             "upgrade_types": [
                 14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform a <focus> action, you may treat it as red. If you do, gain 1 additional focus token for each enemy ship at range 0–1, to a maximum of 2.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_79",
+            "force_side": null,
+            "id": 303,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Baze Malbus",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody>Before rolling defense dice, you may spend 1 calculate token to guess aloud a number 1 or higher. If you do and you roll exactly that many <evade> results, add 1<nonbreak><evade> result.</smallbody><return><smallbody>After you perform the <calculate> action, gain 1 calculate token.</smallbody>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5827,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "12",
+            "faction_id": null,
+            "ffg_id": "XW_U_80",
+            "force_side": null,
+            "id": 304,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "C-3PO",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23514,6 +22749,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "During the Perform Action step, you may perform 1 action, even while stressed. After you perform an action while stressed, suffer 1<nonbreak><hit> damage unless you expose 1 of your damage cards.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_83",
+            "force_side": null,
+            "id": 307,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "You can execute red maneuvers even while stressed. After you fully execute a red maneuver, if you have 3 or more stress tokens, remove 1 stress token and suffer 1<nonbreak><hit> damage.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23531,6 +22806,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "Hera Syndulla",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "If a friendly ship at range 0–3 would gain a focus token, it may gain 1 evade token instead.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_85",
+            "force_side": null,
+            "id": 309,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Jyn Erso",
             "restrictions": [
                 [
                     {
@@ -23688,6 +23003,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "After you defend, if the attack hit, you may acquire a lock on the attacker.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_89",
+            "force_side": null,
+            "id": 313,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Magva Yarro",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Decrease the difficulty of your bank maneuvers (<leftbank> and <rightbank>).",
             "available_actions": [],
             "available_upgrades": [],
@@ -23705,6 +23060,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "Nien Nunb",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "During the End Phase, if you are damaged and not shielded, you may roll 1 attack die to recover 1 shield. On a <hit> result, expose 1 of your damage cards.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_91",
+            "force_side": null,
+            "id": 315,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "R2-D2",
             "restrictions": [
                 [
                     {
@@ -23768,23 +23163,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "During the End Phase, if you are damaged and not shielded, you may roll 1 attack die to recover 1 shield. On a <hit> result, expose 1 of your damage cards.",
+            "ability_text": "While you perform an attack, you may suffer 1<nonbreak><hit> damage to change all of your <focus> results to <crit> results.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
             "card_set_ids": [
-                4
+                2
             ],
             "card_type_id": 2,
             "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_91",
+            "ffg_id": "XW_U_93",
             "force_side": null,
-            "id": 315,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "id": 317,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "R2-D2",
+            "name": "Saw Gerrera",
             "restrictions": [
                 [
                     {
@@ -23803,6 +23198,86 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "You can perform primary attacks at range 0. Enemy ships at range 0 can perform primary attacks against you.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_94",
+            "force_side": null,
+            "id": 318,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "“Zeb” Orrelios",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform a primary attack, if you are focused, you may perform a bonus <turretarc> attack against a ship you have not already attacked this round.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "14",
+            "faction_id": null,
+            "ffg_id": "XW_U_95",
+            "force_side": null,
+            "id": 319,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Bistan",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23895,46 +23370,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "While you perform an attack, you may suffer 1<nonbreak><hit> damage to change all of your <focus> results to <crit> results.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_93",
-            "force_side": null,
-            "id": 317,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Saw Gerrera",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "At the start of the Engagement Phase, you may spend 1<nonbreak><forcecharge> to rotate your <turretarc> indicator.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23977,6 +23412,46 @@
             "subtitle": null,
             "upgrade_types": [
                 16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Action:</smallcaps> Spend 1<nonbreak><standardcharge> from another equipped upgrade to recover 1 shield. <return><smallcaps>Action:</smallcaps> Spend 2 shields to recover 1 non-recurring <standardcharge> on an equipped upgrade.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_99",
+            "force_side": null,
+            "id": 323,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24076,23 +23551,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "You can perform primary attacks at range 0. Enemy ships at range 0 can perform primary attacks against you.",
+            "ability_text": "You can dock 1 attack shuttle or <italic>Sheathipede</italic>-class shuttle.<return>Your docked ships can deploy only from your rear guides.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 2,
-            "cost": "1",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_94",
+            "ffg_id": "XW_U_102",
             "force_side": null,
-            "id": 318,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "id": 326,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "“Zeb” Orrelios",
+            "name": "<italic>Ghost</italic>",
             "restrictions": [
                 [
                     {
@@ -24102,6 +23577,15 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 23,
+                            "raw_name": "VCX-100 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
@@ -24110,40 +23594,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you perform an attack that is obstructed by an obstacle, roll 1 additional attack die.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_18",
-            "force_side": null,
-            "id": 247,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Trick Shot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24311,6 +23762,103 @@
             "weapon_range": null
         },
         {
+            "ability_text": "You can dock at range 0–1.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_106",
+            "force_side": null,
+            "id": 330,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "<italic>Phantom</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 32,
+                            "raw_name": "Attack Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    },
+                    {
+                        "kwargs": {
+                            "pk": 8,
+                            "raw_name": "Sheathipede-class Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Before you activate, you may flip this card.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+            "card_set_ids": [
+                2,
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_107",
+            "force_side": null,
+            "id": 331,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Pivot Wing (Open)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 15,
+                            "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you defend, roll 1 fewer defense die.<Return>After you execute a [0<nonbreak><stop>] maneuver, you may rotate your ship 90º or 180º.<return>Before you activate, you may flip this card.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24332,6 +23880,49 @@
                         "kwargs": {
                             "pk": 15,
                             "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Before you activate, you may flip this card.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_set_ids": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_108",
+            "force_side": null,
+            "id": 333,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Servomotor S-foils (Open)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 33,
+                            "raw_name": "T-65 X-wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -24402,34 +23993,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Before you activate, you may flip this card.",
+            "ability_text": "After another friendly ship at range 0–3 defends, if it is destroyed, the attacker gains 2 stress tokens.<return>While a friendly ship at range 0–3 performs an attack against a stressed ship, it may reroll 1 attack die.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
             "card_set_ids": [
-                1,
-                2,
-                4,
-                7
+                5
             ],
             "card_type_id": 2,
-            "cost": "0",
+            "cost": "10",
             "faction_id": null,
-            "ffg_id": "XW_U_108",
+            "ffg_id": "XW_U_109",
             "force_side": null,
-            "id": 333,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "id": 335,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Servomotor S-foils (Open)",
+            "is_unique": true,
+            "name": "Admiral Sloane",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "pk": 33,
-                            "raw_name": "T-65 X-wing"
+                            "name": "Galactic Empire",
+                            "pk": 2
                         },
-                        "type": "SHIP_TYPE"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -24439,7 +24027,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                18
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24590,6 +24178,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "During the Activation Phase, enemy ships at range 0–1 cannot remove stress tokens.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_113",
+            "force_side": null,
+            "id": 339,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Death Troopers",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8,
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallcaps>Setup:</smallcaps> Before placing forces, assign the <smallcaps>Optimized Prototype</smallcaps> condition to another friendly ship.",
             "available_actions": [
                 {
@@ -24733,6 +24362,111 @@
             "weapon_range": null
         },
         {
+            "ability_text": "During the System Phase, you may spend 2 <standardcharge>. If you do, each friendly ship may acquire a lock on a ship that you have locked.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_117",
+            "force_side": null,
+            "id": 343,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Grand Moff Tarkin",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6601,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "During the End Phase, enemy ships at range 1–2 cannot remove jam tokens.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_118",
+            "force_side": null,
+            "id": 344,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "ISB Slicer",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "At the start of the Engagement Phase, if you are damaged, you may perform a red <reinforce> action.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24838,23 +24572,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "During the End Phase, enemy ships at range 1–2 cannot remove jam tokens.",
+            "ability_text": "If an enemy ship at range 0–1 would gain a stress token, you may spend 1<nonbreak><forcecharge> to have it gain 1 jam or tractor token instead.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
             "card_set_ids": [
-                3
+                5
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "12",
             "faction_id": null,
-            "ffg_id": "XW_U_118",
+            "ffg_id": "XW_U_121",
             "force_side": null,
-            "id": 344,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "id": 347,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "ISB Slicer",
+            "is_unique": true,
+            "name": "Seventh Sister",
             "restrictions": [
                 [
                     {
@@ -24869,7 +24603,14 @@
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [],
+            "statistics": [
+                {
+                    "id": 6613,
+                    "recurring": false,
+                    "statistic_id": 4,
+                    "value": "+1"
+                }
+            ],
             "subtitle": null,
             "upgrade_types": [
                 8
@@ -24925,94 +24666,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "If an enemy ship at range 0–1 would gain a stress token, you may spend 1<nonbreak><forcecharge> to have it gain 1 jam or tractor token instead.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_121",
-            "force_side": null,
-            "id": 347,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Seventh Sister",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6613,
-                    "recurring": false,
-                    "statistic_id": 4,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Before you activate, you may flip this card.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
-            "card_set_ids": [
-                2,
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_107",
-            "force_side": null,
-            "id": 331,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Pivot Wing (Open)",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 15,
-                            "raw_name": "UT-60D U-wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "After you partially execute a maneuver, you may perform 1 white action, treating that action as red.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25062,38 +24715,29 @@
             "weapon_range": null
         },
         {
-            "ability_text": "After you perform a <coordinate> action, you may choose an enemy ship at range 0–3 of the ship you coordinated. If you do, acquire a lock on that enemy ship, ignoring range restrictions.",
+            "ability_text": "While you have exactly 1 disarm token, you can still perform <torpedo> and <missile> attacks against targets you have locked. If you do, you cannot spend your lock during the attack.<return>Add <torpedo> and <missile> slots.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_124",
+            "ffg_id": "XW_U_125",
             "force_side": null,
-            "id": 391,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "id": 350,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
             "initiative": null,
-            "is_unique": true,
-            "name": "<italic>ST-321</italic>",
+            "is_unique": false,
+            "name": "Os-1 Arsenal Loadout",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 26,
-                            "raw_name": "Lambda-class T-4a Shuttle"
+                            "pk": 14,
+                            "raw_name": "Alpha-class Star Wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -25105,7 +24749,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                15
+                18
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25146,6 +24790,60 @@
             "subtitle": null,
             "upgrade_types": [
                 18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the Engagement Phase, you may choose 1 enemy ship at range 0–1. If you do, you gain 1 calculate token unless that ship chooses to gain 1 stress token.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_127",
+            "force_side": null,
+            "id": 352,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "0-0-0",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 338
+                        },
+                        "type": "CARD_INCLUDED"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 93
+                        },
+                        "type": "CARD_INCLUDED"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25249,6 +24947,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "Cad Bane",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "During the End Phase, you may choose 2 <illicit> upgrades equipped to friendly ships at range 0–1. If you do, you may exchange these upgrades.<return><smallcaps>End of Game:</smallcaps> Return all <illicit> upgrades to their original ships.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_131",
+            "force_side": null,
+            "id": 356,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Cikatro Vizago",
             "restrictions": [
                 [
                     {
@@ -25385,6 +25123,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "Ketsu Onyo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you defend, if the attacker is stressed, you may remove 1 stress from the attacker to change 1 of your blank/<focus> results to an <evade> result.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_135",
+            "force_side": null,
+            "id": 360,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Latts Razzi",
             "restrictions": [
                 [
                     {
@@ -25563,6 +25341,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "After you perform a primary attack that misses, if you are not stressed, you <bold>must</bold> receive 1 stress token to perform a bonus primary attack against the same target.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_139",
+            "force_side": null,
+            "id": 364,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Bossk",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "While you perform an attack, you may change 1<nonbreak><hit> result to a <crit> result for each stress token the defender has.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25711,6 +25529,133 @@
             "weapon_range": null
         },
         {
+            "ability_text": "After you fully execute a maneuver, if you have not dropped or launched a device this round, you may drop 1 bomb.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_143",
+            "force_side": null,
+            "id": 368,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "“Genius”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you perform an attack against a defender in your <frontarc>, you may spend 1<nonbreak><standardcharge> to reroll 1 attack die. If the rerolled result is a <crit> result, suffer 1<nonbreak><crit> damage.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_144",
+            "force_side": null,
+            "id": 369,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "R5-P8",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6612,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "You can perform attacks against friendly ships.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_145",
+            "force_side": null,
+            "id": 370,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "R5-TK",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Add <bomb> slot.",
             "available_actions": [
                 {
@@ -25818,23 +25763,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "While you perform an attack against a defender in your <frontarc>, you may spend 1<nonbreak><standardcharge> to reroll 1 attack die. If the rerolled result is a <crit> result, suffer 1<nonbreak><crit> damage.",
+            "ability_text": "1 Z-95-AF4 headhunter can dock with you.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "4",
+            "cost": "1",
             "faction_id": null,
-            "ffg_id": "XW_U_144",
+            "ffg_id": "XW_U_148",
             "force_side": null,
-            "id": 369,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "id": 373,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "R5-P8",
+            "name": "<italic>Hound’s Tooth</italic>",
             "restrictions": [
                 [
                     {
@@ -25844,22 +25789,73 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 24,
+                            "raw_name": "YV-666 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6612,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "3"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                10
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "You have the pilot ability of each other friendly ship with the <sabold>IG-2000</sabold> upgrade.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_149",
+            "force_side": null,
+            "id": 374,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "<italic>IG-2000</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 21,
+                            "raw_name": "Aggressor Assault Fighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25971,23 +25967,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "You have the pilot ability of each other friendly ship with the <sabold>IG-2000</sabold> upgrade.",
+            "ability_text": "While you perform a primary attack, if the defender is in your <frontarc>, roll 1 additional attack die.<return>Remove <crew> slot. Add <astro> slot.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_149",
+            "ffg_id": "XW_U_152",
             "force_side": null,
-            "id": 374,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "id": 377,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "<italic>IG-2000</italic>",
+            "is_unique": true,
+            "name": "<italic>Punishing One</italic>",
             "restrictions": [
                 [
                     {
@@ -26001,8 +25997,8 @@
                 [
                     {
                         "kwargs": {
-                            "pk": 21,
-                            "raw_name": "Aggressor Assault Fighter"
+                            "pk": 45,
+                            "raw_name": "JumpMaster 5000"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -26172,23 +26168,72 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Setup:</smallcaps> Equip this side faceup.<return>While you defend, you may flip this card. If you do, the attacker must reroll all attack dice.",
+            "ability_text": "After you fail an action, if you have no green tokens, you may perform a <focus> action.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_156",
+            "force_side": null,
+            "id": 381,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Composure",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "At the start of the End Phase, you may spend 1 focus token to repair 1 of your faceup damage cards.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_158",
+            "ffg_id": "XW_U_157",
             "force_side": null,
-            "id": 384,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+            "id": 382,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "L3–37",
+            "name": "Chewbacca",
             "restrictions": [
                 [
                     {
@@ -26250,40 +26295,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "After you fail an action, if you have no green tokens, you may perform a <focus> action.",
+            "ability_text": "<smallcaps>Setup:</smallcaps> Equip this side faceup.<return>While you defend, you may flip this card. If you do, the attacker must reroll all attack dice.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_156",
+            "ffg_id": "XW_U_158",
             "force_side": null,
-            "id": 381,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "id": 384,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Composure",
+            "is_unique": true,
+            "name": "L3–37",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "STRESS"
+                            "name": "Scum and Villainy",
+                            "pk": 3
                         },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -26293,7 +26329,47 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                1
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you roll dice, you may spend 1 green token to reroll up to 2 of your results.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_159",
+            "force_side": null,
+            "id": 385,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Lando Calrissian",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26316,6 +26392,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "Tobias Beckett",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "While you move and perform attacks, you ignore obstacles that you are locking.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_161",
+            "force_side": null,
+            "id": 387,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "Qi’ra",
             "restrictions": [
                 [
                     {
@@ -26369,46 +26485,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "After you roll dice, you may spend 1 green token to reroll up to 2 of your results.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_159",
-            "force_side": null,
-            "id": 385,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Lando Calrissian",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Before you engage, you may perform a red <focus> action.",
             "available_actions": [],
             "available_upgrades": [],
@@ -26444,331 +26520,6 @@
             "subtitle": null,
             "upgrade_types": [
                 16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While you move and perform attacks, you ignore obstacles that you are locking.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_161",
-            "force_side": null,
-            "id": 387,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "Qi’ra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you receive a stress token, you may roll 1 attack die to remove it. On a <hit> result, suffer 1<nonbreak><hit> damage.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5851,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5852,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5853,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_5",
-            "force_side": null,
-            "id": 5,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "Jek Porkins",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6688,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6689,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6690,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6691,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Six",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "You can perform primary attacks at range 0.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6363,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6364,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6365,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6366,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6367,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_146",
-            "force_side": null,
-            "id": 146,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "Captain Oicunn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7244,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7245,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7246,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7247,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Inspired Tactician",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "While an enemy ship at range 0 defends, it rolls 1 fewer defense die.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_7",
-            "force_side": null,
-            "id": 236,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Intimidation",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "After you perform a <focus> action, gain 1 focus token.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_46",
-            "force_side": null,
-            "id": 275,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Perceptive Copilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "You can perform attacks against friendly ships.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_145",
-            "force_side": null,
-            "id": 370,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "R5-TK",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26818,6 +26569,255 @@
             "subtitle": null,
             "upgrade_types": [
                 15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "After you perform a <coordinate> action, you may choose an enemy ship at range 0–3 of the ship you coordinated. If you do, acquire a lock on that enemy ship, ignoring range restrictions.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_124",
+            "force_side": null,
+            "id": 391,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "<italic>ST-321</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 26,
+                            "raw_name": "Lambda-class T-4a Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallbody><bitalic>Bomb</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Bomblet with the [1<nonbreak><straight>] template.<return>At the start of the Activation Phase, you may spend 1 shield to recover 2 <standardcharge>.</smallbody>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_63",
+            "force_side": null,
+            "id": 392,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Bomblet Generator",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6622,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12,
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mine</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Conner Net using the [1<nonbreak><straight>] template.<return>This card’s <standardcharge> cannot be recovered.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_64",
+            "force_side": null,
+            "id": 393,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Conner Nets",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6630,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomb</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Proton Bomb using the [1<nonbreak><straight>] template.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_65",
+            "force_side": null,
+            "id": 394,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Proton Bombs",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6655,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mine</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Proximity Mine using the [1<nonbreak><straight>] template.<return>This card’s <standardcharge> cannot be recovered.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_66",
+            "force_side": null,
+            "id": 395,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Proximity Mines",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6662,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomb</bitalic><return>During the System Phase, you may spend 1<nonbreak><standardcharge> to drop a Seismic Charge with the [1<nonbreak><straight>] template.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_67",
+            "force_side": null,
+            "id": 396,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Seismic Charges",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6666,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
             ],
             "weapon_no_bonus": false,
             "weapon_range": null

--- a/translation_helper/api_export_es.json
+++ b/translation_helper/api_export_es.json
@@ -6,21 +6,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 6673,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 6674,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 6675,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -53,25 +53,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 7588,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 7589,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 7590,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 7591,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -88,21 +88,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5842,
+                    "id": 6676,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5843,
+                    "id": 6677,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5844,
+                    "id": 6678,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -134,31 +134,31 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6675,
+                    "id": 7592,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6676,
+                    "id": 7593,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6677,
+                    "id": 7594,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6678,
+                    "id": 7595,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 6679,
+                    "id": 7596,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -175,21 +175,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 6679,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 6680,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 6681,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -221,25 +221,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 7597,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 7598,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 7599,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 7600,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -256,21 +256,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5848,
+                    "id": 6682,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5849,
+                    "id": 6683,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5850,
+                    "id": 6684,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -303,25 +303,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6684,
+                    "id": 7601,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6685,
+                    "id": 7602,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6686,
+                    "id": 7603,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6687,
+                    "id": 7604,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -338,21 +338,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5851,
+                    "id": 6685,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5852,
+                    "id": 6686,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5853,
+                    "id": 6687,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -384,25 +384,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6688,
+                    "id": 7605,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6689,
+                    "id": 7606,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6690,
+                    "id": 7607,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6691,
+                    "id": 7608,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -419,21 +419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5854,
+                    "id": 6688,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5855,
+                    "id": 6689,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5856,
+                    "id": 6690,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -466,25 +466,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6692,
+                    "id": 7609,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6693,
+                    "id": 7610,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6694,
+                    "id": 7611,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6695,
+                    "id": 7612,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -501,21 +501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5857,
+                    "id": 6691,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5858,
+                    "id": 6692,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5859,
+                    "id": 6693,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -547,25 +547,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6696,
+                    "id": 7613,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6697,
+                    "id": 7614,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6698,
+                    "id": 7615,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6699,
+                    "id": 7616,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -582,21 +582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 6694,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 6695,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 6696,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -629,25 +629,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 7617,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6701,
+                    "id": 7618,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 7619,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6703,
+                    "id": 7620,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -664,21 +664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5863,
+                    "id": 6697,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5864,
+                    "id": 6698,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5865,
+                    "id": 6699,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -710,25 +710,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6704,
+                    "id": 7621,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6705,
+                    "id": 7622,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6706,
+                    "id": 7623,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6707,
+                    "id": 7624,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -745,21 +745,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5866,
+                    "id": 6700,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5867,
+                    "id": 6701,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5868,
+                    "id": 6702,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -793,25 +793,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6708,
+                    "id": 7625,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6709,
+                    "id": 7626,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6710,
+                    "id": 7627,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6711,
+                    "id": 7628,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -828,21 +828,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5869,
+                    "id": 6703,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5870,
+                    "id": 6704,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5871,
+                    "id": 6705,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -875,25 +875,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6712,
+                    "id": 7629,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6713,
+                    "id": 7630,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6714,
+                    "id": 7631,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6715,
+                    "id": 7632,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -910,21 +910,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5872,
+                    "id": 6706,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5873,
+                    "id": 6707,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5874,
+                    "id": 6708,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -956,25 +956,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6716,
+                    "id": 7633,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6717,
+                    "id": 7634,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6718,
+                    "id": 7635,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6719,
+                    "id": 7636,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -991,28 +991,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5875,
+                    "id": 6709,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5876,
+                    "id": 6710,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5877,
+                    "id": 6711,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5878,
+                    "id": 6712,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1046,25 +1046,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6720,
+                    "id": 7637,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6721,
+                    "id": 7638,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6722,
+                    "id": 7639,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6723,
+                    "id": 7640,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1081,28 +1081,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5879,
+                    "id": 6713,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5880,
+                    "id": 6714,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5881,
+                    "id": 6715,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5882,
+                    "id": 6716,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1137,25 +1137,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6724,
+                    "id": 7641,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6725,
+                    "id": 7642,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6726,
+                    "id": 7643,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6727,
+                    "id": 7644,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1172,28 +1172,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5883,
+                    "id": 6717,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5884,
+                    "id": 6718,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5885,
+                    "id": 6719,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5886,
+                    "id": 6720,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1228,25 +1228,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6728,
+                    "id": 7645,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6729,
+                    "id": 7646,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6730,
+                    "id": 7647,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6731,
+                    "id": 7648,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1263,28 +1263,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 6721,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 6722,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 6723,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 6724,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1318,25 +1318,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 7649,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 7650,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 7651,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 7652,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1353,28 +1353,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5891,
+                    "id": 6725,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5892,
+                    "id": 6726,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5893,
+                    "id": 6727,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5894,
+                    "id": 6728,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1409,25 +1409,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6736,
+                    "id": 7653,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6737,
+                    "id": 7654,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6738,
+                    "id": 7655,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6739,
+                    "id": 7656,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1444,28 +1444,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 6729,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 6730,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "id": 6731,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "id": 6732,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1499,25 +1499,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 7657,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 7658,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6742,
+                    "id": 7659,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6743,
+                    "id": 7660,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1534,35 +1534,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5899,
+                    "id": 6733,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5900,
+                    "id": 6734,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5901,
+                    "id": 6735,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5902,
+                    "id": 6736,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5903,
+                    "id": 6737,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1591,25 +1591,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6744,
+                    "id": 7661,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6745,
+                    "id": 7662,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6746,
+                    "id": 7663,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6747,
+                    "id": 7664,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1626,35 +1626,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
+                    "id": 6738,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5905,
+                    "id": 6739,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 6740,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
+                    "id": 6741,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 6742,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1683,25 +1683,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 7665,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 7666,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6750,
+                    "id": 7667,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 7668,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1718,35 +1718,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5909,
+                    "id": 6743,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5910,
+                    "id": 6744,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5911,
+                    "id": 6745,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5912,
+                    "id": 6746,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5913,
+                    "id": 6747,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1775,25 +1775,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6752,
+                    "id": 7669,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6753,
+                    "id": 7670,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6754,
+                    "id": 7671,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6755,
+                    "id": 7672,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1810,35 +1810,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5914,
+                    "id": 6748,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5915,
+                    "id": 6749,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5916,
+                    "id": 6750,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5917,
+                    "id": 6751,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5918,
+                    "id": 6752,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1866,25 +1866,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6756,
+                    "id": 7673,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6757,
+                    "id": 7674,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6758,
+                    "id": 7675,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6759,
+                    "id": 7676,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1901,21 +1901,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5919,
+                    "id": 6753,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5920,
+                    "id": 6754,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5921,
+                    "id": 6755,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1948,25 +1948,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6760,
+                    "id": 7677,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6761,
+                    "id": 7678,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6762,
+                    "id": 7679,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6763,
+                    "id": 7680,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -1983,21 +1983,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5922,
+                    "id": 6756,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5923,
+                    "id": 6757,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5924,
+                    "id": 6758,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2030,25 +2030,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6764,
+                    "id": 7681,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6765,
+                    "id": 7682,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6766,
+                    "id": 7683,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6767,
+                    "id": 7684,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2065,21 +2065,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5925,
+                    "id": 6759,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5926,
+                    "id": 6760,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5927,
+                    "id": 6761,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2112,25 +2112,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6768,
+                    "id": 7685,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6769,
+                    "id": 7686,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6770,
+                    "id": 7687,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6771,
+                    "id": 7688,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2147,21 +2147,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5928,
+                    "id": 6762,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5929,
+                    "id": 6763,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5930,
+                    "id": 6764,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2193,25 +2193,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6772,
+                    "id": 7689,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6773,
+                    "id": 7690,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6774,
+                    "id": 7691,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6775,
+                    "id": 7692,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2228,21 +2228,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5931,
+                    "id": 6765,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5932,
+                    "id": 6766,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5933,
+                    "id": 6767,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2272,25 +2272,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6776,
+                    "id": 7693,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6777,
+                    "id": 7694,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6778,
+                    "id": 7695,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6779,
+                    "id": 7696,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2307,21 +2307,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5934,
+                    "id": 6768,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5935,
+                    "id": 6769,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5936,
+                    "id": 6770,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2351,25 +2351,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6780,
+                    "id": 7697,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6781,
+                    "id": 7698,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6782,
+                    "id": 7699,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6783,
+                    "id": 7700,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2386,21 +2386,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5937,
+                    "id": 6771,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5938,
+                    "id": 6772,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5939,
+                    "id": 6773,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2430,25 +2430,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6784,
+                    "id": 7701,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6785,
+                    "id": 7702,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6786,
+                    "id": 7703,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6787,
+                    "id": 7704,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2465,21 +2465,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5940,
+                    "id": 6774,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5941,
+                    "id": 6775,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5942,
+                    "id": 6776,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2508,25 +2508,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6788,
+                    "id": 7705,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6789,
+                    "id": 7706,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6790,
+                    "id": 7707,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6791,
+                    "id": 7708,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2543,21 +2543,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5943,
+                    "id": 6777,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5944,
+                    "id": 6778,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5945,
+                    "id": 6779,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2588,25 +2588,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6792,
+                    "id": 7709,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6793,
+                    "id": 7710,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6794,
+                    "id": 7711,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6795,
+                    "id": 7712,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2623,21 +2623,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5946,
+                    "id": 6780,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5947,
+                    "id": 6781,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5948,
+                    "id": 6782,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2668,25 +2668,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6796,
+                    "id": 7713,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6797,
+                    "id": 7714,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6798,
+                    "id": 7715,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6799,
+                    "id": 7716,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2703,21 +2703,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5949,
+                    "id": 6783,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5950,
+                    "id": 6784,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5951,
+                    "id": 6785,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2747,25 +2747,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6800,
+                    "id": 7717,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6801,
+                    "id": 7718,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6802,
+                    "id": 7719,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6803,
+                    "id": 7720,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2782,21 +2782,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5952,
+                    "id": 6786,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5953,
+                    "id": 6787,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5954,
+                    "id": 6788,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2828,25 +2828,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6804,
+                    "id": 7721,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6805,
+                    "id": 7722,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6806,
+                    "id": 7723,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6807,
+                    "id": 7724,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2863,21 +2863,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5955,
+                    "id": 6789,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5956,
+                    "id": 6790,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5957,
+                    "id": 6791,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2909,25 +2909,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6808,
+                    "id": 7725,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6809,
+                    "id": 7726,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6810,
+                    "id": 7727,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6811,
+                    "id": 7728,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2944,21 +2944,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5958,
+                    "id": 6792,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5959,
+                    "id": 6793,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5960,
+                    "id": 6794,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2990,31 +2990,31 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6812,
+                    "id": 7729,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6813,
+                    "id": 7730,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6814,
+                    "id": 7731,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6815,
+                    "id": 7732,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6816,
+                    "id": 7733,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3031,21 +3031,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5961,
+                    "id": 6795,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5962,
+                    "id": 6796,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5963,
+                    "id": 6797,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -3076,25 +3076,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6817,
+                    "id": 7734,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6818,
+                    "id": 7735,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6819,
+                    "id": 7736,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6820,
+                    "id": 7737,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3111,14 +3111,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5964,
+                    "id": 6798,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5965,
+                    "id": 6799,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3150,31 +3150,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6821,
+                    "id": 7738,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6822,
+                    "id": 7739,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6823,
+                    "id": 7740,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6824,
+                    "id": 7741,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6825,
+                    "id": 7742,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3191,14 +3191,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5966,
+                    "id": 6800,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5967,
+                    "id": 6801,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3230,37 +3230,37 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6826,
+                    "id": 7743,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6827,
+                    "id": 7744,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6828,
+                    "id": 7745,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6829,
+                    "id": 7746,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6830,
+                    "id": 7747,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6831,
+                    "id": 7748,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3277,14 +3277,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5968,
+                    "id": 6802,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5969,
+                    "id": 6803,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3316,31 +3316,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6832,
+                    "id": 7749,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6833,
+                    "id": 7750,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6834,
+                    "id": 7751,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6835,
+                    "id": 7752,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6836,
+                    "id": 7753,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3357,14 +3357,14 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 5970,
+                    "id": 6804,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5971,
+                    "id": 6805,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3396,31 +3396,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6837,
+                    "id": 7754,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6838,
+                    "id": 7755,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6839,
+                    "id": 7756,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6840,
+                    "id": 7757,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6841,
+                    "id": 7758,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3437,35 +3437,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5972,
+                    "id": 6806,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5973,
+                    "id": 6807,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5974,
+                    "id": 6808,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5975,
+                    "id": 6809,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5976,
+                    "id": 6810,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3498,25 +3498,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6842,
+                    "id": 7759,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6843,
+                    "id": 7760,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6844,
+                    "id": 7761,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6845,
+                    "id": 7762,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3533,35 +3533,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5977,
+                    "id": 6811,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5978,
+                    "id": 6812,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5979,
+                    "id": 6813,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5980,
+                    "id": 6814,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5981,
+                    "id": 6815,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3594,25 +3594,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6846,
+                    "id": 7763,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6847,
+                    "id": 7764,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6848,
+                    "id": 7765,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6849,
+                    "id": 7766,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3629,35 +3629,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5982,
+                    "id": 6816,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5983,
+                    "id": 6817,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5984,
+                    "id": 6818,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5985,
+                    "id": 6819,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5986,
+                    "id": 6820,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3690,25 +3690,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6850,
+                    "id": 7767,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6851,
+                    "id": 7768,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6852,
+                    "id": 7769,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6853,
+                    "id": 7770,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3725,35 +3725,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5987,
+                    "id": 6821,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5988,
+                    "id": 6822,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5989,
+                    "id": 6823,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5990,
+                    "id": 6824,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5991,
+                    "id": 6825,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3785,25 +3785,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6854,
+                    "id": 7771,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6855,
+                    "id": 7772,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6856,
+                    "id": 7773,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6857,
+                    "id": 7774,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3820,21 +3820,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5992,
+                    "id": 6826,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5993,
+                    "id": 6827,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5994,
+                    "id": 6828,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3863,25 +3863,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6858,
+                    "id": 7775,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6859,
+                    "id": 7776,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6860,
+                    "id": 7777,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6861,
+                    "id": 7778,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3898,21 +3898,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5995,
+                    "id": 6829,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5996,
+                    "id": 6830,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5997,
+                    "id": 6831,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3941,19 +3941,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6862,
+                    "id": 7779,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6863,
+                    "id": 7780,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6864,
+                    "id": 7781,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -3970,21 +3970,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5998,
+                    "id": 6832,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5999,
+                    "id": 6833,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6000,
+                    "id": 6834,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4012,19 +4012,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6865,
+                    "id": 7782,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6866,
+                    "id": 7783,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6867,
+                    "id": 7784,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4041,21 +4041,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6001,
+                    "id": 6835,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6002,
+                    "id": 6836,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6003,
+                    "id": 6837,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4083,19 +4083,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6868,
+                    "id": 7785,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6869,
+                    "id": 7786,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6870,
+                    "id": 7787,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4112,35 +4112,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6004,
+                    "id": 6838,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6005,
+                    "id": 6839,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6006,
+                    "id": 6840,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6007,
+                    "id": 6841,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6008,
+                    "id": 6842,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4172,25 +4172,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6871,
+                    "id": 7788,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6872,
+                    "id": 7789,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6873,
+                    "id": 7790,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6874,
+                    "id": 7791,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4207,35 +4207,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6009,
+                    "id": 6843,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6010,
+                    "id": 6844,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6011,
+                    "id": 6845,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6012,
+                    "id": 6846,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6013,
+                    "id": 6847,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4267,25 +4267,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6875,
+                    "id": 7792,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6876,
+                    "id": 7793,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6877,
+                    "id": 7794,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6878,
+                    "id": 7795,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4302,35 +4302,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6014,
+                    "id": 6848,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6015,
+                    "id": 6849,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6016,
+                    "id": 6850,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6017,
+                    "id": 6851,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6018,
+                    "id": 6852,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4362,25 +4362,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6879,
+                    "id": 7796,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6880,
+                    "id": 7797,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6881,
+                    "id": 7798,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6882,
+                    "id": 7799,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4397,35 +4397,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6019,
+                    "id": 6853,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6020,
+                    "id": 6854,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6021,
+                    "id": 6855,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6022,
+                    "id": 6856,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6023,
+                    "id": 6857,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4456,25 +4456,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6883,
+                    "id": 7800,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6884,
+                    "id": 7801,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6885,
+                    "id": 7802,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6886,
+                    "id": 7803,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4491,21 +4491,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6024,
+                    "id": 6858,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6025,
+                    "id": 6859,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6026,
+                    "id": 6860,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4538,25 +4538,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6887,
+                    "id": 7804,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6888,
+                    "id": 7805,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6889,
+                    "id": 7806,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6890,
+                    "id": 7807,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4573,21 +4573,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6861,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6862,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "id": 6863,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4621,25 +4621,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6891,
+                    "id": 7808,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6892,
+                    "id": 7809,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6893,
+                    "id": 7810,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6894,
+                    "id": 7811,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4656,21 +4656,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6030,
+                    "id": 6864,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6031,
+                    "id": 6865,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6032,
+                    "id": 6866,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4703,25 +4703,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6895,
+                    "id": 7812,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6896,
+                    "id": 7813,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6897,
+                    "id": 7814,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6898,
+                    "id": 7815,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4738,21 +4738,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6033,
+                    "id": 6867,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6034,
+                    "id": 6868,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6035,
+                    "id": 6869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4786,25 +4786,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6899,
+                    "id": 7816,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6900,
+                    "id": 7817,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6901,
+                    "id": 7818,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6902,
+                    "id": 7819,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4821,21 +4821,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6036,
+                    "id": 6870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6037,
+                    "id": 6871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6038,
+                    "id": 6872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4868,25 +4868,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6903,
+                    "id": 7820,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6904,
+                    "id": 7821,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6905,
+                    "id": 7822,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6906,
+                    "id": 7823,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4903,21 +4903,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6039,
+                    "id": 6873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6040,
+                    "id": 6874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6041,
+                    "id": 6875,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4950,25 +4950,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6907,
+                    "id": 7824,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6908,
+                    "id": 7825,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6909,
+                    "id": 7826,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6910,
+                    "id": 7827,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4985,21 +4985,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6042,
+                    "id": 6876,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6043,
+                    "id": 6877,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6044,
+                    "id": 6878,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5031,25 +5031,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6911,
+                    "id": 7828,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6912,
+                    "id": 7829,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6913,
+                    "id": 7830,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6914,
+                    "id": 7831,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5066,21 +5066,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6045,
+                    "id": 6879,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6046,
+                    "id": 6880,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6047,
+                    "id": 6881,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5113,25 +5113,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6915,
+                    "id": 7832,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6916,
+                    "id": 7833,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6917,
+                    "id": 7834,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6918,
+                    "id": 7835,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5148,35 +5148,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6048,
+                    "id": 6882,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6049,
+                    "id": 6883,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6050,
+                    "id": 6884,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6051,
+                    "id": 6885,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6052,
+                    "id": 6886,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5211,25 +5211,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6919,
+                    "id": 7836,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6920,
+                    "id": 7837,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6921,
+                    "id": 7838,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6922,
+                    "id": 7839,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5246,35 +5246,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6053,
+                    "id": 6887,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6054,
+                    "id": 6888,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6055,
+                    "id": 6889,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6056,
+                    "id": 6890,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6057,
+                    "id": 6891,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5309,25 +5309,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6923,
+                    "id": 7840,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6924,
+                    "id": 7841,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6925,
+                    "id": 7842,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6926,
+                    "id": 7843,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5344,35 +5344,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6058,
+                    "id": 6892,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6059,
+                    "id": 6893,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6060,
+                    "id": 6894,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6061,
+                    "id": 6895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6062,
+                    "id": 6896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5407,25 +5407,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6927,
+                    "id": 7844,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6928,
+                    "id": 7845,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6929,
+                    "id": 7846,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6930,
+                    "id": 7847,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5442,21 +5442,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6063,
+                    "id": 6897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6064,
+                    "id": 6898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6065,
+                    "id": 6899,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5489,31 +5489,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6931,
+                    "id": 7848,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6932,
+                    "id": 7849,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6933,
+                    "id": 7850,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6934,
+                    "id": 7851,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6935,
+                    "id": 7852,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5530,21 +5530,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6066,
+                    "id": 6900,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6067,
+                    "id": 6901,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6068,
+                    "id": 6902,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5577,31 +5577,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6936,
+                    "id": 7853,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6937,
+                    "id": 7854,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6938,
+                    "id": 7855,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6939,
+                    "id": 7856,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6940,
+                    "id": 7857,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5618,21 +5618,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6069,
+                    "id": 6903,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6070,
+                    "id": 6904,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6071,
+                    "id": 6905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5665,31 +5665,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6941,
+                    "id": 7858,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6942,
+                    "id": 7859,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6943,
+                    "id": 7860,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6944,
+                    "id": 7861,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6945,
+                    "id": 7862,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5706,21 +5706,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6072,
+                    "id": 6906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6073,
+                    "id": 6907,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6074,
+                    "id": 6908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5753,31 +5753,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6946,
+                    "id": 7863,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6947,
+                    "id": 7864,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6948,
+                    "id": 7865,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6949,
+                    "id": 7866,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6950,
+                    "id": 7867,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5794,28 +5794,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6075,
+                    "id": 6909,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6076,
+                    "id": 6910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6077,
+                    "id": 6911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6078,
+                    "id": 6912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5850,25 +5850,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6951,
+                    "id": 7868,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6952,
+                    "id": 7869,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6953,
+                    "id": 7870,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6954,
+                    "id": 7871,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5885,28 +5885,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6079,
+                    "id": 6913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6080,
+                    "id": 6914,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6081,
+                    "id": 6915,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6082,
+                    "id": 6916,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5941,25 +5941,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6955,
+                    "id": 7872,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6956,
+                    "id": 7873,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6957,
+                    "id": 7874,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6958,
+                    "id": 7875,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5976,28 +5976,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6083,
+                    "id": 6917,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6084,
+                    "id": 6918,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6085,
+                    "id": 6919,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6086,
+                    "id": 6920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6032,31 +6032,31 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6959,
+                    "id": 7876,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6960,
+                    "id": 7877,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6961,
+                    "id": 7878,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6962,
+                    "id": 7879,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
                 },
                 {
-                    "id": 6963,
+                    "id": 7880,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -6073,28 +6073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6087,
+                    "id": 6921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6088,
+                    "id": 6922,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6089,
+                    "id": 6923,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6090,
+                    "id": 6924,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6128,25 +6128,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6964,
+                    "id": 7881,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6965,
+                    "id": 7882,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6966,
+                    "id": 7883,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6967,
+                    "id": 7884,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -6163,21 +6163,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6091,
+                    "id": 6925,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6092,
+                    "id": 6926,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6093,
+                    "id": 6927,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6212,25 +6212,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6968,
+                    "id": 7885,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6969,
+                    "id": 7886,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6970,
+                    "id": 7887,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6971,
+                    "id": 7888,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6247,21 +6247,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6094,
+                    "id": 6928,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6095,
+                    "id": 6929,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6096,
+                    "id": 6930,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6296,31 +6296,31 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6972,
+                    "id": 7889,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6973,
+                    "id": 7890,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6974,
+                    "id": 7891,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6975,
+                    "id": 7892,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 6976,
+                    "id": 7893,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -6337,21 +6337,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6097,
+                    "id": 6931,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6098,
+                    "id": 6932,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6099,
+                    "id": 6933,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6385,25 +6385,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6977,
+                    "id": 7894,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6978,
+                    "id": 7895,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6979,
+                    "id": 7896,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6980,
+                    "id": 7897,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6420,21 +6420,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6100,
+                    "id": 6934,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6101,
+                    "id": 6935,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6102,
+                    "id": 6936,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6468,25 +6468,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6981,
+                    "id": 7898,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6982,
+                    "id": 7899,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6983,
+                    "id": 7900,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6984,
+                    "id": 7901,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6503,28 +6503,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6103,
+                    "id": 6937,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6104,
+                    "id": 6938,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6105,
+                    "id": 6939,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6106,
+                    "id": 6940,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6558,25 +6558,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6985,
+                    "id": 7902,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6986,
+                    "id": 7903,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6987,
+                    "id": 7904,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6988,
+                    "id": 7905,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6593,28 +6593,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6107,
+                    "id": 6941,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6108,
+                    "id": 6942,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6109,
+                    "id": 6943,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6110,
+                    "id": 6944,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6647,25 +6647,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6989,
+                    "id": 7906,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6990,
+                    "id": 7907,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6991,
+                    "id": 7908,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6992,
+                    "id": 7909,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6682,28 +6682,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6111,
+                    "id": 6945,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6112,
+                    "id": 6946,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6113,
+                    "id": 6947,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6114,
+                    "id": 6948,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6736,25 +6736,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6993,
+                    "id": 7910,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6994,
+                    "id": 7911,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6995,
+                    "id": 7912,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6996,
+                    "id": 7913,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6771,21 +6771,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6115,
+                    "id": 6949,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6116,
+                    "id": 6950,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6117,
+                    "id": 6951,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6815,19 +6815,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6997,
+                    "id": 7914,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6998,
+                    "id": 7915,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6999,
+                    "id": 7916,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6844,21 +6844,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6118,
+                    "id": 6952,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6119,
+                    "id": 6953,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6120,
+                    "id": 6954,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6888,19 +6888,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7000,
+                    "id": 7917,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7001,
+                    "id": 7918,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7002,
+                    "id": 7919,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6917,21 +6917,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6121,
+                    "id": 6955,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6122,
+                    "id": 6956,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6123,
+                    "id": 6957,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6961,19 +6961,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7003,
+                    "id": 7920,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7004,
+                    "id": 7921,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7005,
+                    "id": 7922,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6990,21 +6990,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6124,
+                    "id": 6958,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6125,
+                    "id": 6959,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6126,
+                    "id": 6960,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7033,25 +7033,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7006,
+                    "id": 7923,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7007,
+                    "id": 7924,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7008,
+                    "id": 7925,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7009,
+                    "id": 7926,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -7068,21 +7068,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6127,
+                    "id": 6961,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6128,
+                    "id": 6962,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6129,
+                    "id": 6963,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7111,19 +7111,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7010,
+                    "id": 7927,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7011,
+                    "id": 7928,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7012,
+                    "id": 7929,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7140,21 +7140,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6130,
+                    "id": 6964,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6131,
+                    "id": 6965,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6132,
+                    "id": 6966,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7183,19 +7183,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7013,
+                    "id": 7930,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7014,
+                    "id": 7931,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7015,
+                    "id": 7932,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7212,21 +7212,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6133,
+                    "id": 6967,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6134,
+                    "id": 6968,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6135,
+                    "id": 6969,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7255,19 +7255,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7016,
+                    "id": 7933,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7017,
+                    "id": 7934,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7018,
+                    "id": 7935,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7284,21 +7284,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6136,
+                    "id": 6970,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6137,
+                    "id": 6971,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6138,
+                    "id": 6972,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7327,19 +7327,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7019,
+                    "id": 7936,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7020,
+                    "id": 7937,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7021,
+                    "id": 7938,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7356,21 +7356,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6139,
+                    "id": 6973,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6140,
+                    "id": 6974,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6141,
+                    "id": 6975,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7398,19 +7398,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7022,
+                    "id": 7939,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7023,
+                    "id": 7940,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7024,
+                    "id": 7941,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7427,21 +7427,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6142,
+                    "id": 6976,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6143,
+                    "id": 6977,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6144,
+                    "id": 6978,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7470,25 +7470,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7025,
+                    "id": 7942,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7026,
+                    "id": 7943,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7027,
+                    "id": 7944,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7028,
+                    "id": 7945,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -7505,21 +7505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6145,
+                    "id": 6979,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6146,
+                    "id": 6980,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6147,
+                    "id": 6981,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7550,19 +7550,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7029,
+                    "id": 7946,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7030,
+                    "id": 7947,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7031,
+                    "id": 7948,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7579,21 +7579,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6148,
+                    "id": 6982,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6149,
+                    "id": 6983,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6150,
+                    "id": 6984,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7623,19 +7623,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7032,
+                    "id": 7949,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7033,
+                    "id": 7950,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7034,
+                    "id": 7951,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7652,21 +7652,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6151,
+                    "id": 6985,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6152,
+                    "id": 6986,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6153,
+                    "id": 6987,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7696,19 +7696,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7035,
+                    "id": 7952,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7036,
+                    "id": 7953,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7037,
+                    "id": 7954,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7725,21 +7725,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6154,
+                    "id": 6988,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6155,
+                    "id": 6989,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6156,
+                    "id": 6990,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7771,31 +7771,31 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7038,
+                    "id": 7955,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7039,
+                    "id": 7956,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7040,
+                    "id": 7957,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7041,
+                    "id": 7958,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7042,
+                    "id": 7959,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "3"
@@ -7812,21 +7812,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6157,
+                    "id": 6991,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6158,
+                    "id": 6992,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6159,
+                    "id": 6993,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7858,25 +7858,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7043,
+                    "id": 7960,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7044,
+                    "id": 7961,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7045,
+                    "id": 7962,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7046,
+                    "id": 7963,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7893,21 +7893,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6160,
+                    "id": 6994,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6161,
+                    "id": 6995,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6162,
+                    "id": 6996,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7938,25 +7938,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7047,
+                    "id": 7964,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7048,
+                    "id": 7965,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7049,
+                    "id": 7966,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7050,
+                    "id": 7967,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7973,21 +7973,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6163,
+                    "id": 6997,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6164,
+                    "id": 6998,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6165,
+                    "id": 6999,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8018,25 +8018,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7051,
+                    "id": 7968,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7052,
+                    "id": 7969,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7053,
+                    "id": 7970,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7054,
+                    "id": 7971,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8053,21 +8053,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6166,
+                    "id": 7000,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6167,
+                    "id": 7001,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6168,
+                    "id": 7002,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8099,25 +8099,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7055,
+                    "id": 7972,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7056,
+                    "id": 7973,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7057,
+                    "id": 7974,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7058,
+                    "id": 7975,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8134,21 +8134,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6169,
+                    "id": 7003,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6170,
+                    "id": 7004,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6171,
+                    "id": 7005,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8179,25 +8179,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7059,
+                    "id": 7976,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7060,
+                    "id": 7977,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7061,
+                    "id": 7978,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7062,
+                    "id": 7979,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8214,35 +8214,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6172,
+                    "id": 7006,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6173,
+                    "id": 7007,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6174,
+                    "id": 7008,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6175,
+                    "id": 7009,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6176,
+                    "id": 7010,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8272,31 +8272,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7063,
+                    "id": 7980,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7064,
+                    "id": 7981,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7065,
+                    "id": 7982,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7066,
+                    "id": 7983,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7067,
+                    "id": 7984,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8313,35 +8313,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6177,
+                    "id": 7011,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6178,
+                    "id": 7012,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6179,
+                    "id": 7013,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6180,
+                    "id": 7014,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6181,
+                    "id": 7015,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8371,31 +8371,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7068,
+                    "id": 7985,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7069,
+                    "id": 7986,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7070,
+                    "id": 7987,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7071,
+                    "id": 7988,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7072,
+                    "id": 7989,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8412,35 +8412,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6182,
+                    "id": 7016,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6183,
+                    "id": 7017,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6184,
+                    "id": 7018,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6185,
+                    "id": 7019,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6186,
+                    "id": 7020,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8470,25 +8470,25 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7073,
+                    "id": 7990,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7074,
+                    "id": 7991,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7075,
+                    "id": 7992,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7076,
+                    "id": 7993,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8505,35 +8505,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6187,
+                    "id": 7021,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6188,
+                    "id": 7022,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6189,
+                    "id": 7023,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6190,
+                    "id": 7024,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6191,
+                    "id": 7025,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8563,31 +8563,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7994,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7078,
+                    "id": 7995,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7996,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7080,
+                    "id": 7997,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7081,
+                    "id": 7998,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -8604,28 +8604,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6192,
+                    "id": 7026,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6193,
+                    "id": 7027,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6194,
+                    "id": 7028,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6195,
+                    "id": 7029,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8655,19 +8655,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7082,
+                    "id": 7999,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7083,
+                    "id": 8000,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7084,
+                    "id": 8001,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8684,28 +8684,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6196,
+                    "id": 7030,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6197,
+                    "id": 7031,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6198,
+                    "id": 7032,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6199,
+                    "id": 7033,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8735,19 +8735,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7085,
+                    "id": 8002,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7086,
+                    "id": 8003,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7087,
+                    "id": 8004,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8764,28 +8764,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6200,
+                    "id": 7034,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6201,
+                    "id": 7035,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6202,
+                    "id": 7036,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6203,
+                    "id": 7037,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8815,19 +8815,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7088,
+                    "id": 8005,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7089,
+                    "id": 8006,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7090,
+                    "id": 8007,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8844,28 +8844,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6204,
+                    "id": 7038,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6205,
+                    "id": 7039,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6206,
+                    "id": 7040,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6207,
+                    "id": 7041,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8894,19 +8894,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7091,
+                    "id": 8008,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7092,
+                    "id": 8009,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7093,
+                    "id": 8010,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8923,28 +8923,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6208,
+                    "id": 7042,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6209,
+                    "id": 7043,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6210,
+                    "id": 7044,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6211,
+                    "id": 7045,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8979,19 +8979,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7094,
+                    "id": 8011,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7095,
+                    "id": 8012,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7096,
+                    "id": 8013,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9008,28 +9008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6212,
+                    "id": 7046,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6213,
+                    "id": 7047,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6214,
+                    "id": 7048,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6215,
+                    "id": 7049,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9064,19 +9064,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7097,
+                    "id": 8014,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7098,
+                    "id": 8015,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7099,
+                    "id": 8016,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9093,28 +9093,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6216,
+                    "id": 7050,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6217,
+                    "id": 7051,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6218,
+                    "id": 7052,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6219,
+                    "id": 7053,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9149,19 +9149,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7100,
+                    "id": 8017,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7101,
+                    "id": 8018,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7102,
+                    "id": 8019,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9178,28 +9178,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6220,
+                    "id": 7054,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6221,
+                    "id": 7055,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6222,
+                    "id": 7056,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6223,
+                    "id": 7057,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9233,19 +9233,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7103,
+                    "id": 8020,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7104,
+                    "id": 8021,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7105,
+                    "id": 8022,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9262,28 +9262,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6224,
+                    "id": 7058,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6225,
+                    "id": 7059,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6226,
+                    "id": 7060,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6227,
+                    "id": 7061,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9318,19 +9318,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7106,
+                    "id": 8023,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7107,
+                    "id": 8024,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7108,
+                    "id": 8025,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9347,28 +9347,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6228,
+                    "id": 7062,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6229,
+                    "id": 7063,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6230,
+                    "id": 7064,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6231,
+                    "id": 7065,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9402,19 +9402,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7109,
+                    "id": 8026,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7110,
+                    "id": 8027,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7111,
+                    "id": 8028,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9431,28 +9431,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6232,
+                    "id": 7066,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6233,
+                    "id": 7067,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6234,
+                    "id": 7068,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6235,
+                    "id": 7069,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9483,25 +9483,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7112,
+                    "id": 8029,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7113,
+                    "id": 8030,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7114,
+                    "id": 8031,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7115,
+                    "id": 8032,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9518,28 +9518,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6236,
+                    "id": 7070,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6237,
+                    "id": 7071,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6238,
+                    "id": 7072,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6239,
+                    "id": 7073,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9570,25 +9570,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7116,
+                    "id": 8033,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7117,
+                    "id": 8034,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7118,
+                    "id": 8035,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7119,
+                    "id": 8036,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9605,28 +9605,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6240,
+                    "id": 7074,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6241,
+                    "id": 7075,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6242,
+                    "id": 7076,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6243,
+                    "id": 7077,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9656,25 +9656,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7120,
+                    "id": 8037,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7121,
+                    "id": 8038,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7122,
+                    "id": 8039,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7123,
+                    "id": 8040,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9691,28 +9691,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6244,
+                    "id": 7078,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6245,
+                    "id": 7079,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6246,
+                    "id": 7080,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6247,
+                    "id": 7081,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9742,25 +9742,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7124,
+                    "id": 8041,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7125,
+                    "id": 8042,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7126,
+                    "id": 8043,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7127,
+                    "id": 8044,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9777,21 +9777,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6248,
+                    "id": 7082,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6249,
+                    "id": 7083,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6250,
+                    "id": 7084,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9822,19 +9822,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7128,
+                    "id": 8045,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7129,
+                    "id": 8046,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7130,
+                    "id": 8047,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9851,21 +9851,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6251,
+                    "id": 7085,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6252,
+                    "id": 7086,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6253,
+                    "id": 7087,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9896,19 +9896,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7131,
+                    "id": 8048,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7132,
+                    "id": 8049,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7133,
+                    "id": 8050,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9925,21 +9925,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6254,
+                    "id": 7088,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6255,
+                    "id": 7089,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6256,
+                    "id": 7090,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9970,19 +9970,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7134,
+                    "id": 8051,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7135,
+                    "id": 8052,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7136,
+                    "id": 8053,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9999,21 +9999,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6257,
+                    "id": 7091,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6258,
+                    "id": 7092,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6259,
+                    "id": 7093,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10044,19 +10044,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7137,
+                    "id": 8054,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7138,
+                    "id": 8055,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7139,
+                    "id": 8056,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10073,21 +10073,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6260,
+                    "id": 7094,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6261,
+                    "id": 7095,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6262,
+                    "id": 7096,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10117,19 +10117,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7140,
+                    "id": 8057,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7141,
+                    "id": 8058,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7142,
+                    "id": 8059,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10146,35 +10146,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6263,
+                    "id": 7097,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6264,
+                    "id": 7098,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6265,
+                    "id": 7099,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6266,
+                    "id": 7100,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6267,
+                    "id": 7101,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10205,25 +10205,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7143,
+                    "id": 8060,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7144,
+                    "id": 8061,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7145,
+                    "id": 8062,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7146,
+                    "id": 8063,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10240,35 +10240,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6268,
+                    "id": 7102,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6269,
+                    "id": 7103,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6270,
+                    "id": 7104,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6271,
+                    "id": 7105,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6272,
+                    "id": 7106,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10299,25 +10299,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7147,
+                    "id": 8064,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7148,
+                    "id": 8065,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7149,
+                    "id": 8066,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7150,
+                    "id": 8067,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10334,35 +10334,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6273,
+                    "id": 7107,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6274,
+                    "id": 7108,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6275,
+                    "id": 7109,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6276,
+                    "id": 7110,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6277,
+                    "id": 7111,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10393,25 +10393,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7151,
+                    "id": 8068,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7152,
+                    "id": 8069,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7153,
+                    "id": 8070,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7154,
+                    "id": 8071,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10428,35 +10428,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6278,
+                    "id": 7112,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6279,
+                    "id": 7113,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6280,
+                    "id": 7114,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6281,
+                    "id": 7115,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6282,
+                    "id": 7116,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10487,25 +10487,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7155,
+                    "id": 8072,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7156,
+                    "id": 8073,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7157,
+                    "id": 8074,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7158,
+                    "id": 8075,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10522,35 +10522,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6283,
+                    "id": 7117,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6284,
+                    "id": 7118,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6285,
+                    "id": 7119,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6286,
+                    "id": 7120,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6287,
+                    "id": 7121,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10580,25 +10580,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7159,
+                    "id": 8076,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7160,
+                    "id": 8077,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7161,
+                    "id": 8078,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7162,
+                    "id": 8079,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10615,21 +10615,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6288,
+                    "id": 7122,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6289,
+                    "id": 7123,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6290,
+                    "id": 7124,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10662,25 +10662,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7163,
+                    "id": 8080,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7164,
+                    "id": 8081,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7165,
+                    "id": 8082,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7166,
+                    "id": 8083,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10697,21 +10697,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6291,
+                    "id": 7125,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6292,
+                    "id": 7126,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6293,
+                    "id": 7127,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10744,25 +10744,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7167,
+                    "id": 8084,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7168,
+                    "id": 8085,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7169,
+                    "id": 8086,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7170,
+                    "id": 8087,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10779,21 +10779,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6294,
+                    "id": 7128,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6295,
+                    "id": 7129,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6296,
+                    "id": 7130,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10826,25 +10826,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7171,
+                    "id": 8088,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7172,
+                    "id": 8089,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7173,
+                    "id": 8090,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7174,
+                    "id": 8091,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10861,21 +10861,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6297,
+                    "id": 7131,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6298,
+                    "id": 7132,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6299,
+                    "id": 7133,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10907,25 +10907,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7175,
+                    "id": 8092,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7176,
+                    "id": 8093,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7177,
+                    "id": 8094,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7178,
+                    "id": 8095,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10942,28 +10942,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6300,
+                    "id": 7134,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6301,
+                    "id": 7135,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6302,
+                    "id": 7136,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6303,
+                    "id": 7137,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10994,25 +10994,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7179,
+                    "id": 8096,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7180,
+                    "id": 8097,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7181,
+                    "id": 8098,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7182,
+                    "id": 8099,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11029,28 +11029,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6304,
+                    "id": 7138,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6305,
+                    "id": 7139,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6306,
+                    "id": 7140,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6307,
+                    "id": 7141,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11081,25 +11081,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7183,
+                    "id": 8100,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7184,
+                    "id": 8101,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7185,
+                    "id": 8102,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7186,
+                    "id": 8103,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11116,28 +11116,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6308,
+                    "id": 7142,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6309,
+                    "id": 7143,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6310,
+                    "id": 7144,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6311,
+                    "id": 7145,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11168,25 +11168,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7187,
+                    "id": 8104,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7188,
+                    "id": 8105,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7189,
+                    "id": 8106,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7190,
+                    "id": 8107,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11203,28 +11203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6312,
+                    "id": 7146,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6313,
+                    "id": 7147,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6314,
+                    "id": 7148,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6315,
+                    "id": 7149,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11254,25 +11254,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7191,
+                    "id": 8108,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7192,
+                    "id": 8109,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7193,
+                    "id": 8110,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7194,
+                    "id": 8111,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11289,28 +11289,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6316,
+                    "id": 7150,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6317,
+                    "id": 7151,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6318,
+                    "id": 7152,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6319,
+                    "id": 7153,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11343,25 +11343,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7195,
+                    "id": 8112,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7196,
+                    "id": 8113,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7197,
+                    "id": 8114,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7198,
+                    "id": 8115,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11378,28 +11378,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6320,
+                    "id": 7154,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6321,
+                    "id": 7155,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6322,
+                    "id": 7156,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6323,
+                    "id": 7157,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11432,25 +11432,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7199,
+                    "id": 8116,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7200,
+                    "id": 8117,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7201,
+                    "id": 8118,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7202,
+                    "id": 8119,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11467,28 +11467,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6324,
+                    "id": 7158,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6325,
+                    "id": 7159,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6326,
+                    "id": 7160,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6327,
+                    "id": 7161,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11521,25 +11521,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7203,
+                    "id": 8120,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7204,
+                    "id": 8121,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7205,
+                    "id": 8122,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7206,
+                    "id": 8123,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11556,28 +11556,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6328,
+                    "id": 7162,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6329,
+                    "id": 7163,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6330,
+                    "id": 7164,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6331,
+                    "id": 7165,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11609,25 +11609,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7207,
+                    "id": 8124,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7208,
+                    "id": 8125,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7209,
+                    "id": 8126,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7210,
+                    "id": 8127,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11644,35 +11644,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6332,
+                    "id": 7166,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6333,
+                    "id": 7167,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6334,
+                    "id": 7168,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6335,
+                    "id": 7169,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6336,
+                    "id": 7170,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11707,25 +11707,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7211,
+                    "id": 8128,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7212,
+                    "id": 8129,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7213,
+                    "id": 8130,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7214,
+                    "id": 8131,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11742,35 +11742,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6337,
+                    "id": 7171,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6338,
+                    "id": 7172,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6339,
+                    "id": 7173,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6340,
+                    "id": 7174,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6341,
+                    "id": 7175,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11805,25 +11805,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7215,
+                    "id": 8132,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7216,
+                    "id": 8133,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7217,
+                    "id": 8134,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7218,
+                    "id": 8135,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11840,35 +11840,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6342,
+                    "id": 7176,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6343,
+                    "id": 7177,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6344,
+                    "id": 7178,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6345,
+                    "id": 7179,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6346,
+                    "id": 7180,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11903,25 +11903,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7219,
+                    "id": 8136,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7220,
+                    "id": 8137,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7221,
+                    "id": 8138,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7222,
+                    "id": 8139,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11938,28 +11938,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6347,
+                    "id": 7181,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6348,
+                    "id": 7182,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6349,
+                    "id": 7183,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6350,
+                    "id": 7184,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11992,31 +11992,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7223,
+                    "id": 8140,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7224,
+                    "id": 8141,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7225,
+                    "id": 8142,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7226,
+                    "id": 8143,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7227,
+                    "id": 8144,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12033,28 +12033,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6351,
+                    "id": 7185,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6352,
+                    "id": 7186,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6353,
+                    "id": 7187,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6354,
+                    "id": 7188,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12087,37 +12087,37 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7228,
+                    "id": 8145,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7229,
+                    "id": 8146,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7230,
+                    "id": 8147,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7231,
+                    "id": 8148,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7232,
+                    "id": 8149,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7233,
+                    "id": 8150,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -12134,28 +12134,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6355,
+                    "id": 7189,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6356,
+                    "id": 7190,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6357,
+                    "id": 7191,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6358,
+                    "id": 7192,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12188,31 +12188,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7234,
+                    "id": 8151,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7235,
+                    "id": 8152,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7236,
+                    "id": 8153,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7237,
+                    "id": 8154,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7238,
+                    "id": 8155,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12229,28 +12229,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6359,
+                    "id": 7193,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6360,
+                    "id": 7194,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6361,
+                    "id": 7195,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6362,
+                    "id": 7196,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12283,31 +12283,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7239,
+                    "id": 8156,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7240,
+                    "id": 8157,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7241,
+                    "id": 8158,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7242,
+                    "id": 8159,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7243,
+                    "id": 8160,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12324,35 +12324,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6363,
+                    "id": 7197,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6364,
+                    "id": 7198,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6365,
+                    "id": 7199,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6366,
+                    "id": 7200,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6367,
+                    "id": 7201,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12387,25 +12387,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7244,
+                    "id": 8161,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7245,
+                    "id": 8162,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7246,
+                    "id": 8163,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7247,
+                    "id": 8164,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12422,35 +12422,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6368,
+                    "id": 7202,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6369,
+                    "id": 7203,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6370,
+                    "id": 7204,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6371,
+                    "id": 7205,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6372,
+                    "id": 7206,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12485,25 +12485,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7248,
+                    "id": 8165,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7249,
+                    "id": 8166,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7250,
+                    "id": 8167,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7251,
+                    "id": 8168,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12520,35 +12520,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6373,
+                    "id": 7207,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6374,
+                    "id": 7208,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6375,
+                    "id": 7209,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6376,
+                    "id": 7210,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6377,
+                    "id": 7211,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12582,25 +12582,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7252,
+                    "id": 8169,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7253,
+                    "id": 8170,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7254,
+                    "id": 8171,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7255,
+                    "id": 8172,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12617,28 +12617,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6378,
+                    "id": 7212,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6379,
+                    "id": 7213,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6380,
+                    "id": 7214,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6381,
+                    "id": 7215,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12674,31 +12674,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7256,
+                    "id": 8173,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7257,
+                    "id": 8174,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7258,
+                    "id": 8175,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7259,
+                    "id": 8176,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7260,
+                    "id": 8177,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12715,28 +12715,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6382,
+                    "id": 7216,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6383,
+                    "id": 7217,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6384,
+                    "id": 7218,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6385,
+                    "id": 7219,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12772,31 +12772,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7261,
+                    "id": 8178,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7262,
+                    "id": 8179,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7263,
+                    "id": 8180,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7264,
+                    "id": 8181,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7265,
+                    "id": 8182,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12813,28 +12813,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6386,
+                    "id": 7220,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6387,
+                    "id": 7221,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6388,
+                    "id": 7222,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6389,
+                    "id": 7223,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12870,31 +12870,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7266,
+                    "id": 8183,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7267,
+                    "id": 8184,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7268,
+                    "id": 8185,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7269,
+                    "id": 8186,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7270,
+                    "id": 8187,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12911,28 +12911,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6390,
+                    "id": 7224,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6391,
+                    "id": 7225,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6392,
+                    "id": 7226,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6393,
+                    "id": 7227,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12967,31 +12967,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7271,
+                    "id": 8188,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7272,
+                    "id": 8189,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7273,
+                    "id": 8190,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7274,
+                    "id": 8191,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7275,
+                    "id": 8192,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13008,28 +13008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6394,
+                    "id": 7228,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6395,
+                    "id": 7229,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6396,
+                    "id": 7230,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6397,
+                    "id": 7231,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13065,31 +13065,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7276,
+                    "id": 8193,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7277,
+                    "id": 8194,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7278,
+                    "id": 8195,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7279,
+                    "id": 8196,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7280,
+                    "id": 8197,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13106,28 +13106,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6398,
+                    "id": 7232,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6399,
+                    "id": 7233,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6400,
+                    "id": 7234,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6401,
+                    "id": 7235,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13162,31 +13162,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7281,
+                    "id": 8198,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7282,
+                    "id": 8199,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7283,
+                    "id": 8200,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7284,
+                    "id": 8201,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7285,
+                    "id": 8202,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13203,28 +13203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6402,
+                    "id": 7236,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6403,
+                    "id": 7237,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6404,
+                    "id": 7238,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6405,
+                    "id": 7239,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13254,19 +13254,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7286,
+                    "id": 8203,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7287,
+                    "id": 8204,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7288,
+                    "id": 8205,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13283,28 +13283,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6406,
+                    "id": 7240,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6407,
+                    "id": 7241,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6408,
+                    "id": 7242,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6409,
+                    "id": 7243,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13334,19 +13334,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7289,
+                    "id": 8206,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7290,
+                    "id": 8207,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7291,
+                    "id": 8208,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13363,28 +13363,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6410,
+                    "id": 7244,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6411,
+                    "id": 7245,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6412,
+                    "id": 7246,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6413,
+                    "id": 7247,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13413,19 +13413,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7292,
+                    "id": 8209,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7293,
+                    "id": 8210,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7294,
+                    "id": 8211,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13442,28 +13442,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6414,
+                    "id": 7248,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6415,
+                    "id": 7249,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6416,
+                    "id": 7250,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6417,
+                    "id": 7251,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13493,19 +13493,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7295,
+                    "id": 8212,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7296,
+                    "id": 8213,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7297,
+                    "id": 8214,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13522,28 +13522,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6418,
+                    "id": 7252,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6419,
+                    "id": 7253,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6420,
+                    "id": 7254,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6421,
+                    "id": 7255,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13573,19 +13573,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7298,
+                    "id": 8215,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7299,
+                    "id": 8216,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7300,
+                    "id": 8217,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13602,28 +13602,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6422,
+                    "id": 7256,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6423,
+                    "id": 7257,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6424,
+                    "id": 7258,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6425,
+                    "id": 7259,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13652,19 +13652,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7301,
+                    "id": 8218,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7302,
+                    "id": 8219,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7303,
+                    "id": 8220,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13681,21 +13681,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6426,
+                    "id": 7260,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6427,
+                    "id": 7261,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6428,
+                    "id": 7262,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13728,19 +13728,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7304,
+                    "id": 8221,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7305,
+                    "id": 8222,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7306,
+                    "id": 8223,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13757,21 +13757,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6429,
+                    "id": 7263,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6430,
+                    "id": 7264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6431,
+                    "id": 7265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13803,19 +13803,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7307,
+                    "id": 8224,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7308,
+                    "id": 8225,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7309,
+                    "id": 8226,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13832,21 +13832,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6432,
+                    "id": 7266,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6433,
+                    "id": 7267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6434,
+                    "id": 7268,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13878,19 +13878,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7310,
+                    "id": 8227,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7311,
+                    "id": 8228,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7312,
+                    "id": 8229,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13907,21 +13907,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6435,
+                    "id": 7269,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6436,
+                    "id": 7270,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6437,
+                    "id": 7271,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13953,19 +13953,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7313,
+                    "id": 8230,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7314,
+                    "id": 8231,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7315,
+                    "id": 8232,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13982,28 +13982,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6438,
+                    "id": 7272,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6439,
+                    "id": 7273,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6440,
+                    "id": 7274,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6441,
+                    "id": 7275,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14038,25 +14038,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7316,
+                    "id": 8233,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7317,
+                    "id": 8234,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7318,
+                    "id": 8235,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7319,
+                    "id": 8236,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14073,28 +14073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6442,
+                    "id": 7276,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6443,
+                    "id": 7277,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6444,
+                    "id": 7278,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6445,
+                    "id": 7279,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14129,25 +14129,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7320,
+                    "id": 8237,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7321,
+                    "id": 8238,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7322,
+                    "id": 8239,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7323,
+                    "id": 8240,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14164,28 +14164,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6446,
+                    "id": 7280,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6447,
+                    "id": 7281,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6448,
+                    "id": 7282,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6449,
+                    "id": 7283,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14220,25 +14220,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7324,
+                    "id": 8241,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7325,
+                    "id": 8242,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7326,
+                    "id": 8243,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7327,
+                    "id": 8244,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14255,28 +14255,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6450,
+                    "id": 7284,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6451,
+                    "id": 7285,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6452,
+                    "id": 7286,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6453,
+                    "id": 7287,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14310,25 +14310,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7328,
+                    "id": 8245,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7329,
+                    "id": 8246,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7330,
+                    "id": 8247,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7331,
+                    "id": 8248,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14345,21 +14345,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6454,
+                    "id": 7288,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6455,
+                    "id": 7289,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6456,
+                    "id": 7290,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14390,25 +14390,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7332,
+                    "id": 8249,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7333,
+                    "id": 8250,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7334,
+                    "id": 8251,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7335,
+                    "id": 8252,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14425,21 +14425,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6457,
+                    "id": 7291,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6458,
+                    "id": 7292,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6459,
+                    "id": 7293,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14470,25 +14470,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7336,
+                    "id": 8253,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7337,
+                    "id": 8254,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7338,
+                    "id": 8255,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7339,
+                    "id": 8256,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14505,21 +14505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6460,
+                    "id": 7294,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6461,
+                    "id": 7295,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6462,
+                    "id": 7296,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14549,25 +14549,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7340,
+                    "id": 8257,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7341,
+                    "id": 8258,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7342,
+                    "id": 8259,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7343,
+                    "id": 8260,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14584,21 +14584,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6463,
+                    "id": 7297,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6464,
+                    "id": 7298,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6465,
+                    "id": 7299,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14629,25 +14629,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7344,
+                    "id": 8261,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7345,
+                    "id": 8262,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7346,
+                    "id": 8263,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7347,
+                    "id": 8264,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14664,21 +14664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6466,
+                    "id": 7300,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6467,
+                    "id": 7301,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6468,
+                    "id": 7302,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14708,25 +14708,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7348,
+                    "id": 8265,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7349,
+                    "id": 8266,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7350,
+                    "id": 8267,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7351,
+                    "id": 8268,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14743,35 +14743,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6469,
+                    "id": 7303,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6470,
+                    "id": 7304,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6471,
+                    "id": 7305,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6472,
+                    "id": 7306,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6473,
+                    "id": 7307,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14804,31 +14804,31 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7352,
+                    "id": 8269,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7353,
+                    "id": 8270,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7354,
+                    "id": 8271,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7355,
+                    "id": 8272,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7356,
+                    "id": 8273,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "3"
@@ -14845,35 +14845,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6474,
+                    "id": 7308,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6475,
+                    "id": 7309,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6476,
+                    "id": 7310,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6477,
+                    "id": 7311,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6478,
+                    "id": 7312,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14906,25 +14906,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7357,
+                    "id": 8274,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7358,
+                    "id": 8275,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7359,
+                    "id": 8276,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7360,
+                    "id": 8277,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14941,35 +14941,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6479,
+                    "id": 7313,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6480,
+                    "id": 7314,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6481,
+                    "id": 7315,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6482,
+                    "id": 7316,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6483,
+                    "id": 7317,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15001,25 +15001,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7361,
+                    "id": 8278,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7362,
+                    "id": 8279,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7363,
+                    "id": 8280,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7364,
+                    "id": 8281,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15036,35 +15036,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6484,
+                    "id": 7318,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6485,
+                    "id": 7319,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6486,
+                    "id": 7320,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6487,
+                    "id": 7321,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6488,
+                    "id": 7322,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15096,25 +15096,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7365,
+                    "id": 8282,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7366,
+                    "id": 8283,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7367,
+                    "id": 8284,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7368,
+                    "id": 8285,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15131,28 +15131,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6489,
+                    "id": 7323,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6490,
+                    "id": 7324,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6491,
+                    "id": 7325,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6492,
+                    "id": 7326,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 }
@@ -15184,25 +15184,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7369,
+                    "id": 8286,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7370,
+                    "id": 8287,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7371,
+                    "id": 8288,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7372,
+                    "id": 8289,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15219,28 +15219,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6493,
+                    "id": 7327,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6494,
+                    "id": 7328,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6495,
+                    "id": 7329,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6496,
+                    "id": 7330,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15272,25 +15272,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7373,
+                    "id": 8290,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7374,
+                    "id": 8291,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7375,
+                    "id": 8292,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7376,
+                    "id": 8293,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15307,28 +15307,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6497,
+                    "id": 7331,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6498,
+                    "id": 7332,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6499,
+                    "id": 7333,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6500,
+                    "id": 7334,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15360,25 +15360,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7377,
+                    "id": 8294,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7378,
+                    "id": 8295,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7379,
+                    "id": 8296,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7380,
+                    "id": 8297,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15395,28 +15395,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6501,
+                    "id": 7335,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6502,
+                    "id": 7336,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6503,
+                    "id": 7337,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6504,
+                    "id": 7338,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15448,25 +15448,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7381,
+                    "id": 8298,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7382,
+                    "id": 8299,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7383,
+                    "id": 8300,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7384,
+                    "id": 8301,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15483,28 +15483,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6505,
+                    "id": 7339,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6506,
+                    "id": 7340,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6507,
+                    "id": 7341,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6508,
+                    "id": 7342,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15535,25 +15535,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7385,
+                    "id": 8302,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7386,
+                    "id": 8303,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7387,
+                    "id": 8304,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7388,
+                    "id": 8305,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15570,28 +15570,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6509,
+                    "id": 7343,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6510,
+                    "id": 7344,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6511,
+                    "id": 7345,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6512,
+                    "id": 7346,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15621,25 +15621,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7389,
+                    "id": 8306,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7390,
+                    "id": 8307,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7391,
+                    "id": 8308,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7392,
+                    "id": 8309,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15656,28 +15656,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6513,
+                    "id": 7347,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6514,
+                    "id": 7348,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6515,
+                    "id": 7349,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6516,
+                    "id": 7350,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15707,25 +15707,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7393,
+                    "id": 8310,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7394,
+                    "id": 8311,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7395,
+                    "id": 8312,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7396,
+                    "id": 8313,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15742,28 +15742,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6517,
+                    "id": 7351,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6518,
+                    "id": 7352,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6519,
+                    "id": 7353,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6520,
+                    "id": 7354,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15793,25 +15793,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7397,
+                    "id": 8314,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7398,
+                    "id": 8315,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7399,
+                    "id": 8316,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7400,
+                    "id": 8317,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15828,28 +15828,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6521,
+                    "id": 7355,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6522,
+                    "id": 7356,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6523,
+                    "id": 7357,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6524,
+                    "id": 7358,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15879,25 +15879,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7401,
+                    "id": 8318,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7402,
+                    "id": 8319,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7403,
+                    "id": 8320,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7404,
+                    "id": 8321,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15914,28 +15914,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6525,
+                    "id": 7359,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6526,
+                    "id": 7360,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6527,
+                    "id": 7361,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6528,
+                    "id": 7362,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15964,25 +15964,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7405,
+                    "id": 8322,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7406,
+                    "id": 8323,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7407,
+                    "id": 8324,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7408,
+                    "id": 8325,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15999,28 +15999,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6529,
+                    "id": 7363,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6530,
+                    "id": 7364,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6531,
+                    "id": 7365,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6532,
+                    "id": 7366,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16049,25 +16049,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7409,
+                    "id": 8326,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7410,
+                    "id": 8327,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7411,
+                    "id": 8328,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7412,
+                    "id": 8329,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16084,28 +16084,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6533,
+                    "id": 7367,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6534,
+                    "id": 7368,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6535,
+                    "id": 7369,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6536,
+                    "id": 7370,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16135,25 +16135,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7413,
+                    "id": 8330,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7414,
+                    "id": 8331,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7415,
+                    "id": 8332,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7416,
+                    "id": 8333,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16170,28 +16170,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6537,
+                    "id": 7371,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6538,
+                    "id": 7372,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6539,
+                    "id": 7373,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6540,
+                    "id": 7374,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16220,25 +16220,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7417,
+                    "id": 8334,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7418,
+                    "id": 8335,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7419,
+                    "id": 8336,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7420,
+                    "id": 8337,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16255,21 +16255,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6541,
+                    "id": 7375,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6542,
+                    "id": 7376,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6543,
+                    "id": 7377,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16302,25 +16302,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7421,
+                    "id": 8338,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7422,
+                    "id": 8339,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7423,
+                    "id": 8340,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7424,
+                    "id": 8341,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16337,21 +16337,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6544,
+                    "id": 7378,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6545,
+                    "id": 7379,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6546,
+                    "id": 7380,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16384,25 +16384,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7425,
+                    "id": 8342,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7426,
+                    "id": 8343,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7427,
+                    "id": 8344,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7428,
+                    "id": 8345,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16419,21 +16419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6547,
+                    "id": 7381,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6548,
+                    "id": 7382,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6549,
+                    "id": 7383,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16466,25 +16466,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7429,
+                    "id": 8346,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7430,
+                    "id": 8347,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7431,
+                    "id": 8348,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7432,
+                    "id": 8349,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16501,21 +16501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6550,
+                    "id": 7384,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6551,
+                    "id": 7385,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6552,
+                    "id": 7386,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16547,25 +16547,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7433,
+                    "id": 8350,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7434,
+                    "id": 8351,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7435,
+                    "id": 8352,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7436,
+                    "id": 8353,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16582,21 +16582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6553,
+                    "id": 7387,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6554,
+                    "id": 7388,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6555,
+                    "id": 7389,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16629,25 +16629,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7437,
+                    "id": 8354,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7438,
+                    "id": 8355,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7439,
+                    "id": 8356,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7440,
+                    "id": 8357,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16664,21 +16664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6556,
+                    "id": 7390,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6557,
+                    "id": 7391,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6558,
+                    "id": 7392,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16710,25 +16710,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7441,
+                    "id": 8358,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7442,
+                    "id": 8359,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7443,
+                    "id": 8360,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7444,
+                    "id": 8361,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16745,28 +16745,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6559,
+                    "id": 7393,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6560,
+                    "id": 7394,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6561,
+                    "id": 7395,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6562,
+                    "id": 7396,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16801,25 +16801,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7445,
+                    "id": 8362,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7446,
+                    "id": 8363,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7447,
+                    "id": 8364,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7448,
+                    "id": 8365,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16836,28 +16836,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6563,
+                    "id": 7397,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6564,
+                    "id": 7398,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6565,
+                    "id": 7399,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6566,
+                    "id": 7400,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16892,25 +16892,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7449,
+                    "id": 8366,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7450,
+                    "id": 8367,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7451,
+                    "id": 8368,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7452,
+                    "id": 8369,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16927,28 +16927,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6567,
+                    "id": 7401,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6568,
+                    "id": 7402,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6569,
+                    "id": 7403,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6570,
+                    "id": 7404,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16983,25 +16983,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7453,
+                    "id": 8370,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7454,
+                    "id": 8371,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7455,
+                    "id": 8372,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7456,
+                    "id": 8373,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17018,28 +17018,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6571,
+                    "id": 7405,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6572,
+                    "id": 7406,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6573,
+                    "id": 7407,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6574,
+                    "id": 7408,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17074,25 +17074,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7457,
+                    "id": 8374,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7458,
+                    "id": 8375,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7459,
+                    "id": 8376,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7460,
+                    "id": 8377,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17109,21 +17109,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6575,
+                    "id": 7409,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6576,
+                    "id": 7410,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6577,
+                    "id": 7411,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17156,25 +17156,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7461,
+                    "id": 8378,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7462,
+                    "id": 8379,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7463,
+                    "id": 8380,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7464,
+                    "id": 8381,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17191,21 +17191,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6578,
+                    "id": 7412,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6579,
+                    "id": 7413,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6580,
+                    "id": 7414,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17238,25 +17238,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7465,
+                    "id": 8382,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7466,
+                    "id": 8383,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7467,
+                    "id": 8384,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7468,
+                    "id": 8385,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17273,21 +17273,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6581,
+                    "id": 7415,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6582,
+                    "id": 7416,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6583,
+                    "id": 7417,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17319,25 +17319,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7469,
+                    "id": 8386,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7470,
+                    "id": 8387,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7471,
+                    "id": 8388,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7472,
+                    "id": 8389,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17354,21 +17354,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6584,
+                    "id": 7418,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6585,
+                    "id": 7419,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6586,
+                    "id": 7420,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17402,31 +17402,31 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7473,
+                    "id": 8390,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7474,
+                    "id": 8391,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7475,
+                    "id": 8392,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7476,
+                    "id": 8393,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7477,
+                    "id": 8394,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -17443,21 +17443,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6587,
+                    "id": 7421,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6588,
+                    "id": 7422,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6589,
+                    "id": 7423,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17491,25 +17491,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7478,
+                    "id": 8395,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7479,
+                    "id": 8396,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7480,
+                    "id": 8397,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7481,
+                    "id": 8398,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17526,21 +17526,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6590,
+                    "id": 7424,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6591,
+                    "id": 7425,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6592,
+                    "id": 7426,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17573,25 +17573,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7482,
+                    "id": 8399,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7483,
+                    "id": 8400,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7484,
+                    "id": 8401,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7485,
+                    "id": 8402,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17608,28 +17608,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6593,
+                    "id": 7427,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6594,
+                    "id": 7428,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6595,
+                    "id": 7429,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6596,
+                    "id": 7430,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17662,25 +17662,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7486,
+                    "id": 8403,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7487,
+                    "id": 8404,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7488,
+                    "id": 8405,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7489,
+                    "id": 8406,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17697,28 +17697,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6597,
+                    "id": 7431,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6598,
+                    "id": 7432,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6599,
+                    "id": 7433,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6600,
+                    "id": 7434,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17751,31 +17751,31 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7490,
+                    "id": 8407,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7491,
+                    "id": 8408,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7492,
+                    "id": 8409,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7493,
+                    "id": 8410,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7494,
+                    "id": 8411,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -17792,28 +17792,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6601,
+                    "id": 7435,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6602,
+                    "id": 7436,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6603,
+                    "id": 7437,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6604,
+                    "id": 7438,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17846,25 +17846,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7495,
+                    "id": 8412,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7496,
+                    "id": 8413,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7497,
+                    "id": 8414,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7498,
+                    "id": 8415,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17881,21 +17881,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6605,
+                    "id": 7439,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6606,
+                    "id": 7440,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6607,
+                    "id": 7441,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17931,25 +17931,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7499,
+                    "id": 8416,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7500,
+                    "id": 8417,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7501,
+                    "id": 8418,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7502,
+                    "id": 8419,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17966,21 +17966,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6608,
+                    "id": 7442,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6609,
+                    "id": 7443,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6610,
+                    "id": 7444,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18016,31 +18016,31 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7503,
+                    "id": 8420,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7504,
+                    "id": 8421,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7505,
+                    "id": 8422,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7506,
+                    "id": 8423,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7507,
+                    "id": 8424,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -18057,21 +18057,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6611,
+                    "id": 7445,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6612,
+                    "id": 7446,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6613,
+                    "id": 7447,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18107,25 +18107,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7508,
+                    "id": 8425,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7509,
+                    "id": 8426,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7510,
+                    "id": 8427,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7511,
+                    "id": 8428,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18142,21 +18142,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6614,
+                    "id": 7448,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6615,
+                    "id": 7449,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6616,
+                    "id": 7450,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18191,25 +18191,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7512,
+                    "id": 8429,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7513,
+                    "id": 8430,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7514,
+                    "id": 8431,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7515,
+                    "id": 8432,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18226,21 +18226,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6617,
+                    "id": 7451,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6618,
+                    "id": 7452,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6619,
+                    "id": 7453,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18273,31 +18273,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7516,
+                    "id": 8433,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7517,
+                    "id": 8434,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7518,
+                    "id": 8435,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7519,
+                    "id": 8436,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7520,
+                    "id": 8437,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -18314,21 +18314,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6620,
+                    "id": 7454,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6621,
+                    "id": 7455,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6622,
+                    "id": 7456,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18346,7 +18346,7 @@
                 6
             ],
             "card_type_id": 1,
-            "cost": "54",
+            "cost": "56",
             "faction_id": 3,
             "ffg_id": "XW_P_215",
             "force_side": null,
@@ -18356,30 +18356,30 @@
             "is_unique": true,
             "name": "•Manaroo",
             "restrictions": [],
-            "ship_ability_text": null,
+            "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7521,
+                    "id": 8438,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7522,
+                    "id": 8439,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7523,
+                    "id": 8440,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7524,
+                    "id": 8441,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18396,21 +18396,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6623,
+                    "id": 7457,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6624,
+                    "id": 7458,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6625,
+                    "id": 7459,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18443,31 +18443,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7525,
+                    "id": 8442,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7526,
+                    "id": 8443,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7527,
+                    "id": 8444,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7528,
+                    "id": 8445,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7529,
+                    "id": 8446,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -18484,21 +18484,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6626,
+                    "id": 7460,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6627,
+                    "id": 7461,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6628,
+                    "id": 7462,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18530,25 +18530,25 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7530,
+                    "id": 8447,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7531,
+                    "id": 8448,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7532,
+                    "id": 8449,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7533,
+                    "id": 8450,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18565,28 +18565,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6629,
+                    "id": 7463,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6630,
+                    "id": 7464,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6631,
+                    "id": 7465,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6632,
+                    "id": 7466,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18619,31 +18619,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7534,
+                    "id": 8451,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7535,
+                    "id": 8452,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7536,
+                    "id": 8453,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7537,
+                    "id": 8454,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7538,
+                    "id": 8455,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18660,28 +18660,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6633,
+                    "id": 7467,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6634,
+                    "id": 7468,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6635,
+                    "id": 7469,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6636,
+                    "id": 7470,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18714,37 +18714,37 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7539,
+                    "id": 8456,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7540,
+                    "id": 8457,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7541,
+                    "id": 8458,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7542,
+                    "id": 8459,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7543,
+                    "id": 8460,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7544,
+                    "id": 8461,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -18761,28 +18761,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6637,
+                    "id": 7471,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6638,
+                    "id": 7472,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6639,
+                    "id": 7473,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6640,
+                    "id": 7474,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18815,31 +18815,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7545,
+                    "id": 8462,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7546,
+                    "id": 8463,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7547,
+                    "id": 8464,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7548,
+                    "id": 8465,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7549,
+                    "id": 8466,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18856,28 +18856,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6641,
+                    "id": 7475,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6642,
+                    "id": 7476,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6643,
+                    "id": 7477,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6644,
+                    "id": 7478,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18909,31 +18909,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7550,
+                    "id": 8467,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7551,
+                    "id": 8468,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7552,
+                    "id": 8469,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7553,
+                    "id": 8470,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7554,
+                    "id": 8471,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18950,28 +18950,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6645,
+                    "id": 7479,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6646,
+                    "id": 7480,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6647,
+                    "id": 7481,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6648,
+                    "id": 7482,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19006,25 +19006,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7555,
+                    "id": 8472,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7556,
+                    "id": 8473,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7557,
+                    "id": 8474,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7558,
+                    "id": 8475,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19041,28 +19041,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6649,
+                    "id": 7483,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6650,
+                    "id": 7484,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6651,
+                    "id": 7485,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6652,
+                    "id": 7486,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19097,25 +19097,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7559,
+                    "id": 8476,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7560,
+                    "id": 8477,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7561,
+                    "id": 8478,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7562,
+                    "id": 8479,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19132,28 +19132,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6653,
+                    "id": 7487,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6654,
+                    "id": 7488,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6655,
+                    "id": 7489,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6656,
+                    "id": 7490,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19187,25 +19187,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7563,
+                    "id": 8480,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7564,
+                    "id": 8481,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7565,
+                    "id": 8482,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7566,
+                    "id": 8483,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19222,28 +19222,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 7491,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 7492,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 7493,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 7494,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19277,25 +19277,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 8484,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 8485,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 8486,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 8487,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19312,21 +19312,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6661,
+                    "id": 7495,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6662,
+                    "id": 7496,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6663,
+                    "id": 7497,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19356,25 +19356,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7571,
+                    "id": 8488,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7572,
+                    "id": 8489,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7573,
+                    "id": 8490,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7574,
+                    "id": 8491,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19391,21 +19391,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6664,
+                    "id": 7498,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6665,
+                    "id": 7499,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6666,
+                    "id": 7500,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19435,25 +19435,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7575,
+                    "id": 8492,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7576,
+                    "id": 8493,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7577,
+                    "id": 8494,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7578,
+                    "id": 8495,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19470,21 +19470,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6667,
+                    "id": 7501,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6668,
+                    "id": 7502,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6669,
+                    "id": 7503,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19514,25 +19514,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 8496,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7580,
+                    "id": 8497,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7581,
+                    "id": 8498,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7582,
+                    "id": 8499,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19549,21 +19549,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6670,
+                    "id": 7504,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6671,
+                    "id": 7505,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6672,
+                    "id": 7506,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19589,31 +19589,31 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7583,
+                    "id": 8500,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7584,
+                    "id": 8501,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7585,
+                    "id": 8502,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7586,
+                    "id": 8503,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7587,
+                    "id": 8504,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "3"
@@ -20685,7 +20685,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
@@ -20724,7 +20724,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, todos los resultados <hit>/<crit> infligen fichas de Interferencia en vez de daño.",
@@ -20763,7 +20763,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, todos los resultados <hit>/<crit> infligen fichas de Campo de tracción en vez de daño.",
@@ -20802,7 +20802,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque</smallcaps>",
@@ -20849,7 +20849,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
@@ -20897,7 +20897,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Cambia 1 resultado <hit> por un resultado <crit>.",
@@ -20989,7 +20989,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1 <standardcharge>. Cambia 1 resultado <hit> por un resultado <crit>.",
@@ -21036,7 +21036,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (<focus>):</smallcaps> Gasta 1 <standardcharge>. Si el defensor está situado en tu <bullseye>, puedes gastar 1 o más <standardcharge> para volver a tirar esa misma cantidad de dados de ataque.",
@@ -21080,7 +21080,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Después de este ataque, puedes efectuar este ataque como un ataque adicional contra un objetivo diferente que esté situado a alcance 0–1 del defensor, ignorando el requisito <targetlock>.",
@@ -21126,7 +21126,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Después de que este ataque impacte, toda nave que esté situada a alcance 0–1 del defensor expone 1 de sus cartas de Daño.",
@@ -21172,7 +21172,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Después de que declares quién es el defensor, éste puede elegir sufrir 1 de daño <hit>. Si lo hace, omites los pasos de “Dados de ataque” y “Dados de defensa” y el ataque se considera que ha impactado.",
@@ -21217,7 +21217,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
@@ -21262,7 +21262,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (<focus>):</smallcaps> Gasta 1<nonbreak><standardcharge>.",
@@ -21307,7 +21307,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "Mientras te defiendes, antes de que se tiren los dados de ataque, puedes gastar un Blanco fijado que tengas sobre el atacante para tirar 1 dado de ataque. Si lo haces, el atacante recibe 1 ficha de Interferencia. Luego, si has sacado un resultado <hit> o <crit>, recibes 1 ficha de Interferencia.",

--- a/translation_helper/api_export_es.json
+++ b/translation_helper/api_export_es.json
@@ -1,6 +1,745 @@
 {
     "cards": [
         {
+            "ability_text": "Mientras efectúas un ataque, el defensor tira 1 dado de defensa menos.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5839,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5840,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5841,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_1",
+            "force_side": null,
+            "id": 1,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Wedge Antilles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6671,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6672,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6673,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6674,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rojo Dos",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que te conviertas en el defensor (antes de las tiradas de dados), puedes recuperar 1<nonbreak><forcecharge>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5842,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5843,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5844,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                17,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "62",
+            "faction_id": 1,
+            "ffg_id": "XW_P_2",
+            "force_side": 2,
+            "id": 2,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Luke Skywalker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6675,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6676,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6677,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6678,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 6679,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rojo Cinco",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque, puedes gastar 1 resultado <focus>, <hit> o <crit> para mirar las cartas de Daño boca abajo del defensor, elegir 1 de ellas y exponerla.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5845,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5846,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5847,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_set_ids": [
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_3",
+            "force_side": null,
+            "id": 3,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Thane Kyrell",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6680,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6681,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6682,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6683,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Corona Cuatro",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que gastes una ficha de Concentración, puedes elegir 1 nave aliada que tengas a alcance 1–3. Esa nave recibe 1 ficha de Concentración.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5848,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5849,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5850,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_4",
+            "force_side": null,
+            "id": 4,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6684,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6685,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6686,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6687,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Jefe Rojo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que recibas una ficha de Tensión, puedes tirar 1 dado de ataque para retirarla. Si sacas <hit>, sufres 1 de daño <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5851,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5852,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5853,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_5",
+            "force_side": null,
+            "id": 5,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Jek Porkins",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6688,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6689,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6690,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6691,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rojo Seis",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de de que realices una acción <barrelroll> o <boost>, puedes darle la vuelta a la carta de Mejora <config> que tengas equipada en tu nave.\n",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5854,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5855,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5856,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_6",
+            "force_side": null,
+            "id": 6,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kullbee Sperado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6692,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6693,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6694,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6695,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Pistolero enigmático",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras otra nave aliada que tienes a alcance 0–1 se defiende, antes del paso de “Neutralizar los resultados”, si estás en el arco de ataque, puedes sufrir 1 de daño <hit> o <crit> para anular 1 resultado equivalente.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5857,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5858,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5859,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_7",
+            "force_side": null,
+            "id": 7,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Biggs Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6696,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6697,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6698,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6699,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rojo Tres",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que realices una acción <barrelroll> o <boost>, puedes realizar una acción <evade> roja.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5860,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5861,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5862,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_8",
+            "force_side": null,
+            "id": 8,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Leevan Tenza",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6700,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6701,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6702,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6703,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Desertor de la Alianza Rebelde",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de que te actives, si estás concentrado, puedes realizar una acción.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5863,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5864,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5865,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_9",
+            "force_side": null,
+            "id": 9,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Edrio Dos Tubos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6704,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6705,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6706,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6707,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Veterano de los Ángeles Cavernarios",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>El Escuadrón Rojo fue creado como una unidad de cazas estelares de élite, y está compuesto por algunos de los mejores pilotos de la Alianza Rebelde.</flavor>",
             "available_actions": [
                 {
@@ -84,164 +823,164 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mientras efectúas un ataque, el defensor tira 1 dado de defensa menos.",
+            "ability_text": "<flavor>Diseñado por la Corporación Incom, el caza T-65 Ala-X no tardó en convertirse en uno de los vehículos militares más efectivos y versátiles de la galaxia y una gran baza para la Rebelión.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 5869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 5870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 5871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
             "card_set_ids": [
+                1,
                 4,
                 7
             ],
             "card_type_id": 1,
-            "cost": "52",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_1",
+            "ffg_id": "XW_P_11",
             "force_side": null,
-            "id": 1,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Wedge Antilles",
+            "id": 11,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Escolta del Escuadrón Azul",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 6712,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 6713,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 6714,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 6715,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Rojo Dos",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "Mientras efectúas un ataque, puedes gastar 1 resultado <focus>, <hit> o <crit> para mirar las cartas de Daño boca abajo del defensor, elegir 1 de ellas y exponerla.",
+            "ability_text": "<flavor>A diferencia de la mayoría de las células rebeldes, los partisanos de Saw Gerrera estaban dispuestos a utilizar métodos extremos para frustrar los planes del Imperio Galáctico, y así lo hicieron en brutales batallas que asolaron desde Geonosis a Jedha.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 5872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 5873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 5874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
+                13,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
             "card_set_ids": [
-                7
+                2
             ],
             "card_type_id": 1,
-            "cost": "48",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_3",
+            "ffg_id": "XW_P_12",
             "force_side": null,
-            "id": 3,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Thane Kyrell",
+            "id": 12,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Fanático de los Ángeles Cavernarios",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 6716,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 6717,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 6718,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 6719,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Corona Cuatro",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -332,343 +1071,6 @@
                 }
             ],
             "subtitle": "Oro Nueve",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que gastes una ficha de Concentración, puedes elegir 1 nave aliada que tengas a alcance 1–3. Esa nave recibe 1 ficha de Concentración.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5848,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5849,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5850,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_4",
-            "force_side": null,
-            "id": 4,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6684,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6685,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6686,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6687,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Jefe Rojo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Diseñado por la Corporación Incom, el caza T-65 Ala-X no tardó en convertirse en uno de los vehículos militares más efectivos y versátiles de la galaxia y una gran baza para la Rebelión.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5869,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5870,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5871,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_11",
-            "force_side": null,
-            "id": 11,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Escolta del Escuadrón Azul",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6712,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6713,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6714,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6715,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque, puedes volver a tirar 1 dado de ataque por cada otra nave aliada que esté situada a alcance 0–1 del defensor.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5883,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5884,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5885,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5886,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
-            "card_set_ids": [
-                4,
-                8
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_15",
-            "force_side": null,
-            "id": 15,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Horton Salm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 6728,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6729,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6730,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6731,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Jefe Gris",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de de que realices una acción <barrelroll> o <boost>, puedes darle la vuelta a la carta de Mejora <config> que tengas equipada en tu nave.\n",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5854,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5855,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5856,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_6",
-            "force_side": null,
-            "id": 6,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kullbee Sperado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6692,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6693,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6694,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6695,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Pistolero enigmático",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -765,42 +1167,183 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Al comienzo de la fase Final, puedes gastar 1 ficha de Concentración para reparar 1 de tus cartas de Daño boca arriba.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+            "ability_text": "Mientras efectúas un ataque, puedes volver a tirar 1 dado de ataque por cada otra nave aliada que esté situada a alcance 0–1 del defensor.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5883,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5884,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5885,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5886,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
             "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_157",
-            "force_side": null,
-            "id": 382,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
+                4,
                 8
             ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_15",
+            "force_side": null,
+            "id": 15,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Horton Salm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6728,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6729,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6730,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6731,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Jefe Gris",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes gastar 1 ficha de Concentración para elegir una nave aliada que tengas a alcance 0–1. Si lo haces, esa nave tira 1 dado de defensa adicional mientras se está defendiendo hasta el final de la ronda.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5887,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5888,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5889,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5890,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_set_ids": [
+                8
+            ],
+            "card_type_id": 1,
+            "cost": "36",
+            "faction_id": 1,
+            "ffg_id": "XW_P_16",
+            "force_side": null,
+            "id": 16,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Evaan Verlaine",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6732,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6733,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6734,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6735,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Oro Tres",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -896,39 +1439,38 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes gastar 1 ficha de Concentración para elegir una nave aliada que tengas a alcance 0–1. Si lo haces, esa nave tira 1 dado de defensa adicional mientras se está defendiendo hasta el final de la ronda.",
+            "ability_text": "<flavor>Mucho después de que los Alas-Y dejaran de ser utilizados por el Imperio Galáctico, su resistencia, fiabilidad y potente armamento contribuyeron a asegurar su permanencia en la flota rebelde.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 5895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 5896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 5897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 5898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 4,
                 5,
                 10,
@@ -936,51 +1478,52 @@
                 14,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
             "card_set_ids": [
+                4,
                 8
             ],
             "card_type_id": 1,
-            "cost": "36",
+            "cost": "32",
             "faction_id": 1,
-            "ffg_id": "XW_P_16",
+            "ffg_id": "XW_P_18",
             "force_side": null,
-            "id": 16,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Evaan Verlaine",
+            "id": 18,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Bombardero del Escuadrón Gris",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 6740,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 6741,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 6742,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 6743,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Oro Tres",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1078,167 +1621,179 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Después de que realices una acción <barrelroll> o <boost>, puedes realizar una acción <evade> roja.",
+            "ability_text": "Eres capaz de efectuar ataques principales a alcance 0.<return>Si una acción <boost> tuya va a fracasar debido a que te solapas con otra nave, en vez de eso resuélvela como si estuvieras ejecutando parcialmente una maniobra.<return>Propulsores vectoriales: Después de que realices una acción, puedes realizar una acción <boost> roja.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 5904,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 5906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 5907,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                5,
-                10,
-                13,
-                14,
-                18
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
             "card_set_ids": [
-                2
+                4
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_8",
+            "ffg_id": "XW_P_20",
             "force_side": null,
-            "id": 8,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "id": 20,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "•Leevan Tenza",
+            "name": "•Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 33,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 6748,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6701,
-                    "recurring": false,
-                    "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 6749,
                     "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
+                    "statistic_id": 1,
+                    "value": "3"
                 },
                 {
-                    "id": 6703,
+                    "id": 6750,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6751,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Desertor de la Alianza Rebelde",
+            "subtitle": "Jefe Verde",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Mucho después de que los Alas-Y dejaran de ser utilizados por el Imperio Galáctico, su resistencia, fiabilidad y potente armamento contribuyeron a asegurar su permanencia en la flota rebelde.</flavor>",
+            "ability_text": "<flavor>Debido a la sensibilidad de sus mandos y su elevada capacidad de maniobra, sólo los mejores pilotos se sientan en la carlinga de un Ala-A.</flavor><return>Propulsores vectoriales: Después de que realices una acción, puedes realizar una acción <boost> roja.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 5909,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 5911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "base_action_side_effect": null,
+                    "id": 5912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
+                1,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
             "card_set_ids": [
-                4,
-                8
+                4
             ],
             "card_type_id": 1,
-            "cost": "32",
+            "cost": "34",
             "faction_id": 1,
-            "ffg_id": "XW_P_18",
+            "ffg_id": "XW_P_21",
             "force_side": null,
-            "id": 18,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-            "initiative": 2,
+            "id": 21,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
+            "initiative": 3,
             "is_unique": false,
-            "name": "Bombardero del Escuadrón Gris",
+            "name": "Piloto del Escuadrón Verde",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 12,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 6752,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 6753,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "1"
+                    "value": "3"
                 },
                 {
-                    "id": 6742,
+                    "id": 6754,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "6"
+                    "value": "2"
                 },
                 {
-                    "id": 6743,
+                    "id": 6755,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1246,46 +1801,6 @@
             ],
             "subtitle": "",
             "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras tienes exactamente 1 ficha de Desarme, sigues siendo capaz de efectuar ataques <torpedo> y <missile> contra objetivos sobre los que tengas un Blanco fijado. Si lo haces, no puedes gastar tu Blanco fijado durante el ataque.<return>Añádete los espacios <torpedo> y <missile>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_125",
-            "force_side": null,
-            "id": 350,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Configuración de arsenal Os-1",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 14,
-                            "raw_name": "Alpha-class Star Wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -1381,93 +1896,3985 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Eres capaz de efectuar ataques principales a alcance 0.<return>Si una acción <boost> tuya va a fracasar debido a que te solapas con otra nave, en vez de eso resuélvela como si estuvieras ejecutando parcialmente una maniobra.<return>Propulsores vectoriales: Después de que realices una acción, puedes realizar una acción <boost> roja.",
+            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes volver a tirar hasta 2 de tus dados.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5905,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
+                    "id": 5919,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 5920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 5921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                6
+                2,
+                3,
+                3,
+                5,
+                14
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_23",
+            "force_side": null,
+            "id": 23,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Braylen Stramm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6760,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6761,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6762,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6763,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Jefe Cuchilla",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes o efectúas un ataque, puedes gastar 1 ficha de Tensión para cambiar todos tus resultados <focus> por resultados <evade> o <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5922,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5923,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5924,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_24",
+            "force_side": null,
+            "id": 24,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Ten Numb",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6764,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6765,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6766,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6767,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Azul Cinco",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>El Ala-B dispone de un sistema único de giroestabilización que rota alrededor de la carlinga para mantener al piloto siempre en la misma posición durante el vuelo.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5925,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5926,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5927,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 1,
+            "ffg_id": "XW_P_25",
+            "force_side": null,
+            "id": 25,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Veterano del Escuadrón Cuchilla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6768,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6769,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6770,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6771,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Gracias a sus sistemas de armamento pesado y sus resistentes escudos deflectores, el Ala-B se ha consolidado como uno de los cazas de asalto más innovadores de la Alianza Rebelde.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5928,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5929,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5930,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_26",
+            "force_side": null,
+            "id": 26,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto del Escuadrón Azul",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6772,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6773,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6774,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6775,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que efectúes un ataque, puedes elegir 1 nave aliada que tengas a alcance 1. Esa nave puede realizar una acción, considerándola de color rojo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5931,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5932,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5933,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 1,
             "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_20",
+            "ffg_id": "XW_P_27",
             "force_side": null,
-            "id": 20,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-            "initiative": 3,
+            "id": 27,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
+            "initiative": 5,
             "is_unique": true,
-            "name": "•Arvel Crynyd",
+            "name": "•Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 35,
+            "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 6776,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 6777,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "3"
+                    "value": "2"
                 },
                 {
-                    "id": 6750,
+                    "id": 6778,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 6779,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Jefe Verde",
+            "subtitle": "Jefe de inteligencia",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque principal, si hay al menos 1 otra nave aliada situada a alcance 0–1 del defensor, puedes tirar 1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5934,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5935,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5936,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_28",
+            "force_side": null,
+            "id": 28,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Teniente Blount",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6780,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6781,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6782,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6783,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Trabajador en equipo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>La serie AF4 es la última en una larga serie de diseños de Cazacabezas. Barata y relativamente duradera, es muy apreciada por organizaciones independientes como la Alianza Rebelde.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5937,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5938,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5939,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "25",
+            "faction_id": 1,
+            "ffg_id": "XW_P_29",
+            "force_side": null,
+            "id": 29,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto del Escuadrón Tala",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6784,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6785,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6786,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6787,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>El Z-95 Cazacabezas fue la principal inspiración para el espléndido caza estelar T-65 Ala-X de la Corporación Incom. Aunque el Z-95 se considera anticuado para los estándares modernos, sigue siendo un caza de combate versátil y potente.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5940,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5941,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5942,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "23",
+            "faction_id": 1,
+            "ffg_id": "XW_P_30",
+            "force_side": null,
+            "id": 30,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Piloto del Escuadrón Bandido",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6788,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6789,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6790,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6791,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque principal, si estás dañado, puedes tirar 1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5943,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5944,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5945,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "56",
+            "faction_id": 1,
+            "ffg_id": "XW_P_31",
+            "force_side": null,
+            "id": 31,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Wullffwarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6792,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6793,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6794,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6795,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Caudillo wookiee",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que una nave aliada que tengas a alcance 0–1 se convierta en el defensor, puedes gastar 1 ficha de Refuerzo. Si lo haces, esa nave recibe 1 ficha de Evasión.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5946,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5947,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5948,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_32",
+            "force_side": null,
+            "id": 32,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Lowhhrick",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6796,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6797,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6798,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6799,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gladiador fugado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Equipada con tres cañones láser dobles Sureggi de amplio alcance, la cañonera Auzituck sirve como un potente elemento disuasorio ante las actividades esclavistas en el sistema Kashyyyk.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5949,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5950,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5951,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_33",
+            "force_side": null,
+            "id": 33,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Defensor de Kashyyyk",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6800,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6801,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6802,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6803,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que reveles una maniobra de color rojo o azul, puedes establecer en tu selector otra maniobra con esa misma dificultad.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5952,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5953,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5954,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "39",
+            "faction_id": 1,
+            "ffg_id": "XW_P_34",
+            "force_side": null,
+            "id": 34,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6804,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6805,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6806,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6807,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de que te actives, puedes realizar una maniobra <barrelroll> o <boost>.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5955,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5956,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5957,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_35",
+            "force_side": null,
+            "id": 35,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6808,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6809,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6810,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6811,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes gastar 1 <forcecharge> para cambiar hasta 2 de tus resultados <focus> por resultados <evade> o <hit>.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5958,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5959,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5960,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "41",
+            "faction_id": 1,
+            "ffg_id": "XW_P_36",
+            "force_side": 2,
+            "id": 36,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6812,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6813,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6814,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6815,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6816,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes, los resultados <crit> se neutralizan antes que los resultados <hit>.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5961,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5962,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5963,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 1,
+            "ffg_id": "XW_P_37",
+            "force_side": null,
+            "id": 37,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6817,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6818,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6819,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6820,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que una nave enemiga situada en tu arco de fuego intervenga, si no estás bajo tensión, puedes recibir 1 ficha de Tensión. Si lo haces, esa nave enemiga no puede gastar fichas para modificar dados mientras efectúa un ataque durante esta fase.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5964,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5965,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_38",
+            "force_side": null,
+            "id": 38,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6821,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6822,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6823,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6824,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6825,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Rebelde reacio",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes gastar 1 <forcecharge> para cambiar hasta 2 de tus resultados <focus> por resultados <evade>/<hit>.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5966,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5967,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                10,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_39",
+            "force_side": 2,
+            "id": 39,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6826,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6827,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6828,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6829,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6830,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6831,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes, los resultados <crit> se neutralizan antes que los resultados <hit>.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5968,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5969,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_40",
+            "force_side": null,
+            "id": 40,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6832,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6833,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6834,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6835,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6836,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras realizas una coordinación, si eliges una nave que tenga exactamente 1 ficha de Tensión, esa nave es capaz de realizar acciones.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5970,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5971,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_41",
+            "force_side": null,
+            "id": 41,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
+            "initiative": 1,
+            "is_unique": true,
+            "name": "•AP-5",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6837,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6838,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6839,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6840,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6841,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Droide analista huido",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras una nave aliada situada en tu arco de fuego efectúa un ataque principal, si no estás bajo tensión, puedes recibir 1 ficha de Tensión. Si lo haces, esa nave aliada puede tirar 1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5972,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5973,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5974,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5975,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5976,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_42",
+            "force_side": null,
+            "id": 42,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Jan Ors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6842,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6843,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6844,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6845,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Experta en espionaje",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes transferir 1 de tus fichas de Concentración a una nave aliada situada en tu arco de fuego.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5977,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5978,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5979,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5980,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5981,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_43",
+            "force_side": null,
+            "id": 43,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kyle Katarn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6846,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6847,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6848,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6849,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Operativo incansable",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave que esté situada en tu arco de fuego. Si lo haces, en esta fase esa nave interviene con Iniciativa 7 en vez de su valor de Iniciativa normal.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5982,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5983,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5984,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5985,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5986,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_44",
+            "force_side": null,
+            "id": 44,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Roark Garnet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6850,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6851,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6852,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6853,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Contrabandista de buen corazón",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Diseñadas por la Corporación de Ingeniería Corelliana para que se parecieran a un pájaro en vuelo, las naves de la serie HWK son unos magníficos transportes. La velocidad y robustez del HWK-290 hacen que suela ser empleado por agentes rebeldes como base móvil de operaciones.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5987,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5988,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5989,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5990,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5991,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_45",
+            "force_side": null,
+            "id": 45,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Explorador rebelde",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6854,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6855,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6856,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6857,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes gastar 1 <forcecharge> para cambiar hasta 2 de tus resultados <focus> por resultados <evade> o <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5992,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5993,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5994,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_46",
+            "force_side": 2,
+            "id": 46,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6858,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6859,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6860,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6861,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de que te actives, puedes realizar una acción <barrelroll> o <boost>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5995,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5996,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5997,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 1,
+            "ffg_id": "XW_P_47",
+            "force_side": null,
+            "id": 47,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6862,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6863,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6864,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Espectro-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que efectúes un ataque, asigna el Estado Fuego de supresión al defensor.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5998,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5999,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6000,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_48",
+            "force_side": null,
+            "id": 48,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Capitán Rex",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6865,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6866,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6867,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Veterano de las Guerras Clon",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes, los resultados <crit> se neutralizan antes que los resultados <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6001,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6002,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6003,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "26",
+            "faction_id": 1,
+            "ffg_id": "XW_P_49",
+            "force_side": null,
+            "id": 49,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6868,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6869,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6870,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Espectro-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "A Iniciativa 0, puedes efectuar un ataque principal adicional contra una nave enemiga que tengas en tu <bullseye>. Si lo haces, al comienzo de la siguiente fase de Planificación, recibes 1 ficha de Desarme.<return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6004,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6005,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6006,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6007,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6008,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 1,
+            "ffg_id": "XW_P_50",
+            "force_side": null,
+            "id": 50,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Corran Horn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6871,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6872,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6873,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6874,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Investigador tenaz",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras una nave aliada efectúa un ataque, si el defensor está situado en tu <frontarc>, el atacante puede cambiar 1 resultado <hit> por un resultado <crit>.<return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6009,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6010,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6011,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6012,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6013,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 1,
+            "ffg_id": "XW_P_51",
+            "force_side": null,
+            "id": 51,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Gavin Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6875,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6876,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6877,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6878,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Piloto de flanco audaz",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Los pilotos de élite del Escuadrón Pícaro se cuentan entre los mejores de la Alianza Rebelde.</flavor><return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6014,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6015,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6016,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6017,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6018,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "63",
+            "faction_id": 1,
+            "ffg_id": "XW_P_52",
+            "force_side": null,
+            "id": 52,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Escolta del Escuadrón Pícaro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6879,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6880,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6881,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6882,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Diseñados para combinar las mejores prestaciones de las series Ala-X y Ala-A, el Ala-E supera a ambos modelos en velocidad, maniobrabilidad y potencia de fuego.</flavor><return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6019,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6020,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6021,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6022,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6023,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "61",
+            "faction_id": 1,
+            "ffg_id": "XW_P_53",
+            "force_side": null,
+            "id": 53,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Escolta del Escuadrón Canalla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6883,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6884,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6885,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6886,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Las naves aliadas son capaces de obtener Blancos fijados sobre objetos que estén situados a alcance 0–3 de cualquier nave aliada.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6024,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6025,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6026,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 1,
+            "ffg_id": "XW_P_54",
+            "force_side": null,
+            "id": 54,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Bodhi Rook",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6887,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6888,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6889,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6890,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Desertor imperial",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras una nave aliada dañada que tienes a alcance 0–3 efectúa un ataque, esa nave puede volver a tirar 1 dado de ataque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6027,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6028,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6029,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_55",
+            "force_side": null,
+            "id": 55,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Saw Gerrera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6891,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6892,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6893,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6894,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Radical obsesivo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Activación, puedes elegir 1 nave aliada que tengas a alcance 1–3. Si lo haces, esa nave retira 1 ficha de Tensión.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6030,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6031,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6032,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_56",
+            "force_side": null,
+            "id": 56,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Cassian Andor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6895,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6896,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6897,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6898,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Criado por la Rebelión",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras una nave aliada que tienes a alcance 0–2 se defiende, el atacante no puede volver a tirar más de 1 dado de ataque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6033,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6034,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6035,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_57",
+            "force_side": null,
+            "id": 57,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6899,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6900,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6901,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6902,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Vigía de los Ángeles Cavernarios",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que realices una acción <focus>, puedes transferir 1 de tus fichas de Concentración a una nave aliada que tengas a alcance 1–2.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6036,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6037,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6038,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_58",
+            "force_side": null,
+            "id": 58,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Benthic Dos Tubos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6903,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6904,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6905,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6906,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Tirador de los Ángeles Cavernarios",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que una nave enemiga ejecute una maniobra, si esa nave enemiga está situada a alcance 0 de ti, puedes realizar una acción.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6039,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6040,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6041,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_59",
+            "force_side": null,
+            "id": 59,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Heff Tobber",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6907,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6908,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6909,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6910,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Azul Ocho",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Empleado para desplegar tropas bajo el amparo de la oscuridad o en el fragor de la batalla, el UT-60D Ala-U proporciona a la Alianza Rebelde el transporte de tropas veloz y resistente que tanto necesitan.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6042,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6043,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6044,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_60",
+            "force_side": null,
+            "id": 60,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Explorador del Escuadrón Azul",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6911,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6912,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6913,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6914,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Los partisanos de Saw Gerrera se fundaron originalmente durante las Guerras Clon para hacer frente a las fuerzas separatistas en Onderon, pero decidieron proseguir su lucha contra la tiranía galáctica cuando el Imperio se hizo con el poder.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6045,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6046,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6047,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_61",
+            "force_side": null,
+            "id": 61,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Insurgente de los Partisanos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6915,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6916,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6917,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6918,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque principal, puedes optar por gastar 1 escudo para tirar 1 dado de ataque adicional o, si no estás protegido por escudos, puedes tirar 1 dado de ataque menos para recuperar 1 escudo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6048,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6049,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6050,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6051,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6052,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_62",
+            "force_side": null,
+            "id": 62,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Miranda Doni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6919,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6920,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6921,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6922,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Peso pesado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras una nave aliada que tienes a alcance 0–2 se defiende o efectúa un ataque, esa nave puede gastar tus fichas de Concentración como si fueran suyas.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6053,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6054,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6055,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6056,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6057,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_63",
+            "force_side": null,
+            "id": 63,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Esege Tuketu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6923,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6924,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6925,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6926,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Héroe abnegado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>El Ala-K de Koensayr está provisto de un avanzado motor de aceleración sublumínica y dieciocho ensamblajes, cualidades inéditas que le confieren una velocidad y potencia de fuego inigualables.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6058,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6059,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6060,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6061,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6062,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 1,
+            "ffg_id": "XW_P_64",
+            "force_side": null,
+            "id": 64,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto del Escuadrón Custodio",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6927,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6928,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6929,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6930,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes, si tienes al menos una nave enemiga a alcance 0–1, puedes añadir 1 resultado <evade> a tus resultados de dados.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6063,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6064,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6065,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "55",
+            "faction_id": 1,
+            "ffg_id": "XW_P_65",
+            "force_side": null,
+            "id": 65,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Norra Wexley",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6931,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6932,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6933,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6934,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6935,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Oro Nueve",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que gastes una ficha de Concentración, puedes elegir 1 nave aliada que tengas a alcance 1–3. Esa nave recibe 1 ficha de Concentración.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6066,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6067,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6068,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "51",
+            "faction_id": 1,
+            "ffg_id": "XW_P_66",
+            "force_side": null,
+            "id": 66,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6936,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6937,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6938,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6939,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6940,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Jefe Rojo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes o efectúas un ataque principal, puedes gastar 1 Blanco fijado que tengas sobre la nave enemiga para añadir 1 resultado <focus> a tus resultados de dados.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6069,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6070,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6071,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "53",
+            "faction_id": 1,
+            "ffg_id": "XW_P_67",
+            "force_side": null,
+            "id": 67,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Shara Bey",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6941,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6942,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6943,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6944,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6945,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Verde Cuatro",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que ejecutes completamente una maniobra, si estás bajo tensión, puedes tirar 1 dado de ataque. Si sacas un resultado <hit> o <crit>, retiras 1 ficha de Tensión.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6072,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6073,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6074,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_68",
+            "force_side": null,
+            "id": 68,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ibtisam",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6946,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6947,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6948,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6949,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6950,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Superviviente de Endor",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que tires los dados, si estás a alcance 0–1 de un obstáculo, puedes volver a tirar todos tus dados. Esto no cuenta como volver a tirar los dados en lo que respecta a otros efectos de juego.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6075,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6076,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6077,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6078,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "92",
+            "faction_id": 1,
+            "ffg_id": "XW_P_69",
+            "force_side": null,
+            "id": 69,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6951,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6952,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6953,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6954,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Granuja incorregible",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1559,6 +5966,533 @@
                 }
             ],
             "subtitle": "General de la Alianza",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de que te vaya a ser infligida una carta de Daño boca arriba, puedes gastar 1 <standardcharge> para que esa carta de Daño te sea infligida boca abajo en vez de boca arriba.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6083,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6084,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6085,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6086,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 1,
+            "ffg_id": "XW_P_71",
+            "force_side": null,
+            "id": 71,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Chewbacca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6959,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6960,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6961,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6962,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                },
+                {
+                    "id": 6963,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "El poderoso wookiee",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Conocido por su robustez y su diseño modular, el YT-1300 es uno de los cargueros más populares, utilizados y ampliamente modificados en toda la galaxia.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6087,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6088,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6089,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6090,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "78",
+            "faction_id": 1,
+            "ffg_id": "XW_P_72",
+            "force_side": null,
+            "id": 72,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Contrabandista del Borde Exterior",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6964,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6965,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6966,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6967,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que reveles una maniobra de color rojo o azul, puedes establecer en tu selector otra maniobra con esa misma dificultad.<return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6091,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6092,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6093,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "76",
+            "faction_id": 1,
+            "ffg_id": "XW_P_73",
+            "force_side": null,
+            "id": 73,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6968,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6969,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6970,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6971,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Espectro-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras una nave aliada situada en tu arco de fuego se defiende, puedes gastar 1 <forcecharge>. Si lo haces, el atacante tira 1 dado de ataque menos.<return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6094,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6095,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6096,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "90",
+            "faction_id": 1,
+            "ffg_id": "XW_P_74",
+            "force_side": 2,
+            "id": 74,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kanan Jarrus",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6972,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6973,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6974,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6975,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                },
+                {
+                    "id": 6976,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Espectro-1",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, toda nave enemiga que tengas a alcance 0 recibe 2 fichas de Interferencia.<return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6097,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6098,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6099,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 1,
+            "ffg_id": "XW_P_75",
+            "force_side": null,
+            "id": 75,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6977,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6978,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6979,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6980,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Espectro-3",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Otro exitoso diseño de carguero de la Corporación de Ingeniería Corelliana, el VCX-100 es más grande que la ubicua serie YT, por lo que dispone de más espacio para la tripulación y la instalación de mejoras personalizadas.</flavor><return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6100,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6101,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6102,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 1,
+            "ffg_id": "XW_P_76",
+            "force_side": null,
+            "id": 76,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebelde de Lothal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6981,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6982,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6983,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6984,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1973,87 +6907,6 @@
                 }
             ],
             "subtitle": "Jefe Obsidiana",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A diferencia de la mayoría de las células rebeldes, los partisanos de Saw Gerrera estaban dispuestos a utilizar métodos extremos para frustrar los planes del Imperio Galáctico, y así lo hicieron en brutales batallas que asolaron desde Geonosis a Jedha.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5872,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5873,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5874,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_12",
-            "force_side": null,
-            "id": 12,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Fanático de los Ángeles Cavernarios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6716,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6717,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6718,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6719,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -2647,9455 +7500,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Después de que realices una acción, puedes gastar 1 <forcecharge> para realizar una acción.<return><shipability>Computadora de selección de blancos avanzada: Mientras efectúas un ataque principal contra un defensor que tienes fijado como blanco, tira 1 dado de ataque adicional y cambia 1 resultado <hit> por un resultado <crit>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6154,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6155,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6156,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 2,
-            "ffg_id": "XW_P_93",
-            "force_side": 1,
-            "id": 93,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Darth Vader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7038,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7039,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7040,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7041,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7042,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Jefe Negro",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>El caza TIE avanzado supuso una mejora del popular TIE/ln gracias a la incorporación de escudos, armamento más potente, paneles solares curvados y un hiperimpulsor.</flavor><return><shipability>Computadora de selección de blancos avanzada: Mientras efectúas un ataque principal contra un defensor que tienes fijado como blanco, tira 1 dado de ataque adicional y cambia 1 resultado <hit> por un resultado <crit>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6166,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6167,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6168,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 2,
-            "ffg_id": "XW_P_97",
-            "force_side": null,
-            "id": 97,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "As del Escuadrón Tormenta",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7055,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7056,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7057,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7058,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>El TIE avanzado v1 de Sistemas de Flota Sienar es un diseño innovador de caza estelar provisto de motores ultramodernos, un lanzamisiles y alas plegables.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6182,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6183,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6184,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6185,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6186,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_101",
-            "force_side": null,
-            "id": 101,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Barón del Imperio",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 25,
-            "statistics": [
-                {
-                    "id": 7073,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7074,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7075,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7076,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes una acción <reload>, puedes recuperar 1 ficha <standardcharge> que esté sobre 1 de tus cartas de Mejora <talent> equipadas.<return><shipability>Bombardero ágil: Si vas a soltar un dispositivo utilizando una plantilla <straight>, en vez de esa plantilla puedes utilizar una plantilla <leftbank> o <rightbank> con la misma velocidad.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6208,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6209,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6210,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6211,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_107",
-            "force_side": null,
-            "id": 107,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Tomax Bren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7094,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7095,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7096,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Inconformista impetuoso",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que seas destruido, antes de ser retirado de la zona de juego, puedes efectuar un ataque y soltar o lanzar 1 dispositivo. <return><shipability>Bombardero ágil: Si vas a soltar un dispositivo utilizando una plantilla <straight>, en vez de esa plantilla puedes utilizar una plantilla <leftbank> o <rightbank> con la misma velocidad.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6220,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6221,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6222,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6223,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_110",
-            "force_side": null,
-            "id": 110,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Muerte Ígnea”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7103,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7104,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7105,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Desafiante hasta el final",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>Mientras te defiendes, si el atacante no tiene ninguna ficha verde, puedes cambiar 1 de tus resultados <focus> o de cara vacía por un resultado <evade>.</smallbody><return><sasmall><sabold>Alerones adaptativos:</sabold> Antes de revelar tu selector, si no estás bajo tensión, <bold>debes</bold> ejecutar una maniobra [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>] blanca.</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6236,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6237,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6238,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6239,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 2,
-            "ffg_id": "XW_P_114",
-            "force_side": null,
-            "id": 114,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitán Feroph",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 43,
-            "statistics": [
-                {
-                    "id": 7116,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7117,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7118,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7119,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Mensajero imperial",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes, después del paso de “Neutralizar los resultados”, puedes sufrir 1 de daño <hit> y recibir 1 ficha de Tensión. Si lo haces, anula todos los resultados de los dados.<return><shipability>Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 <leftbank>], [1 <straight>] o [1 <rightbank>] de color blanco.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6251,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6252,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6253,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_118",
-            "force_side": null,
-            "id": 118,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•“Cuenta Atrás”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 16,
-            "statistics": [
-                {
-                    "id": 7131,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7132,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7133,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Amante del riesgo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes un ataque que impacte, si estás evadiéndote, expón 1 de las cartas de Daño del defensor.<return><shipability>Aceleración máxima: Después de que ejecutes completamente una maniobra de velocidad 3−5, puedes realizar una acción <evade>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6263,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6264,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6265,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6266,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6267,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_122",
-            "force_side": null,
-            "id": 122,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Rexler Brath",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 18,
-            "statistics": [
-                {
-                    "id": 7143,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7144,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7145,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7146,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Jefe Ónice",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Durante el desarrollo del TIE Agresor, Sistemas de Flota Sienar antepuso las prestaciones y la versatilidad a la mera eficiencia en costes.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6297,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6298,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6299,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 2,
-            "ffg_id": "XW_P_130",
-            "force_side": null,
-            "id": 130,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Especialista de Sienar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7175,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7176,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7177,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7178,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>EL TIE Fantasma, producto de las investigaciones llevadas a cabo en unas instalaciones secretas de Imdaar Alfa, es algo que muchos creían imposible: un caza estelar de dimensiones reducidas equipado con un avanzado dispositivo de camuflaje.</flavor><return><shipability>Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción <evade>. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6312,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6313,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6314,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 7,
-                    "base_action_side_effect": null,
-                    "id": 6315,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_134",
-            "force_side": null,
-            "id": 134,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Piloto de pruebas de Imdaar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 27,
-            "statistics": [
-                {
-                    "id": 7191,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7192,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7193,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7194,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Con un diseño inspirado en el de otras naves de Talleres Espaciales Cygnus, el Ala Estelar clase Alfa es un vehículo versátil asignado a unidades especializadas de la Armada Imperial que precisan un caza estelar capaz de desempeñar múltiples funciones.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6328,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6329,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6330,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6331,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                6,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "35",
-            "faction_id": 2,
-            "ffg_id": "XW_P_138",
-            "force_side": null,
-            "id": 138,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto del Escuadrón Nu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 14,
-            "statistics": [
-                {
-                    "id": 7207,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7208,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7209,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7210,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 o más naves aliadas que tengas a alcance 0−3. Si lo haces, transfiere a tu nave todas las fichas enemigas de Blanco fijado que hay en las naves elegidas.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6347,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6348,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 6349,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6350,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                8,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 2,
-            "ffg_id": "XW_P_142",
-            "force_side": null,
-            "id": 142,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Capitán Kagi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 26,
-            "statistics": [
-                {
-                    "id": 7223,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7224,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 7225,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7226,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7227,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Piloto de la lanzadera del Emperador",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque, si estás reforzado y el defensor está en el <fullfront> o <fullrear> que coincide con el de tu ficha de Refuerzo, puedes cambiar 1 de tus resultados <focus> por un resultado <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6368,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6369,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6370,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6371,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6372,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "88",
-            "faction_id": 2,
-            "ffg_id": "XW_P_147",
-            "force_side": null,
-            "id": 147,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Contralmirante Chiraneau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7248,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7249,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7250,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7251,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Asesor del almirante Piett",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque principal, si hay al menos 1 nave aliada que no sea limitada situada a alcance 0 del defensor, tira 1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6386,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6387,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": "stress",
-                    "id": 6388,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6389,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
-            "card_set_ids": [
-                6,
-                11
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 3,
-            "ffg_id": "XW_P_151",
-            "force_side": null,
-            "id": 151,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kath Scarlet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 10,
-            "statistics": [
-                {
-                    "id": 7266,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7267,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "3"
-                },
-                {
-                    "id": 7268,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7269,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7270,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Capitana de los piratas Binayre",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, si el alcance de ataque es 1, puedes tirar 1 dado adicional.<return>Envite de Concordia: Mientras te defiendes, si el alcance de ataque es 1 y estás en el <frontarc> del atacante, cambia 1 resultado por un resultado <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6402,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6403,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6404,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6405,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 3,
-            "ffg_id": "XW_P_155",
-            "force_side": null,
-            "id": 155,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7286,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7287,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7288,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Jefe Calavera",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Debido a la sensibilidad de sus mandos y su elevada capacidad de maniobra, sólo los mejores pilotos se sientan en la carlinga de un Ala-A.</flavor><return>Propulsores vectoriales: Después de que realices una acción, puedes realizar una acción <boost> roja.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5909,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5910,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5911,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5912,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5913,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_21",
-            "force_side": null,
-            "id": 21,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Piloto del Escuadrón Verde",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 35,
-            "statistics": [
-                {
-                    "id": 6752,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6753,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6754,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6755,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Los ases del Escuadrón Calavera prefieren los estilos de vuelo agresivos con los que gracias al diseño de ala pivotante de sus naves disfrutan de una agilidad insuperable mientras persiguen a sus presas.</flavor><return>Envite de Concordia: Mientras te defiendes, si el alcance de ataque es 1 y estás en el <frontarc> del atacante, cambia 1 resultado por un resultado <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6418,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6419,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6420,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6421,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_159",
-            "force_side": null,
-            "id": 159,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Piloto del Escuadrón Calavera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7298,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7299,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7300,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, si tienes una o más naves a alcance 0, tú y toda otra nave que tengas a alcance 0 recibís 1 ficha de Campo de tracción. <return><shipability>Campos de tracción de remolque: Acción: Elige una nave que tengas en tu <frontarc> a alcance 1. Esa nave recibe 1 ficha de Campo de tracción, o 2 fichas de Campo de tracción si está situada en tu <bullseye> a alcance 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6432,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6433,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6434,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 3,
-            "ffg_id": "XW_P_163",
-            "force_side": null,
-            "id": 163,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Unkar Plutt",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7310,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7311,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7312,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Chatarrero tacaño",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave aliada que no sea limitada efectúa un ataque, si el defensor está situado en tu arco de fuego, el atacante puede volver a tirar 1 dado de ataque.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6442,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6443,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6444,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6445,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 3,
-            "ffg_id": "XW_P_166",
-            "force_side": null,
-            "id": 166,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Drea Renthal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7320,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7321,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7322,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7323,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Reina pirata",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>La mera mención de créditos imperiales basta para poner a tu servicio a un gran número de individuos no excesivamente dignos de confianza.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6446,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6447,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6448,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6449,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 3,
-            "ffg_id": "XW_P_167",
-            "force_side": null,
-            "id": 167,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto de fortuna",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7324,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7325,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7326,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7327,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Sólo puedes desplegarte mediante el despliegue de emergencia, y posees el nombre, Iniciativa, capacidad especial de piloto y <standardcharge> de nave del Diente de Perro aliado que ha sido destruido.<return><shipability>Nave de escape: Requiere el Diente de Perro. Debes empezar la partida acoplado con el Diente de Perro.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6460,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6461,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6462,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "6",
-            "faction_id": 3,
-            "ffg_id": "XW_P_171",
-            "force_side": null,
-            "id": 171,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Cachorro de Nashtah",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 7340,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7341,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7342,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7343,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Plan de contingencia",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave enemiga que tengas en tu arco de fuego a alcance 0–2. Si lo haces, transfiere 1 ficha de Concentración o Evasión de esa nave a la tuya.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6474,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6475,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6476,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6477,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6478,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 3,
-            "ffg_id": "XW_P_175",
-            "force_side": null,
-            "id": 175,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Palob Godalhi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 7357,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7358,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7359,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7360,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Insurgente de Teth",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que ejecutes completamente una maniobra, puedes recibir 1 ficha de Tensión para girar tu nave 90º sobre sí misma.<return><shipability>Micropropulsores: Mientras realizas un tonel volado, debes utilizar la plantilla <leftbank> o <rightbank> en vez de la plantilla <straight>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6493,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6494,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6495,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6496,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_179",
-            "force_side": null,
-            "id": 179,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Dalan Oberos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 3,
-            "statistics": [
-                {
-                    "id": 7373,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7374,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7375,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7376,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Cazarrecompensas de élite",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave aliada que tienes a alcance 0–1 se defiende, esa nave puede volver a tirar 1 de sus dados.<return><shipability>Emplazamiento para armas: Puedes equiparte con una mejora <cannon>, <torpedo> o <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6509,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6510,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6511,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6512,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_183",
-            "force_side": null,
-            "id": 183,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Serissu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7389,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7390,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7391,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7392,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Instructora de vuelo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, puedes sufrir 1 de daño <hit> para volver a tirar cualquier cantidad de tus dados.<return><shipability>Emplazamiento para armas: Puedes equiparte con una mejora <cannon>, <torpedo> o <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6525,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6526,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6527,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6528,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 3,
-            "ffg_id": "XW_P_187",
-            "force_side": null,
-            "id": 187,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Inaldra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7405,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7406,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7407,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7408,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Jefa de Punto Tansarii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes a alcance de ataque 3 o efectúas un ataque a alcance de ataque 1, tira 1 dado adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6541,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6542,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6543,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_191",
-            "force_side": null,
-            "id": 191,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Talonbane Cobra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7421,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7422,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7423,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7424,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Azote de Punto Tansarii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>El caza de asalto Kihraxz fue desarrollado expresamente para el sindicato criminal del Sol Negro, cuyos cotizadísimos ases estelares exigían naves ágiles y potentes que estuvieran a la altura de sus habilidades.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6553,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6554,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6555,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 3,
-            "ffg_id": "XW_P_195",
-            "force_side": null,
-            "id": 195,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "As del Sol negro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7437,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7438,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7439,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7440,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes una acción <boost>, puedes efectuar una acción <evade>.<return><shipability>Cerebro droide avanzado: Después de que efectúes una acción <calculate>, recibes 1 ficha de Cálculos.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6567,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6568,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6569,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6570,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 3,
-            "ffg_id": "XW_P_199",
-            "force_side": null,
-            "id": 199,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•IG-88C",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 21,
-            "statistics": [
-                {
-                    "id": 7453,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7454,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7455,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7456,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Máquina confabuladora",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Los legendarios buscadores de Gand rinden culto a las arremolinadas nieblas de su planeta natal y utilizan presagios, augurios y rituales místicos para hallar a su presa.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6581,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6582,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6583,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_203",
-            "force_side": null,
-            "id": 203,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Buscador gandiano",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 22,
-            "statistics": [
-                {
-                    "id": 7469,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7470,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7471,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7472,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes un ataque, toda nave enemiga situada en tu <bullseye> sufre 1 de daño <hit> a menos que retire 1 ficha verde.<return><shipability>En el punto de mira: Mientras efectúas un ataque, si el defensor está situado en tu <bullseye>, los dados de defensa no pueden ser modificados mediante fichas verdes.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6593,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6594,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6595,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6596,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                10,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_207",
-            "force_side": null,
-            "id": 207,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Torani Kulda",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 39,
-            "statistics": [
-                {
-                    "id": 7486,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7487,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7488,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "7"
-                },
-                {
-                    "id": 7489,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Mercenaria rodiana",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes volver a tirar hasta 2 de tus dados.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5919,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5920,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5921,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_23",
-            "force_side": null,
-            "id": 23,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Braylen Stramm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6760,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6761,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6762,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6763,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Jefe Cuchilla",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Si vas a huir del campo de batalla, puedes gastar 1 <standardcharge>. Si lo haces, colócate en reserva en vez de huir. Al comienzo de la siguiente fase de Planificación, colócate en la zona de juego dentro de alcance 1 del borde de la zona de juego por el que has huido.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6608,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6609,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6610,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                8,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 3,
-            "ffg_id": "XW_P_211",
-            "force_side": null,
-            "id": 211,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Moralo eval",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 24,
-            "statistics": [
-                {
-                    "id": 7503,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 7504,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7505,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "9"
-                },
-                {
-                    "id": 7506,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                },
-                {
-                    "id": 7507,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Genio del crimen",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir una nave aliada que tengas a alcance 0–1. Si lo haces, transfiere todas tus fichas verdes a esa nave.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6620,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6621,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6622,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_215",
-            "force_side": null,
-            "id": 215,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Manaroo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 45,
-            "statistics": [
-                {
-                    "id": 7521,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7522,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7523,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7524,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Aruzana agraciada",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Gracias a sus sistemas de armamento pesado y sus resistentes escudos deflectores, el Ala-B se ha consolidado como uno de los cazas de asalto más innovadores de la Alianza Rebelde.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5928,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5929,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5930,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_26",
-            "force_side": null,
-            "id": 26,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto del Escuadrón Azul",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6772,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6773,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6774,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6775,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, puedes gastar 1 ficha de Tensión para cambiar todos tus resultados <focus> por resultados <evade> o <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5922,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5923,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5924,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_24",
-            "force_side": null,
-            "id": 24,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Ten Numb",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6764,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6765,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6766,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6767,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Azul Cinco",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>El Ala-B dispone de un sistema único de giroestabilización que rota alrededor de la carlinga para mantener al piloto siempre en la misma posición durante el vuelo.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5925,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5926,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5927,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 1,
-            "ffg_id": "XW_P_25",
-            "force_side": null,
-            "id": 25,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Veterano del Escuadrón Cuchilla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6768,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6769,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6770,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6771,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque principal, si el ataque está obstruido por un obstáculo, puedes tirar 1 dado adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6645,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6646,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6647,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6648,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_222",
-            "force_side": null,
-            "id": 222,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7555,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7556,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7557,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7558,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "El chico de Corellia",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque principal, si hay al menos 1 otra nave aliada situada a alcance 0–1 del defensor, puedes tirar 1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5934,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5935,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5936,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_28",
-            "force_side": null,
-            "id": 28,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Teniente Blount",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6780,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6781,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6782,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6783,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Trabajador en equipo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Diseñado para enfrentamientos prolongados, el TIE/ag se asigna casi siempre a pilotos de élite entrenados para saber aprovechar al máximo tanto su particular complemento de armas como su maniobrabilidad.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6294,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6295,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6296,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_129",
-            "force_side": null,
-            "id": 129,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Explorador del Escuadrón Ónice",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7171,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7172,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7173,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7174,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Las naves aliadas que tienes a alcance 0–1 son capaces de efectuar ataques aunque estén situadas a alcance 0 de obstáculos.\n<return><shipability><sabold>Copiloto:</sabold> Mientras estás acoplado, tu nave nodriza posee tu capacidad especial de piloto además de la suya propia.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6664,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6665,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6666,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "24",
-            "faction_id": 3,
-            "ffg_id": "XW_P_227",
-            "force_side": null,
-            "id": 227,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Pionero del Borde Exterior",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
-            "statistics": [
-                {
-                    "id": 7575,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7576,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7577,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7578,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Forajido ingenioso",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>El Z-95 Cazacabezas fue la principal inspiración para el espléndido caza estelar T-65 Ala-X de la Corporación Incom. Aunque el Z-95 se considera anticuado para los estándares modernos, sigue siendo un caza de combate versátil y potente.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5940,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5941,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5942,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "23",
-            "faction_id": 1,
-            "ffg_id": "XW_P_30",
-            "force_side": null,
-            "id": 30,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Piloto del Escuadrón Bandido",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6788,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6789,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6790,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6791,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que tires los dados, si no estás bajo tensión, puedes recibir 1 ficha de Tensión para volver a tirar todos tus resultados de cara vacía.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6649,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6650,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6651,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6652,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 3,
-            "ffg_id": "XW_P_223",
-            "force_side": null,
-            "id": 223,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7559,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7560,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7561,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7562,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Tahúr elocuente",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras otra nave aliada que tienes a alcance 0–1 se defiende, antes del paso de “Neutralizar los resultados”, si estás en el arco de ataque, puedes sufrir 1 de daño <hit> o <crit> para anular 1 resultado equivalente.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5857,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5858,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5859,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_7",
-            "force_side": null,
-            "id": 7,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Biggs Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6696,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6697,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6698,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6699,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rojo Tres",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de que te actives, si estás concentrado, puedes realizar una acción.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5863,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5864,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5865,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_9",
-            "force_side": null,
-            "id": 9,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Edrio Dos Tubos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6704,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6705,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6706,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6707,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Veterano de los Ángeles Cavernarios",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que una nave aliada que tengas a alcance 0–1 se convierta en el defensor, puedes gastar 1 ficha de Refuerzo. Si lo haces, esa nave recibe 1 ficha de Evasión.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5946,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5947,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5948,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_32",
-            "force_side": null,
-            "id": 32,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Lowhhrick",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6796,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6797,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6798,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6799,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gladiador fugado",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>La serie AF4 es la última en una larga serie de diseños de Cazacabezas. Barata y relativamente duradera, es muy apreciada por organizaciones independientes como la Alianza Rebelde.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5937,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5938,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5939,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "25",
-            "faction_id": 1,
-            "ffg_id": "XW_P_29",
-            "force_side": null,
-            "id": 29,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto del Escuadrón Tala",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6784,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6785,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6786,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6787,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque principal, si estás dañado, puedes tirar 1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5943,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5944,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5945,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "56",
-            "faction_id": 1,
-            "ffg_id": "XW_P_31",
-            "force_side": null,
-            "id": 31,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Wullffwarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6792,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6793,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6794,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6795,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Caudillo wookiee",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes un ataque, puedes elegir 1 nave aliada que tengas a alcance 1. Esa nave puede realizar una acción, considerándola de color rojo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5931,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5932,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5933,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "36",
-            "faction_id": 1,
-            "ffg_id": "XW_P_27",
-            "force_side": null,
-            "id": 27,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Airen Cracken",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6776,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6777,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6778,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6779,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Jefe de inteligencia",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de que te actives, puedes realizar una maniobra <barrelroll> o <boost>.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5955,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5956,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5957,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_35",
-            "force_side": null,
-            "id": 35,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6808,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6809,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6810,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6811,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>El remolcador espacial cuatrimotor para transferencia de carga, conocido popularmente como “saltador quad”, es tan ágil en el espacio como en la atmósfera, lo que lo hace popular entre contrabandistas y exploradores por igual.</flavor><return><shipability>Campos de tracción de remolque: Acción: Elige una nave que tengas en tu <frontarc> a alcance 1. Esa nave recibe 1 ficha de Campo de tracción, o 2 fichas de Campo de tracción si está situada en tu <bullseye> a alcance 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6435,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6436,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6437,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 3,
-            "ffg_id": "XW_P_164",
-            "force_side": null,
-            "id": 164,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Traficante de armas de Jakku",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7313,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7314,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7315,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Equipada con tres cañones láser dobles Sureggi de amplio alcance, la cañonera Auzituck sirve como un potente elemento disuasorio ante las actividades esclavistas en el sistema Kashyyyk.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5949,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5950,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5951,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_33",
-            "force_side": null,
-            "id": 33,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Defensor de Kashyyyk",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6800,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6801,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6802,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6803,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes gastar 1 <forcecharge> para cambiar hasta 2 de tus resultados <focus> por resultados <evade> o <hit>.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5958,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5959,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5960,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_36",
-            "force_side": 2,
-            "id": 36,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6812,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6813,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6814,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6815,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6816,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque principal, puedes optar por gastar 1 escudo para tirar 1 dado de ataque adicional o, si no estás protegido por escudos, puedes tirar 1 dado de ataque menos para recuperar 1 escudo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6048,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6049,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6050,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6051,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6052,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_62",
-            "force_side": null,
-            "id": 62,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Miranda Doni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6919,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6920,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6921,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6922,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Peso pesado",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante el paso de “Realizar una acción”, puedes realizar 1 acción, incluso aunque estés bajo tensión. Después de que realices una acción mientras estás bajo tensión, sufres 1 de daño <hit> a menos que expongas 1 de tus cartas de Daño.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_83",
-            "force_side": null,
-            "id": 307,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Acción:</smallcaps> Gasta 1<nonbreak><standardcharge> no recurrente de otra carta de Mejora que tengas equipada para recuperar 1 escudo.<return><smallcaps>Acción:</smallcaps> Gasta 2 escudos para recuperar 1<nonbreak><standardcharge> no recurrente sobre una mejora que tengas equipada.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_99",
-            "force_side": null,
-            "id": 323,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que ejecutes completamente una maniobra, si no has soltado ni lanzado ningún dispositivo en esta ronda, puedes soltar 1 bomba.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_143",
-            "force_side": null,
-            "id": 368,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Genio”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puedes acoplar 1 lanzadera de ataque o 1 lanzadera clase Sheathipede.<return>Tus naves acopladas sólo pueden desplegarse desde tus salientes traseros.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_102",
-            "force_side": null,
-            "id": 326,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Espíritu</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 23,
-                            "raw_name": "VCX-100 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "1 Z-95-AF4 Cazacabezas puede acoplarse contigo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_148",
-            "force_side": null,
-            "id": 373,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Diente de Perro</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 24,
-                            "raw_name": "YV-666 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puedes acoplarte a alcance 0–1.<return>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_106",
-            "force_side": null,
-            "id": 330,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Fantasma</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 32,
-                            "raw_name": "Attack Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    },
-                    {
-                        "kwargs": {
-                            "pk": 8,
-                            "raw_name": "Sheathipede-class Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientas efectúas un ataque principal, si el defensor está situado en tu <frontarc>, tira 1 dado de ataque adicional.<return>Elimínate el espacio <crew>. Añádete el espacio <astro>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_152",
-            "force_side": null,
-            "id": 377,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Castigadora</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 45,
-                            "raw_name": "JumpMaster 5000"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave enemiga que tengas a alcance 0–1. Si lo haces, recibes 1 ficha de Cálculos a menos que esa nave elija recibir 1 ficha de Tensión.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_127",
-            "force_side": null,
-            "id": 352,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•0-0-0",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 338
-                        },
-                        "type": "CARD_INCLUDED"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 93
-                        },
-                        "type": "CARD_INCLUDED"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que otra nave aliada que tengas a alcance 0–3 se defienda, si esa nave es destruida, el atacante recibe 2 fichas de Tensión.<return>Mientras una nave aliada que tienes a alcance 0–3 efectúa un ataque contra una nave que está bajo tensión, esa nave aliada puede volver a tirar 1 dado de ataque.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_109",
-            "force_side": null,
-            "id": 335,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Admiral Sloane",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes un ataque principal, si estás concentrado, puedes realizar un ataque <turretarc> adicional contra una nave que no hayas atacado todavía en esta ronda.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "14",
-            "faction_id": null,
-            "ffg_id": "XW_U_95",
-            "force_side": null,
-            "id": 319,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bistan",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes un ataque principal que falle, si no estás bajo tensión, debes recibir 1 ficha de Tensión para efectuar un ataque principal adicional contra ese mismo objetivo.<return>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_139",
-            "force_side": null,
-            "id": 364,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bossk",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas una acción <focus>, puedes considerarla como si fuera roja. Si lo haces, recibes 1 ficha de Concentración adicional por cada nave enemiga que tengas a alcance 0–1, hasta un máximo de 2.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_79",
-            "force_side": null,
-            "id": 303,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Baze Malbus",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante la fase Final, puedes elegir 2 mejoras <illicit> que estén equipadas en naves aliadas que tengas a alcance 0–1. Si lo haces, puedes intercambiar esas mejoras.<return>Final de la partida: Devuelve todas las mejoras <illicit> a sus naves originales.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_131",
-            "force_side": null,
-            "id": 356,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Cikatro Vizago",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Acción:</smallcaps> Gasta 1<nonbreak><standardcharge> para realizar una acción <cloak>.<return>Al comienzo de la fase de Planificación, tira 1 dado de ataque, Si sacas un resultado <focus>, desactiva el camuflaje o descarta tu ficha de Camuflaje.<return>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_57",
-            "force_side": null,
-            "id": 286,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Dispositivo de camuflaje",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6594,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante la fase de Activación, las naves enemigas que tengas a alcance 0–1 no pueden retirar fichas de Tensión.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_113",
-            "force_side": null,
-            "id": 339,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Soldados de la muerte",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8,
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante la fase de Sistemas, puedes gastar 2<nonbreak><standardcharge>. Si lo haces, toda nave aliada puede obtener un Blanco fijado sobre una nave que tengas fijada como blanco.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_117",
-            "force_side": null,
-            "id": 343,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Gran Moff Tarkin",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "STRESS"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6601,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Preparación:<smallcaps> Después de desplegar las fuerzas, elige 1 nave enemiga y asígnale el Estado <smallcaps>Dispositivo de escucha</smallcaps>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_44",
-            "force_side": null,
-            "id": 273,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Confidente",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Si una nave aliada que tienes a alcance 0–3 va a recibir una ficha de Concentración, en vez de eso puede recibir 1 ficha de Evasión.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_85",
-            "force_side": null,
-            "id": 309,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Jyn Erso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes, si el atacante está bajo tensión, puedes retirar 1 ficha de Tensión del atacante para cambiar 1 de tus resultados de cara vacía/<focus> por un resultado <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_135",
-            "force_side": null,
-            "id": 360,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Latts Razzi",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, si no tienes ninguna otra nave aliada a alcance 0–2, puedes gastar 1<nonbreak><standardcharge> para volver a tirar 1 de tus dados.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_9",
-            "force_side": null,
-            "id": 238,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lobo solitario",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6606,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que te defiendas, si el ataque ha impactado, puedes obtener un Blanco fijado sobre el atacante.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_89",
-            "force_side": null,
-            "id": 313,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras realizas una coordinación, la nave que eliges sólo es capaz de realizar una acción si dicha acción figura también en tu barra de acciones.",
-            "available_actions": [
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 5830,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_16",
-            "force_side": null,
-            "id": 245,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Jefe de escuadrón",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de que vayas a sufrir daño causado por un obstáculo o por la detonación de una bomba aliada, puedes gastar 1<nonbreak><standardcharge>. Si lo haces, evitas sufrir 1 de ese daño.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_68",
-            "force_side": null,
-            "id": 292,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Blindaje ablativo",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "LARGE"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6614,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Cambia 1 resultado <hit> por un resultado <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_33",
-            "force_side": null,
-            "id": 262,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Torpedos de protones avanzados",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6615,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "5"
-                },
-                {
-                    "id": 6617,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                5
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1"
-        },
-        {
-            "ability_text": "Después de que reveles tu selector, puedes realizar 1 acción.<return>Si lo haces, no puedes realizar otra acción durante tu activación.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_23",
-            "force_side": null,
-            "id": 252,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Sensores avanzados",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes una acción <slam>, si has ejecutado completamente la maniobra, puedes realizar una acción blanca que figure en tu barra de acciones, considerando esa acción como si fuera roja.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_69",
-            "force_side": null,
-            "id": 293,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Motor sublumínico avanzado",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Slam",
-                            "pk": 13,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Minibomba utilizando la plantilla [1<nonbreak><straight>].<return>Al comienzo de la fase de Activación, puedes gastar 1 escudo para recuperar 2<nonbreak> <standardcharge>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_63",
-            "force_side": null,
-            "id": 392,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Generador de minibombas",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6622,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12,
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Después de este ataque, puedes efectuar este ataque como un ataque adicional contra un objetivo diferente que esté situado a alcance 0–1 del defensor, ignorando el requisito <targetlock>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_37",
-            "force_side": null,
-            "id": 266,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Misiles de racimo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6623,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6625,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "4"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                6
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<flavor>Empleado para desplegar tropas bajo el amparo de la oscuridad o en el fragor de la batalla, el UT-60D Ala-U proporciona a la Alianza Rebelde el transporte de tropas veloz y resistente que tanto necesitan.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6042,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6043,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6044,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_60",
-            "force_side": null,
-            "id": 60,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Explorador del Escuadrón Azul",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6911,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6912,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6913,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6914,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras realizas un impulso o un tonel volado, eres capaz de moverte pasando a través de obstáculos y solaparte con ellos.<return>Después de que pases a través de un obstáculo o te solapes con uno, puedes gastar 1<nonbreak><standardcharge> para ignorar sus efectos hasta el final de la ronda.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_24",
-            "force_side": null,
-            "id": 253,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Detector de colisiones",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6626,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de que te actives, puedes gastar 1 ficha <standardcharge>. Si lo haces, hasta el final de la ronda, eres capaz de realizar acciones y ejecutar maniobras rojas, incluso aunque estés bajo tensión.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_58",
-            "force_side": null,
-            "id": 287,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ciberimplantes ilícitos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6631,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras realizas una acción <boost> blanca, puedes considerarla como si fuera roja para usar la plantilla [1<nonbreak><leftturn>] o [1<nonbreak><rightturn>] en vez de una de las plantillas normales para esta acción.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                12
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_2",
-            "force_side": null,
-            "id": 231,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Temerario",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Boost",
-                            "pk": 1,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Preparación:</smallcaps> Pierdes 1 <standardcharge>.<return><smallcaps>Acción:</smallcaps> Recupera 1<nonbreak><standardcharge>.<return><smallcaps>Acción:</smallcaps> Gasta 1<nonbreak><standardcharge> para recuperar 1 escudo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_43",
-            "force_side": null,
-            "id": 272,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Droide GNK “Gonk”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6636,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque <turretarc>, después del paso de “Modificar dados de defensa”, el defensor retira 1 ficha de Concentración o de Cálculos.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_49",
-            "force_side": null,
-            "id": 278,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Artillero habilidoso",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Para quienes no pueden permitirse instalar un generador de escudos más potente, añadir capas adicionales de blindaje al casco de una nave puede servirles de alternativa adecuada.</flavor>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "*",
-            "faction_id": null,
-            "ffg_id": "XW_U_73",
-            "force_side": null,
-            "id": 297,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Blindaje mejorado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6642,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_28",
-            "force_side": null,
-            "id": 257,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Cañón de iones",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6643,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                3
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
-        },
-        {
-            "ability_text": "Mientras efectúas un ataque <frontarc>, si no estás situado en el arco de fuego del defensor, éste tira 1 dado de defensa menos.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_11",
-            "force_side": null,
-            "id": 240,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Superioridad táctica",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que reveles tu selector de maniobras, puedes gastar 1<nonbreak><standardcharge> y recibir 1 ficha de Desarme para recuperar 1 escudo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-            "card_set_ids": [
-                1,
-                4,
-                6,
-                7
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_53",
-            "force_side": null,
-            "id": 282,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Droide astromecánico R2",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6663,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes, los resultados <crit> se neutralizan antes que los resultados <hit>.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5961,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5962,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5963,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_37",
-            "force_side": null,
-            "id": 37,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6817,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6818,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6819,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6820,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que una nave enemiga situada en tu arco de fuego intervenga, si no estás bajo tensión, puedes recibir 1 ficha de Tensión. Si lo haces, esa nave enemiga no puede gastar fichas para modificar dados mientras efectúa un ataque durante esta fase.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5964,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5965,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_38",
-            "force_side": null,
-            "id": 38,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6821,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6822,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6823,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6824,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6825,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Rebelde reacio",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Diseñadas por la Corporación de Ingeniería Corelliana para que se parecieran a un pájaro en vuelo, las naves de la serie HWK son unos magníficos transportes. La velocidad y robustez del HWK-290 hacen que suela ser empleado por agentes rebeldes como base móvil de operaciones.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5987,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5988,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5989,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5990,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5991,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_45",
-            "force_side": null,
-            "id": 45,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Explorador rebelde",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6854,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6855,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6856,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6857,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes gastar 1 <forcecharge> para cambiar hasta 2 de tus resultados <focus> por resultados <evade>/<hit>.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5966,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5967,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                10,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_39",
-            "force_side": 2,
-            "id": 39,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6826,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6827,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6828,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6829,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6830,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6831,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes, los resultados <crit> se neutralizan antes que los resultados <hit>.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5968,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5969,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_40",
-            "force_side": null,
-            "id": 40,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6832,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6833,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6834,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6835,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6836,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras realizas una coordinación, si eliges una nave que tenga exactamente 1 ficha de Tensión, esa nave es capaz de realizar acciones.<return>Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere <coordinate>. Antes de que tu nave nodriza se active, puede realizar una acción <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5970,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5971,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_41",
-            "force_side": null,
-            "id": 41,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-            "initiative": 1,
-            "is_unique": true,
-            "name": "•AP-5",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6837,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6838,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6839,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6840,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6841,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Droide analista huido",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave aliada situada en tu arco de fuego efectúa un ataque principal, si no estás bajo tensión, puedes recibir 1 ficha de Tensión. Si lo haces, esa nave aliada puede tirar 1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5972,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5973,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5974,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5975,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5976,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_42",
-            "force_side": null,
-            "id": 42,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Jan Ors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6842,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6843,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6844,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6845,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Experta en espionaje",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes transferir 1 de tus fichas de Concentración a una nave aliada situada en tu arco de fuego.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5977,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5978,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5979,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5980,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5981,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_43",
-            "force_side": null,
-            "id": 43,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kyle Katarn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6846,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6847,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6848,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6849,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Operativo incansable",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave que esté situada en tu arco de fuego. Si lo haces, en esta fase esa nave interviene con Iniciativa 7 en vez de su valor de Iniciativa normal.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5982,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5983,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5984,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5985,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5986,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_44",
-            "force_side": null,
-            "id": 44,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Roark Garnet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6850,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6851,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6852,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6853,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Contrabandista de buen corazón",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de que te actives, puedes realizar una acción <barrelroll> o <boost>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5995,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5996,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5997,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 1,
-            "ffg_id": "XW_P_47",
-            "force_side": null,
-            "id": 47,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6862,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6863,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6864,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Espectro-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que te conviertas en el defensor (antes de las tiradas de dados), puedes recuperar 1<nonbreak><forcecharge>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5842,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5843,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5844,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                17,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "62",
-            "faction_id": 1,
-            "ffg_id": "XW_P_2",
-            "force_side": 2,
-            "id": 2,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Luke Skywalker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6675,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6676,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6677,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6678,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 6679,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rojo Cinco",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave aliada efectúa un ataque, si el defensor está situado en tu <frontarc>, el atacante puede cambiar 1 resultado <hit> por un resultado <crit>.<return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6009,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6010,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6011,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6012,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6013,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 1,
-            "ffg_id": "XW_P_51",
-            "force_side": null,
-            "id": 51,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Gavin Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6875,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6876,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6877,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6878,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Piloto de flanco audaz",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Los pilotos de élite del Escuadrón Pícaro se cuentan entre los mejores de la Alianza Rebelde.</flavor><return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6014,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6015,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6016,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6017,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6018,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "63",
-            "faction_id": 1,
-            "ffg_id": "XW_P_52",
-            "force_side": null,
-            "id": 52,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Escolta del Escuadrón Pícaro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6879,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6880,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6881,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6882,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Diseñados para combinar las mejores prestaciones de las series Ala-X y Ala-A, el Ala-E supera a ambos modelos en velocidad, maniobrabilidad y potencia de fuego.</flavor><return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6019,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6020,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6021,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6022,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6023,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "61",
-            "faction_id": 1,
-            "ffg_id": "XW_P_53",
-            "force_side": null,
-            "id": 53,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Escolta del Escuadrón Canalla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6883,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6884,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6885,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6886,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que reveles una maniobra de color rojo o azul, puedes establecer en tu selector otra maniobra con esa misma dificultad.<return>Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal <frontarc> o <turret>, puede efectuar un ataque principal <reararc> adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5952,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5953,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5954,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "39",
-            "faction_id": 1,
-            "ffg_id": "XW_P_34",
-            "force_side": null,
-            "id": 34,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6804,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6805,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6806,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6807,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que una nave enemiga ejecute una maniobra, si esa nave enemiga está situada a alcance 0 de ti, puedes realizar una acción.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6039,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6040,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6041,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_59",
-            "force_side": null,
-            "id": 59,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Heff Tobber",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6907,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6908,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6909,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6910,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Azul Ocho",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Los partisanos de Saw Gerrera se fundaron originalmente durante las Guerras Clon para hacer frente a las fuerzas separatistas en Onderon, pero decidieron proseguir su lucha contra la tiranía galáctica cuando el Imperio se hizo con el poder.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6045,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6046,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6047,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_61",
-            "force_side": null,
-            "id": 61,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Insurgente de los Partisanos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6915,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6916,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6917,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6918,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>El Ala-K de Koensayr está provisto de un avanzado motor de aceleración sublumínica y dieciocho ensamblajes, cualidades inéditas que le confieren una velocidad y potencia de fuego inigualables.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6058,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6059,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6060,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6061,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6062,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 1,
-            "ffg_id": "XW_P_64",
-            "force_side": null,
-            "id": 64,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto del Escuadrón Custodio",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6927,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6928,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6929,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6930,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque, si estás bajo tensión, puedes gastar 1 <forcecharge> para cambiar hasta 2 de tus resultados <focus> por resultados <evade> o <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5992,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5993,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5994,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_46",
-            "force_side": 2,
-            "id": 46,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6858,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6859,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6860,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6861,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que efectúes un ataque, asigna el Estado Fuego de supresión al defensor.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5998,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5999,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6000,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_48",
-            "force_side": null,
-            "id": 48,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Capitán Rex",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6865,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6866,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6867,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Veterano de las Guerras Clon",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes, los resultados <crit> se neutralizan antes que los resultados <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6001,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6002,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6003,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "26",
-            "faction_id": 1,
-            "ffg_id": "XW_P_49",
-            "force_side": null,
-            "id": 49,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6868,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6869,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6870,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Espectro-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "A Iniciativa 0, puedes efectuar un ataque principal adicional contra una nave enemiga que tengas en tu <bullseye>. Si lo haces, al comienzo de la siguiente fase de Planificación, recibes 1 ficha de Desarme.<return>Sensores experimentales: Eres capaz de obtener Blancos fijados más allá de alcance 3. No puedes obtener Blancos fijados a alcance 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6004,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6005,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6006,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6007,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6008,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 1,
-            "ffg_id": "XW_P_50",
-            "force_side": null,
-            "id": 50,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Corran Horn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6871,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6872,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6873,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6874,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Investigador tenaz",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes, si tienes al menos una nave enemiga a alcance 0–1, puedes añadir 1 resultado <evade> a tus resultados de dados.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6063,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6064,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6065,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "55",
-            "faction_id": 1,
-            "ffg_id": "XW_P_65",
-            "force_side": null,
-            "id": 65,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Norra Wexley",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6931,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6932,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6933,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6934,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6935,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Oro Nueve",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Las naves aliadas son capaces de obtener Blancos fijados sobre objetos que estén situados a alcance 0–3 de cualquier nave aliada.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6024,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6025,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6026,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 1,
-            "ffg_id": "XW_P_54",
-            "force_side": null,
-            "id": 54,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Bodhi Rook",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6887,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6888,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6889,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6890,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Desertor imperial",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Activación, puedes elegir 1 nave aliada que tengas a alcance 1–3. Si lo haces, esa nave retira 1 ficha de Tensión.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6030,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6031,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6032,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_56",
-            "force_side": null,
-            "id": 56,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Cassian Andor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6895,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6896,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6897,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6898,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Criado por la Rebelión",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave aliada que tienes a alcance 0–2 se defiende, el atacante no puede volver a tirar más de 1 dado de ataque.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6033,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6034,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6035,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_57",
-            "force_side": null,
-            "id": 57,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6899,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6900,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6901,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6902,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Vigía de los Ángeles Cavernarios",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que realices una acción <focus>, puedes transferir 1 de tus fichas de Concentración a una nave aliada que tengas a alcance 1–2.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6036,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6037,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6038,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_58",
-            "force_side": null,
-            "id": 58,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Benthic Dos Tubos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6903,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6904,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6905,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6906,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Tirador de los Ángeles Cavernarios",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave aliada que tienes a alcance 0–2 se defiende o efectúa un ataque, esa nave puede gastar tus fichas de Concentración como si fueran suyas.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6053,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6054,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6055,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6056,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6057,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_63",
-            "force_side": null,
-            "id": 63,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Esege Tuketu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6923,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6924,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6925,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6926,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Héroe abnegado",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que gastes una ficha de Concentración, puedes elegir 1 nave aliada que tengas a alcance 1–3. Esa nave recibe 1 ficha de Concentración.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6066,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6067,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6068,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "51",
-            "faction_id": 1,
-            "ffg_id": "XW_P_66",
-            "force_side": null,
-            "id": 66,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6936,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6937,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6938,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6939,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6940,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Jefe Rojo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te defiendes o efectúas un ataque principal, puedes gastar 1 Blanco fijado que tengas sobre la nave enemiga para añadir 1 resultado <focus> a tus resultados de dados.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6069,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6070,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6071,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "53",
-            "faction_id": 1,
-            "ffg_id": "XW_P_67",
-            "force_side": null,
-            "id": 67,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Shara Bey",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6941,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6942,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6943,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6944,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6945,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Verde Cuatro",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que ejecutes completamente una maniobra, si estás bajo tensión, puedes tirar 1 dado de ataque. Si sacas un resultado <hit> o <crit>, retiras 1 ficha de Tensión.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6072,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6073,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6074,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_68",
-            "force_side": null,
-            "id": 68,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ibtisam",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6946,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6947,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6948,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6949,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6950,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Superviviente de Endor",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que tires los dados, si estás a alcance 0–1 de un obstáculo, puedes volver a tirar todos tus dados. Esto no cuenta como volver a tirar los dados en lo que respecta a otros efectos de juego.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6075,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6076,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6077,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6078,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "92",
-            "faction_id": 1,
-            "ffg_id": "XW_P_69",
-            "force_side": null,
-            "id": 69,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6951,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6952,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6953,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6954,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Granuja incorregible",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de que te vaya a ser infligida una carta de Daño boca arriba, puedes gastar 1 <standardcharge> para que esa carta de Daño te sea infligida boca abajo en vez de boca arriba.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6083,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6084,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6085,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6086,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 1,
-            "ffg_id": "XW_P_71",
-            "force_side": null,
-            "id": 71,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6959,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6960,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6961,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6962,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                },
-                {
-                    "id": 6963,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "El poderoso wookiee",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Conocido por su robustez y su diseño modular, el YT-1300 es uno de los cargueros más populares, utilizados y ampliamente modificados en toda la galaxia.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6087,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6088,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6089,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6090,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "78",
-            "faction_id": 1,
-            "ffg_id": "XW_P_72",
-            "force_side": null,
-            "id": 72,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Contrabandista del Borde Exterior",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6964,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6965,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6966,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6967,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que reveles una maniobra de color rojo o azul, puedes establecer en tu selector otra maniobra con esa misma dificultad.<return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6091,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6092,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6093,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "76",
-            "faction_id": 1,
-            "ffg_id": "XW_P_73",
-            "force_side": null,
-            "id": 73,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6968,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6969,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6970,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6971,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Espectro-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave aliada situada en tu arco de fuego se defiende, puedes gastar 1 <forcecharge>. Si lo haces, el atacante tira 1 dado de ataque menos.<return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6094,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6095,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6096,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "90",
-            "faction_id": 1,
-            "ffg_id": "XW_P_74",
-            "force_side": 2,
-            "id": 74,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kanan Jarrus",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6972,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6973,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6974,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6975,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                },
-                {
-                    "id": 6976,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Espectro-1",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, toda nave enemiga que tengas a alcance 0 recibe 2 fichas de Interferencia.<return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6097,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6098,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6099,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 1,
-            "ffg_id": "XW_P_75",
-            "force_side": null,
-            "id": 75,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6977,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6978,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6979,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6980,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Espectro-3",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Otro exitoso diseño de carguero de la Corporación de Ingeniería Corelliana, el VCX-100 es más grande que la ubicua serie YT, por lo que dispone de más espacio para la tripulación y la instalación de mejoras personalizadas.</flavor><return>Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal <reararc> con un valor de Ataque igual al del armamento principal <frontarc> de tu nave acoplada.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6100,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6101,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6102,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 1,
-            "ffg_id": "XW_P_76",
-            "force_side": null,
-            "id": 76,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebelde de Lothal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6981,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6982,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6983,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6984,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>Durante la batalla de Yavin, los selectos pilotos de TIE/ln del Escuadrón Negro efectuaron junto a Darth Vader un devastador ataque contra las fuerzas de la Alianza Rebelde.</flavor>",
             "available_actions": [
                 {
@@ -12311,6 +7715,93 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que realices una acción, puedes gastar 1 <forcecharge> para realizar una acción.<return><shipability>Computadora de selección de blancos avanzada: Mientras efectúas un ataque principal contra un defensor que tienes fijado como blanco, tira 1 dado de ataque adicional y cambia 1 resultado <hit> por un resultado <crit>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6154,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6155,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6156,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 2,
+            "ffg_id": "XW_P_93",
+            "force_side": 1,
+            "id": 93,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Darth Vader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7038,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7039,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7040,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7041,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7042,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Jefe Negro",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12552,6 +8043,87 @@
                 }
             ],
             "subtitle": "Administrador inmisericorde",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>El caza TIE avanzado supuso una mejora del popular TIE/ln gracias a la incorporación de escudos, armamento más potente, paneles solares curvados y un hiperimpulsor.</flavor><return><shipability>Computadora de selección de blancos avanzada: Mientras efectúas un ataque principal contra un defensor que tienes fijado como blanco, tira 1 dado de ataque adicional y cambia 1 resultado <hit> por un resultado <crit>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6166,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6167,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6168,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 2,
+            "ffg_id": "XW_P_97",
+            "force_side": null,
+            "id": 97,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "As del Escuadrón Tormenta",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7055,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7056,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7057,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7058,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12835,6 +8407,278 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>El TIE avanzado v1 de Sistemas de Flota Sienar es un diseño innovador de caza estelar provisto de motores ultramodernos, un lanzamisiles y alas plegables.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6182,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6183,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6184,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6185,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6186,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_101",
+            "force_side": null,
+            "id": 101,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Barón del Imperio",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7073,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7074,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7075,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7076,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>A los temidos inquisidores se les concede un gran nivel de autonomía y acceso a la tecnología más moderna del Imperio, como el prototipo de TIE avanzado v1.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6187,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6188,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6189,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6190,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6191,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 2,
+            "ffg_id": "XW_P_102",
+            "force_side": 1,
+            "id": 102,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Inquisidor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7077,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7078,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7079,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7080,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7081,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, si hay alguna nave enemiga situada en tu <bullseye>, recibes 1 ficha de Concentración.<return><shipability>Propulsores automatizados: Después de que realices una acción, puedes realizar una acción <barrelroll> roja o <boost> roja.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6192,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6193,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6194,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6195,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 2,
+            "ffg_id": "XW_P_103",
+            "force_side": null,
+            "id": 103,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Soontir Fel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 41,
+            "statistics": [
+                {
+                    "id": 7082,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7083,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7084,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "As legendario",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Después de que efectúes un ataque, puedes realizar una acción <barrelroll> o <boost>, incluso aunque estés bajo tensión.<return><shipability>Propulsores automatizados: Después de que realices una acción, puedes realizar una acción <barrelroll> roja o una acción <boost> roja.</shipability>",
             "available_actions": [
                 {
@@ -12995,86 +8839,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, si hay alguna nave enemiga situada en tu <bullseye>, recibes 1 ficha de Concentración.<return><shipability>Propulsores automatizados: Después de que realices una acción, puedes realizar una acción <barrelroll> roja o <boost> roja.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6192,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6193,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6194,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6195,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 2,
-            "ffg_id": "XW_P_103",
-            "force_side": null,
-            "id": 103,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Soontir Fel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 41,
-            "statistics": [
-                {
-                    "id": 7082,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7083,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7084,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "As legendario",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>El diseño de Sistemas de Flota Sienar para el interceptor TIE incluye cuatro cañones láser montados en las alas, con lo que supera ampliamente en potencia de fuego a sus predecesores.</flavor><return><shipability>Propulsores automatizados: Después de que realices una acción, puedes realizar una acción <barrelroll> roja o una acción <boost> roja.</shipability>",
             "available_actions": [
                 {
@@ -13149,6 +8913,91 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que efectúes una acción <reload>, puedes recuperar 1 ficha <standardcharge> que esté sobre 1 de tus cartas de Mejora <talent> equipadas.<return><shipability>Bombardero ágil: Si vas a soltar un dispositivo utilizando una plantilla <straight>, en vez de esa plantilla puedes utilizar una plantilla <leftbank> o <rightbank> con la misma velocidad.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6208,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6209,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6210,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6211,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_107",
+            "force_side": null,
+            "id": 107,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Tomax Bren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7094,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7095,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7096,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Inconformista impetuoso",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13319,6 +9168,90 @@
                 }
             ],
             "subtitle": "Jefe Cimitarra",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que seas destruido, antes de ser retirado de la zona de juego, puedes efectuar un ataque y soltar o lanzar 1 dispositivo. <return><shipability>Bombardero ágil: Si vas a soltar un dispositivo utilizando una plantilla <straight>, en vez de esa plantilla puedes utilizar una plantilla <leftbank> o <rightbank> con la misma velocidad.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6220,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6221,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6222,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6223,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_110",
+            "force_side": null,
+            "id": 110,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Muerte Ígnea”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7103,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7104,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7105,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Desafiante hasta el final",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13580,6 +9513,93 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallbody>Mientras te defiendes, si el atacante no tiene ninguna ficha verde, puedes cambiar 1 de tus resultados <focus> o de cara vacía por un resultado <evade>.</smallbody><return><sasmall><sabold>Alerones adaptativos:</sabold> Antes de revelar tu selector, si no estás bajo tensión, <bold>debes</bold> ejecutar una maniobra [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>] blanca.</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6236,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6237,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6238,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6239,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 2,
+            "ffg_id": "XW_P_114",
+            "force_side": null,
+            "id": 114,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitán Feroph",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 43,
+            "statistics": [
+                {
+                    "id": 7116,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7117,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7118,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7119,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Mensajero imperial",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallbody>Después de que ejecutes completamente una maniobra de velocidad 1 utilizando la capacidad <smallcaps>Alerones adaptativos</smallcaps> de tu nave, puedes realizar una acción <coordinate>. Si lo haces, omite tu paso de “Realizar una acción”.</smallbody><return><sasmall><sabold>Alerones adaptativos:</sabold> Antes de revelar tu selector, si no estás bajo tensión, <bold>debes</bold> ejecutar una maniobra [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>] blanca.</sasmall>",
             "available_actions": [
                 {
@@ -13826,6 +9846,80 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras te defiendes, después del paso de “Neutralizar los resultados”, puedes sufrir 1 de daño <hit> y recibir 1 ficha de Tensión. Si lo haces, anula todos los resultados de los dados.<return><shipability>Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 <leftbank>], [1 <straight>] o [1 <rightbank>] de color blanco.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6251,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6252,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6253,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_118",
+            "force_side": null,
+            "id": 118,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•“Cuenta Atrás”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 16,
+            "statistics": [
+                {
+                    "id": 7131,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7132,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7133,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Amante del riesgo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras efectúas un ataque, si tienes 1 o menos cartas de Daño, puedes tirar 1 dado de ataque adicional.<return><shipability>Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 <leftbank>], [1 <straight>] o [1 <rightbank>] de color blanco.</shipability>",
             "available_actions": [
                 {
@@ -14047,26 +10141,40 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mientras una nave aliada dañada que tienes a alcance 0–3 efectúa un ataque, esa nave puede volver a tirar 1 dado de ataque.",
+            "ability_text": "Después de que efectúes un ataque que impacte, si estás evadiéndote, expón 1 de las cartas de Daño del defensor.<return><shipability>Aceleración máxima: Después de que ejecutes completamente una maniobra de velocidad 3−5, puedes realizar una acción <evade>.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6263,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6266,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14074,156 +10182,54 @@
             "available_upgrades": [
                 1,
                 2,
-                8,
-                8,
-                13,
-                14,
-                18
+                3,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_55",
-            "force_side": null,
-            "id": 55,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6891,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6892,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6893,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6894,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Radical obsesivo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A los temidos inquisidores se les concede un gran nivel de autonomía y acceso a la tecnología más moderna del Imperio, como el prototipo de TIE avanzado v1.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6187,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6188,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6189,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6190,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6191,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 1,
-            "cost": "40",
+            "cost": "84",
             "faction_id": 2,
-            "ffg_id": "XW_P_102",
-            "force_side": 1,
-            "id": 102,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Inquisidor",
+            "ffg_id": "XW_P_122",
+            "force_side": null,
+            "id": 122,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 25,
+            "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7143,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7078,
+                    "id": 7144,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7145,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7080,
+                    "id": 7146,
                     "recurring": false,
                     "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7081,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
+                    "value": "4"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Jefe Ónice",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -14768,6 +10774,169 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Diseñado para enfrentamientos prolongados, el TIE/ag se asigna casi siempre a pilotos de élite entrenados para saber aprovechar al máximo tanto su particular complemento de armas como su maniobrabilidad.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6294,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6295,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6296,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_129",
+            "force_side": null,
+            "id": 129,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Explorador del Escuadrón Ónice",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7171,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7172,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7173,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7174,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Durante el desarrollo del TIE Agresor, Sistemas de Flota Sienar antepuso las prestaciones y la versatilidad a la mera eficiencia en costes.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6297,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6298,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6299,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 2,
+            "ffg_id": "XW_P_130",
+            "force_side": null,
+            "id": 130,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Especialista de Sienar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7175,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7176,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7177,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7178,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Después de que efectúes un ataque que impacte, recibes 1 ficha de Evasión.<return><shipability>Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción <evade>. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje.</shipability>",
             "available_actions": [
                 {
@@ -15018,6 +11187,92 @@
                 },
                 {
                     "id": 7190,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>EL TIE Fantasma, producto de las investigaciones llevadas a cabo en unas instalaciones secretas de Imdaar Alfa, es algo que muchos creían imposible: un caza estelar de dimensiones reducidas equipado con un avanzado dispositivo de camuflaje.</flavor><return><shipability>Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción <evade>. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6312,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6313,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6314,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 7,
+                    "base_action_side_effect": null,
+                    "id": 6315,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_134",
+            "force_side": null,
+            "id": 134,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Piloto de pruebas de Imdaar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 27,
+            "statistics": [
+                {
+                    "id": 7191,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7192,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7193,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7194,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15285,6 +11540,94 @@
                 },
                 {
                     "id": 7206,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Con un diseño inspirado en el de otras naves de Talleres Espaciales Cygnus, el Ala Estelar clase Alfa es un vehículo versátil asignado a unidades especializadas de la Armada Imperial que precisan un caza estelar capaz de desempeñar múltiples funciones.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6328,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6329,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6330,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6331,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                6,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "35",
+            "faction_id": 2,
+            "ffg_id": "XW_P_138",
+            "force_side": null,
+            "id": 138,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto del Escuadrón Nu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 14,
+            "statistics": [
+                {
+                    "id": 7207,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7208,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7209,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7210,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -15590,6 +11933,101 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 o más naves aliadas que tengas a alcance 0−3. Si lo haces, transfiere a tu nave todas las fichas enemigas de Blanco fijado que hay en las naves elegidas.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6347,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6348,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 6349,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6350,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                8,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 2,
+            "ffg_id": "XW_P_142",
+            "force_side": null,
+            "id": 142,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Capitán Kagi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 26,
+            "statistics": [
+                {
+                    "id": 7223,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7224,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 7225,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7226,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7227,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Piloto de la lanzadera del Emperador",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Al comienzo de la fase de Activación, puedes gastar 1 <standardcharge>. Si lo haces, mientras las naves aliadas obtienen Blancos fijados en esta ronda, deben obtener Blancos fijados más allá de alcance 3 en vez de a alcance 0−3.",
             "available_actions": [
                 {
@@ -15876,6 +12314,202 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Eres capaz de efectuar ataques principales a alcance 0.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6363,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6364,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6365,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6366,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6367,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 2,
+            "ffg_id": "XW_P_146",
+            "force_side": null,
+            "id": 146,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitán Oicunn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7244,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7245,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7246,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7247,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Estratega inspirado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque, si estás reforzado y el defensor está en el <fullfront> o <fullrear> que coincide con el de tu ficha de Refuerzo, puedes cambiar 1 de tus resultados <focus> por un resultado <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6368,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6369,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6370,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6371,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6372,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "88",
+            "faction_id": 2,
+            "ffg_id": "XW_P_147",
+            "force_side": null,
+            "id": 147,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Contralmirante Chiraneau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7248,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7249,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7250,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7251,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Asesor del almirante Piett",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -16174,6 +12808,104 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras efectúas un ataque principal, si hay al menos 1 nave aliada que no sea limitada situada a alcance 0 del defensor, tira 1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6386,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6387,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": "stress",
+                    "id": 6388,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6389,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
+            "card_set_ids": [
+                6,
+                11
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 3,
+            "ffg_id": "XW_P_151",
+            "force_side": null,
+            "id": 151,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kath Scarlet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 10,
+            "statistics": [
+                {
+                    "id": 7266,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7267,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "3"
+                },
+                {
+                    "id": 7268,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7269,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7270,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Capitana de los piratas Binayre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras te defiendes o efectúas un ataque, si la nave enemiga está bajo tensión, puedes volver a tirar 1 de tus dados.",
             "available_actions": [
                 {
@@ -16466,6 +13198,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras te defiendes o efectúas un ataque, si el alcance de ataque es 1, puedes tirar 1 dado adicional.<return>Envite de Concordia: Mientras te defiendes, si el alcance de ataque es 1 y estás en el <frontarc> del atacante, cambia 1 resultado por un resultado <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6402,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6403,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6404,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6405,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 3,
+            "ffg_id": "XW_P_155",
+            "force_side": null,
+            "id": 155,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7286,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7287,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7288,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Jefe Calavera",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave enemiga que tengas a alcance 1. Si lo haces y estás en su <frontarc>, esa nave retira todas sus fichas verdes.<return>Envite de Concordia: Mientras te defiendes, si el alcance de ataque es 1 y estás en el <frontarc> del atacante, cambia 1 resultado por un resultado <evade>.",
             "available_actions": [
                 {
@@ -16705,6 +13517,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Los ases del Escuadrón Calavera prefieren los estilos de vuelo agresivos con los que gracias al diseño de ala pivotante de sus naves disfrutan de una agilidad insuperable mientras persiguen a sus presas.</flavor><return>Envite de Concordia: Mientras te defiendes, si el alcance de ataque es 1 y estás en el <frontarc> del atacante, cambia 1 resultado por un resultado <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6418,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6419,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6420,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6421,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_159",
+            "force_side": null,
+            "id": 159,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Piloto del Escuadrón Calavera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7298,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7299,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7300,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Los pilotos del caza Colmillo mandaloriano deben dominar el Envite de Concordia, una maniobra que se vale de la estilizada silueta del vehículo para efectuar mortíferos asaltos frontales.</flavor><return>Envite de Concordia: Mientras te defiendes, si el alcance de ataque es 1 y estás en el <frontarc> del atacante, cambia 1 resultado por un resultado <evade>.",
             "available_actions": [
                 {
@@ -16935,6 +13827,156 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, si tienes una o más naves a alcance 0, tú y toda otra nave que tengas a alcance 0 recibís 1 ficha de Campo de tracción. <return><shipability>Campos de tracción de remolque: Acción: Elige una nave que tengas en tu <frontarc> a alcance 1. Esa nave recibe 1 ficha de Campo de tracción, o 2 fichas de Campo de tracción si está situada en tu <bullseye> a alcance 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6432,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6433,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6434,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 3,
+            "ffg_id": "XW_P_163",
+            "force_side": null,
+            "id": 163,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Unkar Plutt",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7310,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7311,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7312,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Chatarrero tacaño",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>El remolcador espacial cuatrimotor para transferencia de carga, conocido popularmente como “saltador quad”, es tan ágil en el espacio como en la atmósfera, lo que lo hace popular entre contrabandistas y exploradores por igual.</flavor><return><shipability>Campos de tracción de remolque: Acción: Elige una nave que tengas en tu <frontarc> a alcance 1. Esa nave recibe 1 ficha de Campo de tracción, o 2 fichas de Campo de tracción si está situada en tu <bullseye> a alcance 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6435,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6436,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6437,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 3,
+            "ffg_id": "XW_P_164",
+            "force_side": null,
+            "id": 164,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Traficante de armas de Jakku",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7313,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7314,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7315,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras efectúas un ataque que no sea <frontarc>, tira 1 dado de ataque adicional.",
             "available_actions": [
                 {
@@ -17021,6 +14063,188 @@
                 }
             ],
             "subtitle": "Corsario desalmado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras una nave aliada que no sea limitada efectúa un ataque, si el defensor está situado en tu arco de fuego, el atacante puede volver a tirar 1 dado de ataque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6442,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6443,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6444,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6445,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 3,
+            "ffg_id": "XW_P_166",
+            "force_side": null,
+            "id": 166,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Drea Renthal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7320,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7321,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7322,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7323,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Reina pirata",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>La mera mención de créditos imperiales basta para poner a tu servicio a un gran número de individuos no excesivamente dignos de confianza.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6446,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6447,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6448,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6449,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 3,
+            "ffg_id": "XW_P_167",
+            "force_side": null,
+            "id": 167,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto de fortuna",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7324,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7325,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7326,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7327,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17271,6 +14495,85 @@
                 }
             ],
             "subtitle": "Asaltante imponente",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Sólo puedes desplegarte mediante el despliegue de emergencia, y posees el nombre, Iniciativa, capacidad especial de piloto y <standardcharge> de nave del Diente de Perro aliado que ha sido destruido.<return><shipability>Nave de escape: Requiere el Diente de Perro. Debes empezar la partida acoplado con el Diente de Perro.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6460,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6461,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6462,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "6",
+            "faction_id": 3,
+            "ffg_id": "XW_P_171",
+            "force_side": null,
+            "id": 171,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Cachorro de Nashtah",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 7340,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7341,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7342,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7343,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Plan de contingencia",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17532,6 +14835,102 @@
                 }
             ],
             "subtitle": "Mercenario del Borde Exterior",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave enemiga que tengas en tu arco de fuego a alcance 0–2. Si lo haces, transfiere 1 ficha de Concentración o Evasión de esa nave a la tuya.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6474,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6475,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6476,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6477,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6478,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 3,
+            "ffg_id": "XW_P_175",
+            "force_side": null,
+            "id": 175,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Palob Godalhi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 7357,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7358,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7359,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7360,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Insurgente de Teth",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17815,6 +15214,94 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Después de que ejecutes completamente una maniobra, puedes recibir 1 ficha de Tensión para girar tu nave 90º sobre sí misma.<return><shipability>Micropropulsores: Mientras realizas un tonel volado, debes utilizar la plantilla <leftbank> o <rightbank> en vez de la plantilla <straight>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6493,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6494,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6495,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6496,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_179",
+            "force_side": null,
+            "id": 179,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Dalan Oberos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 3,
+            "statistics": [
+                {
+                    "id": 7373,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7374,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7375,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7376,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Cazarrecompensas de élite",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras te defiendes, después del paso de “Neutralizar los resultados”, otra nave aliada que tengas a alcance 0–1 y en el arco de ataque puede sufrir 1 de daño <hit> o <crit>. Si lo haces, anula 1 resultado equivalente.<return><shipability>Micropropulsores: Mientras realizas un tonel volado, debes utilizar la plantilla <leftbank> o <rightbank> en vez de la plantilla <straight>.</shipability>",
             "available_actions": [
                 {
@@ -18078,6 +15565,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras una nave aliada que tienes a alcance 0–1 se defiende, esa nave puede volver a tirar 1 de sus dados.<return><shipability>Emplazamiento para armas: Puedes equiparte con una mejora <cannon>, <torpedo> o <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6509,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6510,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6511,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6512,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_183",
+            "force_side": null,
+            "id": 183,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Serissu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7389,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7390,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7391,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7392,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Instructora de vuelo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Después de que obtengas un Blanco fijado, debes retirar todas tus fichas de Concentración y Evasión. Luego, recibes la misma cantidad de fichas de Concentración y Evasión que posee la nave que tienes fijada como blanco.<return><shipability>Emplazamiento para armas: Puedes equiparte con una mejora <cannon>, <torpedo> o <missile>.</shipability><return>",
             "available_actions": [
                 {
@@ -18331,6 +15904,91 @@
                 }
             ],
             "subtitle": "Buscador de fortuna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes o efectúas un ataque, puedes sufrir 1 de daño <hit> para volver a tirar cualquier cantidad de tus dados.<return><shipability>Emplazamiento para armas: Puedes equiparte con una mejora <cannon>, <torpedo> o <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6525,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6526,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6527,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6528,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 3,
+            "ffg_id": "XW_P_187",
+            "force_side": null,
+            "id": 187,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Inaldra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7405,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7406,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7407,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7408,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Jefa de Punto Tansarii",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -18592,6 +16250,88 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras te defiendes a alcance de ataque 3 o efectúas un ataque a alcance de ataque 1, tira 1 dado adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6541,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6542,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6543,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_191",
+            "force_side": null,
+            "id": 191,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Talonbane Cobra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7421,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7422,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7423,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7424,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Azote de Punto Tansarii",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras te defiendes, si estás detrás del atacante, tira 1 dado de defensa adicional.<return>Mientras efectúas un ataque, si estás detrás del defensor, tira 1 dado de ataque adicional.",
             "available_actions": [
                 {
@@ -18832,6 +16572,88 @@
                 }
             ],
             "subtitle": "Oportunista agresivo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>El caza de asalto Kihraxz fue desarrollado expresamente para el sindicato criminal del Sol Negro, cuyos cotizadísimos ases estelares exigían naves ágiles y potentes que estuvieran a la altura de sus habilidades.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6553,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6554,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6555,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 3,
+            "ffg_id": "XW_P_195",
+            "force_side": null,
+            "id": 195,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "As del Sol negro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7437,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7438,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7439,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7440,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19100,6 +16922,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Después de que efectúes una acción <boost>, puedes efectuar una acción <evade>.<return><shipability>Cerebro droide avanzado: Después de que efectúes una acción <calculate>, recibes 1 ficha de Cálculos.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6567,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6568,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6569,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6570,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 3,
+            "ffg_id": "XW_P_199",
+            "force_side": null,
+            "id": 199,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•IG-88C",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 21,
+            "statistics": [
+                {
+                    "id": 7453,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7454,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7455,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7456,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Máquina confabuladora",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras ejecutas una maniobra de giro de Segnor (<leftsloop> o <rightsloop>), puedes ejecutarla utilizando otra plantilla con la misma velocidad, ya sea una plantilla de giro [<leftturn> o <rightturn>) con la misma dirección o la plantilla de movimiento recto [<straight>].<return><shipability>Cerebro droide avanzado: Después de que efectúes una acción <calculate>, recibes 1 ficha de Cálculos.</shipability>",
             "available_actions": [
                 {
@@ -19355,6 +17268,87 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Los legendarios buscadores de Gand rinden culto a las arremolinadas nieblas de su planeta natal y utilizan presagios, augurios y rituales místicos para hallar a su presa.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6581,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6582,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6583,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_203",
+            "force_side": null,
+            "id": 203,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Buscador gandiano",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 22,
+            "statistics": [
+                {
+                    "id": 7469,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7470,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7471,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7472,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Antes de que una bomba o mina aliada vaya a detonar, puedes gastar 1 <standardcharge> para evitar su detonación.<return>Mientras te defiendes contra un ataque que está obstruido por una bomba o mina, tira 1 dado de defensa adicional.",
             "available_actions": [
                 {
@@ -19604,6 +17598,95 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que efectúes un ataque, toda nave enemiga situada en tu <bullseye> sufre 1 de daño <hit> a menos que retire 1 ficha verde.<return><shipability>En el punto de mira: Mientras efectúas un ataque, si el defensor está situado en tu <bullseye>, los dados de defensa no pueden ser modificados mediante fichas verdes.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6593,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6594,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6595,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6596,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                10,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_207",
+            "force_side": null,
+            "id": 207,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Torani Kulda",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 39,
+            "statistics": [
+                {
+                    "id": 7486,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7487,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7488,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "7"
+                },
+                {
+                    "id": 7489,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Mercenaria rodiana",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19878,6 +17961,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Si vas a huir del campo de batalla, puedes gastar 1 <standardcharge>. Si lo haces, colócate en reserva en vez de huir. Al comienzo de la siguiente fase de Planificación, colócate en la zona de juego dentro de alcance 1 del borde de la zona de juego por el que has huido.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6608,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6609,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6610,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                8,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 3,
+            "ffg_id": "XW_P_211",
+            "force_side": null,
+            "id": 211,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Moralo eval",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 24,
+            "statistics": [
+                {
+                    "id": 7503,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 7504,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7505,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "9"
+                },
+                {
+                    "id": 7506,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                },
+                {
+                    "id": 7507,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Genio del crimen",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave que tengas a alcance 1 y gastar un Blanco fijado que tengas sobre esa nave. Si lo haces, esa nave recibe 1 ficha de Campo de tracción.",
             "available_actions": [
                 {
@@ -20130,6 +18304,88 @@
                 }
             ],
             "subtitle": "Corelliano vengativo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir una nave aliada que tengas a alcance 0–1. Si lo haces, transfiere todas tus fichas verdes a esa nave.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6620,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6621,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6622,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_215",
+            "force_side": null,
+            "id": 215,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Manaroo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 45,
+            "statistics": [
+                {
+                    "id": 7521,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7522,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7523,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7524,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Aruzana agraciada",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20689,38 +18945,39 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Muchos pilotos espaciales se ganan la vida viajando por el Borde Exterior, donde la distinción entre contrabandista y comerciante honrado suele ser difusa. En las fronteras de la civilización, a los compradores raras veces les interesa la procedencia de la mercancía, al menos mientras ésta les sea ofrecida a un buen precio.</flavor>",
+            "ability_text": "Mientras te defiendes o efectúas un ataque principal, si el ataque está obstruido por un obstáculo, puedes tirar 1 dado adicional.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 6645,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 6646,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 6647,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 6648,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
+                1,
                 6,
                 8,
                 8,
@@ -20729,51 +18986,142 @@
                 15,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "54",
             "faction_id": 3,
-            "ffg_id": "XW_P_225",
+            "ffg_id": "XW_P_222",
             "force_side": null,
-            "id": 225,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Capitán de carguero",
+            "id": 222,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 7555,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 7556,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 7557,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 7558,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "El chico de Corellia",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que tires los dados, si no estás bajo tensión, puedes recibir 1 ficha de Tensión para volver a tirar todos tus resultados de cara vacía.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6649,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6650,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6651,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6652,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 3,
+            "ffg_id": "XW_P_223",
+            "force_side": null,
+            "id": 223,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7559,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7560,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7561,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7562,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Tahúr elocuente",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20869,6 +19217,96 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Muchos pilotos espaciales se ganan la vida viajando por el Borde Exterior, donde la distinción entre contrabandista y comerciante honrado suele ser difusa. En las fronteras de la civilización, a los compradores raras veces les interesa la procedencia de la mercancía, al menos mientras ésta les sea ofrecida a un buen precio.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6657,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6658,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6659,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6660,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 3,
+            "ffg_id": "XW_P_225",
+            "force_side": null,
+            "id": 225,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Capitán de carguero",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7567,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7568,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7569,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7570,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Después de que tires los dados, si no estás bajo tensión, puedes recibir 1 ficha de Tensión para volver a tirar todos tus resultados de cara vacía.<shipability><sabold>Copiloto:</sabold> Mientras estás acoplado, tu nave nodriza posee tu capacidad especial de piloto además de la suya propia.</shipability>",
             "available_actions": [
                 {
@@ -20948,42 +19386,160 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mientras efectúas un ataque principal, si el defensor está en tu <bullseye>, antes del paso de “Neutralizar los resultados”, puedes gastar 1<nonbreak><standardcharge> para anular 1 resultado <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                9
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_1",
-            "force_side": null,
-            "id": 230,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Tiro certero",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
+            "ability_text": "Las naves aliadas que tienes a alcance 0–1 son capaces de efectuar ataques aunque estén situadas a alcance 0 de obstáculos.\n<return><shipability><sabold>Copiloto:</sabold> Mientras estás acoplado, tu nave nodriza posee tu capacidad especial de piloto además de la suya propia.</shipability>",
+            "available_actions": [
                 {
-                    "id": 6632,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6664,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6665,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6666,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
                 }
             ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+            "available_upgrades": [
+                1,
+                8,
+                14
             ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "24",
+            "faction_id": 3,
+            "ffg_id": "XW_P_227",
+            "force_side": null,
+            "id": 227,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Pionero del Borde Exterior",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7575,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7576,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7577,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7578,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Forajido ingenioso",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Si no estás protegido por escudos, reduce la dificultad de tus maniobras de inclinación (<leftbank> y <rightbank>).<return><shipability><sabold>Copiloto:</sabold> Mientras estás acoplado, tu nave nodriza posee tu capacidad especial de piloto además de la suya propia.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6667,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6668,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6669,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "22",
+            "faction_id": 3,
+            "ffg_id": "XW_P_228",
+            "force_side": null,
+            "id": 228,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•L3-37",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7579,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7580,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7581,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7582,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Revolucionaria droide",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21069,81 +19625,94 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Si no estás protegido por escudos, reduce la dificultad de tus maniobras de inclinación (<leftbank> y <rightbank>).<return><shipability><sabold>Copiloto:</sabold> Mientras estás acoplado, tu nave nodriza posee tu capacidad especial de piloto además de la suya propia.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6667,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6668,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6669,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "ability_text": "Mientras efectúas un ataque principal, si el defensor está en tu <bullseye>, antes del paso de “Neutralizar los resultados”, puedes gastar 1<nonbreak><standardcharge> para anular 1 resultado <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
             "card_set_ids": [
-                13
+                4,
+                5,
+                6,
+                9
             ],
-            "card_type_id": 1,
-            "cost": "22",
-            "faction_id": 3,
-            "ffg_id": "XW_P_228",
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_1",
             "force_side": null,
-            "id": 228,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•L3-37",
+            "id": 230,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Tiro certero",
             "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 6632,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7580,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7581,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7582,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
+                    "statistic_id": 7,
+                    "value": "1"
                 }
             ],
-            "subtitle": "Revolucionaria droide",
-            "upgrade_types": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras realizas una acción <boost> blanca, puedes considerarla como si fuera roja para usar la plantilla [1<nonbreak><leftturn>] o [1<nonbreak><rightturn>] en vez de una de las plantillas normales para esta acción.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                12
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_2",
+            "force_side": null,
+            "id": 231,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Temerario",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Boost",
+                            "pk": 1,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21351,6 +19920,39 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras una nave enemiga que tienes a alcance 0 se defiende, esa nave tira 1 dado de defensa menos.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_7",
+            "force_side": null,
+            "id": 236,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Intimidación",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras efectúas un ataque, si estás evadiéndote, puedes cambiar 1 de los resultados <evade> del defensor por un resultado <focus>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21400,6 +20002,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras te defiendes o efectúas un ataque, si no tienes ninguna otra nave aliada a alcance 0–2, puedes gastar 1<nonbreak><standardcharge> para volver a tirar 1 de tus dados.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_9",
+            "force_side": null,
+            "id": 238,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lobo solitario",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6606,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras efectúas un ataque, si el defensor está en tu <bullseye>, puedes cambiar 1 resultado <hit> por un resultado <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21420,6 +20062,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Puntería",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque <frontarc>, si no estás situado en el arco de fuego del defensor, éste tira 1 dado de defensa menos.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_11",
+            "force_side": null,
+            "id": 240,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Superioridad táctica",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21558,37 +20233,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes gastar 1 <forcecharge>. Si lo haces, en esta fase intervienes con Iniciativa 7 en vez de tu valor de Iniciativa normal.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-            "card_set_ids": [
-                1,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_19",
-            "force_side": null,
-            "id": 248,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Percepción agudizada",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                17
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Mientras otra nave aliada que tienes a alcance 0–1 se defiende, antes del paso de “Neutralizar los resultados”, si estás en el arco de ataque, puedes sufrir 1 de daño <crit> para anular 1 resultado <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21630,6 +20274,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mientras realizas una coordinación, la nave que eliges sólo es capaz de realizar una acción si dicha acción figura también en tu barra de acciones.",
+            "available_actions": [
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 5830,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_16",
+            "force_side": null,
+            "id": 245,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Jefe de escuadrón",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave aliada que tengas a alcance 1. Si lo haces, esa nave considera su Iniciativa como idéntica a la tuya hasta el final de la ronda.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21658,6 +20343,70 @@
             "subtitle": null,
             "upgrade_types": [
                 1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras estás efectuando un ataque que está obstruido por un obstáculo, tira 1 dado de ataque adicional.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_18",
+            "force_side": null,
+            "id": 247,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Disparo inverosímil",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes gastar 1 <forcecharge>. Si lo haces, en esta fase intervienes con Iniciativa 7 en vez de tu valor de Iniciativa normal.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+            "card_set_ids": [
+                1,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_19",
+            "force_side": null,
+            "id": 248,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Percepción agudizada",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                17
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -21763,6 +20512,78 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Después de que reveles tu selector, puedes realizar 1 acción.<return>Si lo haces, no puedes realizar otra acción durante tu activación.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_23",
+            "force_side": null,
+            "id": 252,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Sensores avanzados",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras realizas un impulso o un tonel volado, eres capaz de moverte pasando a través de obstáculos y solaparte con ellos.<return>Después de que pases a través de un obstáculo o te solapes con uno, puedes gastar 1<nonbreak><standardcharge> para ignorar sus efectos hasta el final de la ronda.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_24",
+            "force_side": null,
+            "id": 253,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Detector de colisiones",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6626,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras efectúas un ataque, si tienes al defensor fijado como blanco, puedes volver a tirar 1 dado de ataque. Si lo haces, no puedes gastar tu Blanco fijado durante este ataque.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21783,6 +20604,37 @@
             "initiative": null,
             "is_unique": false,
             "name": "Sistema de control de disparo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la fase de Sistemas, si vas a soltar o lanzar una bomba, puedes lanzarla utilizando la plantilla [5 <straight>] en vez de la plantilla habitual.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_set_ids": [
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_26",
+            "force_side": null,
+            "id": 255,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Simulador de trayectorias",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21836,83 +20688,43 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Durante la fase de Sistemas, si vas a soltar o lanzar una bomba, puedes lanzarla utilizando la plantilla [5 <straight>] en vez de la plantilla habitual.",
+            "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
             "card_set_ids": [
+                4,
                 5,
                 6
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "5",
             "faction_id": null,
-            "ffg_id": "XW_U_26",
+            "ffg_id": "XW_U_28",
             "force_side": null,
-            "id": 255,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "id": 257,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Simulador de trayectorias",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5835,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_32",
-            "force_side": null,
-            "id": 261,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Torreta de cañones de iones",
+            "name": "Cañón de iones",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6645,
+                    "id": 6643,
                     "recurring": false,
-                    "statistic_id": 12,
+                    "statistic_id": 10,
                     "value": "3"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
-                4
+                3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 - 3"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, todos los resultados <hit>/<crit> infligen fichas de Interferencia en vez de daño.",
@@ -21993,48 +20805,144 @@
             "weapon_range": "1 - 3"
         },
         {
-            "ability_text": "<smallcaps>Ataque (<focus>):</smallcaps> Gasta 1 <standardcharge>. Si el defensor está situado en tu <bullseye>, puedes gastar 1 o más <standardcharge> para volver a tirar esa misma cantidad de dados de ataque.",
-            "available_actions": [],
+            "ability_text": "<smallcaps>Ataque</smallcaps>",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5832,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
             "card_set_ids": [
-                5
+                4,
+                5,
+                6
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_36",
+            "ffg_id": "XW_U_31",
             "force_side": null,
-            "id": 265,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "id": 260,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Cohetes de saturación",
+            "name": "Torreta dorsal",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6619,
+                    "id": 6633,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6621,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "5"
+                    "statistic_id": 12,
+                    "value": "2"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque:</smallcaps> Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5835,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+            "card_set_ids": [
+                4,
+                5,
                 6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_32",
+            "force_side": null,
+            "id": 261,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Torreta de cañones de iones",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6645,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Cambia 1 resultado <hit> por un resultado <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+            "card_set_ids": [
+                4,
+                5,
                 6
             ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_33",
+            "force_side": null,
+            "id": 262,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Torpedos de protones avanzados",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6615,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "5"
+                },
+                {
+                    "id": 6617,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                5
+            ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "1"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Si este ataque impacta, gasta 1 resultado <hit> o <crit> para provocar que el defensor sufra 1 de daño <hit>. Todos los resultados <hit>/<crit> restantes infligen fichas de Iones en vez de daño.",
@@ -22129,6 +21037,96 @@
             ],
             "weapon_no_bonus": true,
             "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque (<focus>):</smallcaps> Gasta 1 <standardcharge>. Si el defensor está situado en tu <bullseye>, puedes gastar 1 o más <standardcharge> para volver a tirar esa misma cantidad de dados de ataque.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_36",
+            "force_side": null,
+            "id": 265,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cohetes de saturación",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6619,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6621,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "5"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6,
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Después de este ataque, puedes efectuar este ataque como un ataque adicional contra un objetivo diferente que esté situado a alcance 0–1 del defensor, ignorando el requisito <targetlock>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_37",
+            "force_side": null,
+            "id": 266,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Misiles de racimo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6623,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6625,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "4"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "1 - 2"
         },
         {
             "ability_text": "<smallcaps>Ataque (<targetlock>):</smallcaps> Gasta 1<nonbreak><standardcharge>. Después de que este ataque impacte, toda nave que esté situada a alcance 0–1 del defensor expone 1 de sus cartas de Daño.",
@@ -22267,38 +21265,6 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Mientras te defiendes, antes de que se tiren los dados de ataque, puedes gastar un Blanco fijado que tengas sobre el atacante para tirar 1 dado de ataque. Si lo haces, el atacante recibe 1 ficha de Interferencia. Luego, si has sacado un resultado <hit> o <crit>, recibes 1 ficha de Interferencia.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_42",
-            "force_side": null,
-            "id": 271,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Pirata informático independiente",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Ataque (<focus>):</smallcaps> Gasta 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22344,6 +21310,109 @@
             "weapon_range": "1 - 2"
         },
         {
+            "ability_text": "Mientras te defiendes, antes de que se tiren los dados de ataque, puedes gastar un Blanco fijado que tengas sobre el atacante para tirar 1 dado de ataque. Si lo haces, el atacante recibe 1 ficha de Interferencia. Luego, si has sacado un resultado <hit> o <crit>, recibes 1 ficha de Interferencia.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_42",
+            "force_side": null,
+            "id": 271,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Pirata informático independiente",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Preparación:</smallcaps> Pierdes 1 <standardcharge>.<return><smallcaps>Acción:</smallcaps> Recupera 1<nonbreak><standardcharge>.<return><smallcaps>Acción:</smallcaps> Gasta 1<nonbreak><standardcharge> para recuperar 1 escudo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_43",
+            "force_side": null,
+            "id": 272,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Droide GNK “Gonk”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6636,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Preparación:<smallcaps> Después de desplegar las fuerzas, elige 1 nave enemiga y asígnale el Estado <smallcaps>Dispositivo de escucha</smallcaps>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_44",
+            "force_side": null,
+            "id": 273,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Confidente",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Al final de la ronda, puedes tirar 1 dado de ataque para reparar 1 carta de Daño boca arriba. Luego, si has sacado un resultado <hit>, expón 1 carta de Daño.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22363,6 +21432,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Técnico novato",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que realices una acción <focus>, recibes 1 ficha de Concentración.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_46",
+            "force_side": null,
+            "id": 275,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Copiloto perceptivo",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -22456,6 +21558,38 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque <turretarc>, después del paso de “Modificar dados de defensa”, el defensor retira 1 ficha de Concentración o de Cálculos.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_49",
+            "force_side": null,
+            "id": 278,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Artillero habilidoso",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -22587,6 +21721,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Después de que reveles tu selector de maniobras, puedes gastar 1<nonbreak><standardcharge> y recibir 1 ficha de Desarme para recuperar 1 escudo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+            "card_set_ids": [
+                1,
+                4,
+                6,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_53",
+            "force_side": null,
+            "id": 282,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Droide astromecánico R2",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6663,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Eres capaz de mantener hasta 2 Blancos fijados. Cada Blanco fijado debe ser mantenido sobre un objeto distinto.<return>Después de que realices una acción <targetlock> puedes obtener un Blanco fijado.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22702,6 +21876,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallcaps>Acción:</smallcaps> Gasta 1<nonbreak><standardcharge> para realizar una acción <cloak>.<return>Al comienzo de la fase de Planificación, tira 1 dado de ataque, Si sacas un resultado <focus>, desactiva el camuflaje o descarta tu ficha de Camuflaje.<return>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_57",
+            "force_side": null,
+            "id": 286,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Dispositivo de camuflaje",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6594,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de que te actives, puedes gastar 1 ficha <standardcharge>. Si lo haces, hasta el final de la ronda, eres capaz de realizar acciones y ejecutar maniobras rojas, incluso aunque estés bajo tensión.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_58",
+            "force_side": null,
+            "id": 287,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ciberimplantes ilícitos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6631,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Después de que seas destruido, toda otra nave que tienes a alcance 0–1 sufre 1 de daño <hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22797,45 +22062,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Red Conner utilizando la plantilla [1<nonbreak><straight>].<return>Las <standardcharge> de esta carta no pueden recuperarse.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_64",
-            "force_side": null,
-            "id": 393,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Redes Conner",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6630,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Acción:</smallcaps> Gasta 1 <standardcharge>. Suelta 1 Cargamento expulsado utilizando la plantilla [1 <straight>].",
             "available_actions": [],
             "available_upgrades": [],
@@ -22890,18 +22116,10 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Ataque</smallcaps>",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5832,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
+            "ability_text": "Antes de que vayas a sufrir daño causado por un obstáculo o por la detonación de una bomba aliada, puedes gastar 1<nonbreak><standardcharge>. Si lo haces, evitas sufrir 1 de ese daño.",
+            "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
             "card_set_ids": [
                 4,
                 5,
@@ -22910,60 +22128,35 @@
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_31",
+            "ffg_id": "XW_U_68",
             "force_side": null,
-            "id": 260,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+            "id": 292,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Torreta dorsal",
-            "restrictions": [],
+            "name": "Blindaje ablativo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "LARGE"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6633,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                4
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Bomba de protones utilizando la plantilla [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_65",
-            "force_side": null,
-            "id": 394,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Bombas de protones",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6655,
+                    "id": 6614,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -22971,88 +22164,50 @@
             ],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Mina de proximidad utilizando la plantilla [1<nonbreak><straight>].<return>Las <standardcharge> de esta carta no pueden recuperarse.",
+            "ability_text": "Después de que efectúes una acción <slam>, si has ejecutado completamente la maniobra, puedes realizar una acción blanca que figure en tu barra de acciones, considerando esa acción como si fuera roja.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
             "card_set_ids": [
                 4,
                 5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_66",
-            "force_side": null,
-            "id": 395,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Minas de proximidad",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6662,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Carga sísmica con la plantilla [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8,
-                11
+                6
             ],
             "card_type_id": 2,
             "cost": "3",
             "faction_id": null,
-            "ffg_id": "XW_U_67",
+            "ffg_id": "XW_U_69",
             "force_side": null,
-            "id": 396,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "id": 293,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Cargas sísmicas",
-            "restrictions": [],
+            "name": "Motor sublumínico avanzado",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Slam",
+                            "pk": 13,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6666,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23187,6 +22342,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Para quienes no pueden permitirse instalar un generador de escudos más potente, añadir capas adicionales de blindaje al casco de una nave puede servirles de alternativa adecuada.</flavor>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "*",
+            "faction_id": null,
+            "ffg_id": "XW_U_73",
+            "force_side": null,
+            "id": 297,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Blindaje mejorado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6642,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "+1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras efectúas un ataque <torpedo> o <missile>, después de tirar los dados de ataque, puedes anular todos los resultados de los dados para recuperar 1<nonbreak><standardcharge> que hayas gastado como coste para el ataque.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23291,54 +22486,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Antes de tirar los dados de defensa, puedes gastar 1 ficha de Cálculos para decir en voz alta un número que sea igual o superior a 1. Si lo haces y en tu tirada de dados obtienes exactamente esa misma cantidad de resultados <evade>, añade 1 resultado <evade>.<return>Después de que realices la acción <calculate>, recibes 1 ficha de Cálculos.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5827,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_80",
-            "force_side": null,
-            "id": 304,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•C-3PO",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Mientras te defiendes, si tu <standardcharge> está activa, tira 1 dado de defensa adicional.<return>Después de que sufras daño, pierdes 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23422,6 +22569,94 @@
             "subtitle": null,
             "upgrade_types": [
                 14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas una acción <focus>, puedes considerarla como si fuera roja. Si lo haces, recibes 1 ficha de Concentración adicional por cada nave enemiga que tengas a alcance 0–1, hasta un máximo de 2.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_79",
+            "force_side": null,
+            "id": 303,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Baze Malbus",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de tirar los dados de defensa, puedes gastar 1 ficha de Cálculos para decir en voz alta un número que sea igual o superior a 1. Si lo haces y en tu tirada de dados obtienes exactamente esa misma cantidad de resultados <evade>, añade 1 resultado <evade>.<return>Después de que realices la acción <calculate>, recibes 1 ficha de Cálculos.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5827,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "12",
+            "faction_id": null,
+            "ffg_id": "XW_U_80",
+            "force_side": null,
+            "id": 304,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•C-3PO",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23514,6 +22749,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante el paso de “Realizar una acción”, puedes realizar 1 acción, incluso aunque estés bajo tensión. Después de que realices una acción mientras estás bajo tensión, sufres 1 de daño <hit> a menos que expongas 1 de tus cartas de Daño.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_83",
+            "force_side": null,
+            "id": 307,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Eres capaz de ejecutar maniobras rojas incluso aunque estés bajo tensión. Después de que ejecutes completamente una maniobra roja, si tienes 3 o más fichas de Tensión, retiras 1 ficha de Tensión y sufres 1 de daño <hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23531,6 +22806,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Hera Syndulla",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Si una nave aliada que tienes a alcance 0–3 va a recibir una ficha de Concentración, en vez de eso puede recibir 1 ficha de Evasión.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_85",
+            "force_side": null,
+            "id": 309,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Jyn Erso",
             "restrictions": [
                 [
                     {
@@ -23688,6 +23003,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Después de que te defiendas, si el ataque ha impactado, puedes obtener un Blanco fijado sobre el atacante.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_89",
+            "force_side": null,
+            "id": 313,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Reduce la dificultad de tus maniobras de inclinación (<leftbank> y <rightbank>).",
             "available_actions": [],
             "available_upgrades": [],
@@ -23705,6 +23060,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Nien Nunb",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la fase Final, si estas dañado y no estás protegido por escudos, puedes tirar 1 dado de ataque para recuperar 1 escudo. Si sacas un resultado <hit>, expón 1 de tus cartas de Daño.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_91",
+            "force_side": null,
+            "id": 315,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R2-D2",
             "restrictions": [
                 [
                     {
@@ -23768,23 +23163,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Durante la fase Final, si estas dañado y no estás protegido por escudos, puedes tirar 1 dado de ataque para recuperar 1 escudo. Si sacas un resultado <hit>, expón 1 de tus cartas de Daño.",
+            "ability_text": "Mientras efectúas un ataque, puedes sufrir 1 de daño <hit> para cambiar todos tus resultados <focus> por resultados <crit>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
             "card_set_ids": [
-                4
+                2
             ],
             "card_type_id": 2,
             "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_91",
+            "ffg_id": "XW_U_93",
             "force_side": null,
-            "id": 315,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "id": 317,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R2-D2",
+            "name": "•Saw Gerrera",
             "restrictions": [
                 [
                     {
@@ -23803,6 +23198,86 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Eres capaz de efectuar ataques principales a alcance 0. Las naves enemigas que tengas a alcance 0 son capaces de efectuar ataques principales contra ti.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_94",
+            "force_side": null,
+            "id": 318,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que efectúes un ataque principal, si estás concentrado, puedes realizar un ataque <turretarc> adicional contra una nave que no hayas atacado todavía en esta ronda.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "14",
+            "faction_id": null,
+            "ffg_id": "XW_U_95",
+            "force_side": null,
+            "id": 319,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bistan",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23895,46 +23370,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mientras efectúas un ataque, puedes sufrir 1 de daño <hit> para cambiar todos tus resultados <focus> por resultados <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_93",
-            "force_side": null,
-            "id": 317,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes gastar 1 <forcecharge> para reorientar tu indicador <turretarc>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23977,6 +23412,46 @@
             "subtitle": null,
             "upgrade_types": [
                 16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Acción:</smallcaps> Gasta 1<nonbreak><standardcharge> no recurrente de otra carta de Mejora que tengas equipada para recuperar 1 escudo.<return><smallcaps>Acción:</smallcaps> Gasta 2 escudos para recuperar 1<nonbreak><standardcharge> no recurrente sobre una mejora que tengas equipada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_99",
+            "force_side": null,
+            "id": 323,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24076,23 +23551,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Eres capaz de efectuar ataques principales a alcance 0. Las naves enemigas que tengas a alcance 0 son capaces de efectuar ataques principales contra ti.",
+            "ability_text": "Puedes acoplar 1 lanzadera de ataque o 1 lanzadera clase Sheathipede.<return>Tus naves acopladas sólo pueden desplegarse desde tus salientes traseros.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 2,
-            "cost": "1",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_94",
+            "ffg_id": "XW_U_102",
             "force_side": null,
-            "id": 318,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "id": 326,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•“Zeb” Orrelios",
+            "name": "•<italic>Espíritu</italic>",
             "restrictions": [
                 [
                     {
@@ -24102,6 +23577,15 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 23,
+                            "raw_name": "VCX-100 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
@@ -24110,40 +23594,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras estás efectuando un ataque que está obstruido por un obstáculo, tira 1 dado de ataque adicional.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_18",
-            "force_side": null,
-            "id": 247,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Disparo inverosímil",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24311,6 +23762,103 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Puedes acoplarte a alcance 0–1.<return>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_106",
+            "force_side": null,
+            "id": 330,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Fantasma</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 32,
+                            "raw_name": "Attack Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    },
+                    {
+                        "kwargs": {
+                            "pk": 8,
+                            "raw_name": "Sheathipede-class Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de que te actives, puedes darle la vuelta a esta carta.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+            "card_set_ids": [
+                2,
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_107",
+            "force_side": null,
+            "id": 331,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ala pivotante (posición abierta)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 15,
+                            "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras te defiendes, tira 1 dado de defensa menos.<return>Después de que ejecutes una maniobra [0<nonbreak><stop>], puedes cambiar la orientación de tu nave en 90º o 180º.<return>Antes de que te actives, puedes darle la vuelta a esta carta.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24332,6 +23880,49 @@
                         "kwargs": {
                             "pk": 15,
                             "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de que te actives, puedes darle la vuelta a esta carta.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_set_ids": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_108",
+            "force_side": null,
+            "id": 333,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Alas móviles (posición abierta)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 33,
+                            "raw_name": "T-65 X-wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -24402,34 +23993,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Antes de que te actives, puedes darle la vuelta a esta carta.",
+            "ability_text": "Después de que otra nave aliada que tengas a alcance 0–3 se defienda, si esa nave es destruida, el atacante recibe 2 fichas de Tensión.<return>Mientras una nave aliada que tienes a alcance 0–3 efectúa un ataque contra una nave que está bajo tensión, esa nave aliada puede volver a tirar 1 dado de ataque.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
             "card_set_ids": [
-                1,
-                2,
-                4,
-                7
+                5
             ],
             "card_type_id": 2,
-            "cost": "0",
+            "cost": "10",
             "faction_id": null,
-            "ffg_id": "XW_U_108",
+            "ffg_id": "XW_U_109",
             "force_side": null,
-            "id": 333,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "id": 335,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Alas móviles (posición abierta)",
+            "is_unique": true,
+            "name": "•Admiral Sloane",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "pk": 33,
-                            "raw_name": "T-65 X-wing"
+                            "name": "Galactic Empire",
+                            "pk": 2
                         },
-                        "type": "SHIP_TYPE"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -24439,7 +24027,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                18
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24590,6 +24178,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante la fase de Activación, las naves enemigas que tengas a alcance 0–1 no pueden retirar fichas de Tensión.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_113",
+            "force_side": null,
+            "id": 339,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Soldados de la muerte",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8,
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallcaps>Preparación:</smallcaps> Antes de desplegar las fuerzas, asigna el Estado <smallcaps>Prototipo optimizado</smallcaps> a otra nave aliada.",
             "available_actions": [
                 {
@@ -24733,6 +24362,111 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante la fase de Sistemas, puedes gastar 2<nonbreak><standardcharge>. Si lo haces, toda nave aliada puede obtener un Blanco fijado sobre una nave que tengas fijada como blanco.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_117",
+            "force_side": null,
+            "id": 343,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Gran Moff Tarkin",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6601,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la fase Final, las naves enemigas que tengas a alcance 1–2 no pueden retirar fichas de Interferencia.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_118",
+            "force_side": null,
+            "id": 344,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Técnico en guerra electrónica de la OSI",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Al comienzo de la fase de Enfrentamiento, si estás dañado, puedes realizar una acción <reinforce> roja.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24838,23 +24572,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Durante la fase Final, las naves enemigas que tengas a alcance 1–2 no pueden retirar fichas de Interferencia.",
+            "ability_text": "Si una nave enemiga que tienes a alcance 0–1 va a recibir una ficha de Tensión, puedes gastar 1<nonbreak><forcecharge> para que en vez de eso la nave reciba 1 ficha de Interferencia o de Campo de tracción.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
             "card_set_ids": [
-                3
+                5
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "12",
             "faction_id": null,
-            "ffg_id": "XW_U_118",
+            "ffg_id": "XW_U_121",
             "force_side": null,
-            "id": 344,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "id": 347,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Técnico en guerra electrónica de la OSI",
+            "is_unique": true,
+            "name": "•Séptima Hermana",
             "restrictions": [
                 [
                     {
@@ -24869,7 +24603,14 @@
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [],
+            "statistics": [
+                {
+                    "id": 6613,
+                    "recurring": false,
+                    "statistic_id": 4,
+                    "value": "+1"
+                }
+            ],
             "subtitle": null,
             "upgrade_types": [
                 8
@@ -24925,94 +24666,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Si una nave enemiga que tienes a alcance 0–1 va a recibir una ficha de Tensión, puedes gastar 1<nonbreak><forcecharge> para que en vez de eso la nave reciba 1 ficha de Interferencia o de Campo de tracción.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_121",
-            "force_side": null,
-            "id": 347,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Séptima Hermana",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6613,
-                    "recurring": false,
-                    "statistic_id": 4,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de que te actives, puedes darle la vuelta a esta carta.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
-            "card_set_ids": [
-                2,
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_107",
-            "force_side": null,
-            "id": 331,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ala pivotante (posición abierta)",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 15,
-                            "raw_name": "UT-60D U-wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Después de que ejecutes parcialmente una maniobra, puedes realizar 1 acción blanca, considerando esa acción como si fuera roja.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25062,38 +24715,29 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Después de que realices una acción <coordinate>, puedes elegir una nave enemiga que esté situada a alcance 0–3 de la nave que has coordinado. Si lo haces, obtienes un Blanco fijado sobre esa nave enemiga, ignorando las restricciones por alcance.",
+            "ability_text": "Mientras tienes exactamente 1 ficha de Desarme, sigues siendo capaz de efectuar ataques <torpedo> y <missile> contra objetivos sobre los que tengas un Blanco fijado. Si lo haces, no puedes gastar tu Blanco fijado durante el ataque.<return>Añádete los espacios <torpedo> y <missile>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_124",
+            "ffg_id": "XW_U_125",
             "force_side": null,
-            "id": 391,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "id": 350,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
             "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>ST-321</italic>",
+            "is_unique": false,
+            "name": "Configuración de arsenal Os-1",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 26,
-                            "raw_name": "Lambda-class T-4a Shuttle"
+                            "pk": 14,
+                            "raw_name": "Alpha-class Star Wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -25105,7 +24749,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                15
+                18
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25146,6 +24790,60 @@
             "subtitle": null,
             "upgrade_types": [
                 18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase de Enfrentamiento, puedes elegir 1 nave enemiga que tengas a alcance 0–1. Si lo haces, recibes 1 ficha de Cálculos a menos que esa nave elija recibir 1 ficha de Tensión.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_127",
+            "force_side": null,
+            "id": 352,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•0-0-0",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 338
+                        },
+                        "type": "CARD_INCLUDED"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 93
+                        },
+                        "type": "CARD_INCLUDED"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25249,6 +24947,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Cad Bane",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la fase Final, puedes elegir 2 mejoras <illicit> que estén equipadas en naves aliadas que tengas a alcance 0–1. Si lo haces, puedes intercambiar esas mejoras.<return>Final de la partida: Devuelve todas las mejoras <illicit> a sus naves originales.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_131",
+            "force_side": null,
+            "id": 356,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Cikatro Vizago",
             "restrictions": [
                 [
                     {
@@ -25385,6 +25123,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Ketsu Onyo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te defiendes, si el atacante está bajo tensión, puedes retirar 1 ficha de Tensión del atacante para cambiar 1 de tus resultados de cara vacía/<focus> por un resultado <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_135",
+            "force_side": null,
+            "id": 360,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Latts Razzi",
             "restrictions": [
                 [
                     {
@@ -25563,6 +25341,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Después de que efectúes un ataque principal que falle, si no estás bajo tensión, debes recibir 1 ficha de Tensión para efectuar un ataque principal adicional contra ese mismo objetivo.<return>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_139",
+            "force_side": null,
+            "id": 364,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bossk",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mientras efectúas un ataque, puedes cambiar 1 resultado <hit> por un resultado<crit> por cada ficha de Tensión que tenga el defensor.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25711,6 +25529,133 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Después de que ejecutes completamente una maniobra, si no has soltado ni lanzado ningún dispositivo en esta ronda, puedes soltar 1 bomba.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_143",
+            "force_side": null,
+            "id": 368,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Genio”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras efectúas un ataque contra un defensor que tienes en tu <frontarc>, puedes gastar 1 <standardcharge> para volver a tirar 1 dado de ataque. Si el nuevo resultado del dado es un resultado <crit> sufres 1 de daño <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_144",
+            "force_side": null,
+            "id": 369,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-P8",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6612,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Puedes efectuar ataques contra naves aliadas.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_145",
+            "force_side": null,
+            "id": 370,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-TK",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Añádete un espacio <bomb>.",
             "available_actions": [
                 {
@@ -25818,23 +25763,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mientras efectúas un ataque contra un defensor que tienes en tu <frontarc>, puedes gastar 1 <standardcharge> para volver a tirar 1 dado de ataque. Si el nuevo resultado del dado es un resultado <crit> sufres 1 de daño <crit>.",
+            "ability_text": "1 Z-95-AF4 Cazacabezas puede acoplarse contigo.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "4",
+            "cost": "1",
             "faction_id": null,
-            "ffg_id": "XW_U_144",
+            "ffg_id": "XW_U_148",
             "force_side": null,
-            "id": 369,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "id": 373,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R5-P8",
+            "name": "•<italic>Diente de Perro</italic>",
             "restrictions": [
                 [
                     {
@@ -25844,22 +25789,73 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 24,
+                            "raw_name": "YV-666 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6612,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "3"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                10
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Posees la capacidad especial de piloto de cada otra nave aliada que tenga la mejora <sabold>IG-2000</sabold>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_149",
+            "force_side": null,
+            "id": 374,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "<italic>IG-2000</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 21,
+                            "raw_name": "Aggressor Assault Fighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25971,23 +25967,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Posees la capacidad especial de piloto de cada otra nave aliada que tenga la mejora <sabold>IG-2000</sabold>.",
+            "ability_text": "Mientas efectúas un ataque principal, si el defensor está situado en tu <frontarc>, tira 1 dado de ataque adicional.<return>Elimínate el espacio <crew>. Añádete el espacio <astro>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_149",
+            "ffg_id": "XW_U_152",
             "force_side": null,
-            "id": 374,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "id": 377,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "<italic>IG-2000</italic>",
+            "is_unique": true,
+            "name": "•<italic>Castigadora</italic>",
             "restrictions": [
                 [
                     {
@@ -26001,8 +25997,8 @@
                 [
                     {
                         "kwargs": {
-                            "pk": 21,
-                            "raw_name": "Aggressor Assault Fighter"
+                            "pk": 45,
+                            "raw_name": "JumpMaster 5000"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -26172,23 +26168,72 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Preparación:<smallcaps> Equipa esta cara boca arriba.<return>Mientras te defiendes, puedes darle la vuelta a esta carta. Si lo haces, el atacante debe volver a tirar todos los dados de ataque.",
+            "ability_text": "Después de que una acción tuya fracase, si no tienes ninguna ficha verde, puedes realizar una acción <focus>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_156",
+            "force_side": null,
+            "id": 381,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Sangre fría",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Al comienzo de la fase Final, puedes gastar 1 ficha de Concentración para reparar 1 de tus cartas de Daño boca arriba.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_158",
+            "ffg_id": "XW_U_157",
             "force_side": null,
-            "id": 384,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+            "id": 382,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•L3–37",
+            "name": "•Chewbacca",
             "restrictions": [
                 [
                     {
@@ -26250,40 +26295,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Después de que una acción tuya fracase, si no tienes ninguna ficha verde, puedes realizar una acción <focus>.",
+            "ability_text": "<smallcaps>Preparación:<smallcaps> Equipa esta cara boca arriba.<return>Mientras te defiendes, puedes darle la vuelta a esta carta. Si lo haces, el atacante debe volver a tirar todos los dados de ataque.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_156",
+            "ffg_id": "XW_U_158",
             "force_side": null,
-            "id": 381,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "id": 384,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Sangre fría",
+            "is_unique": true,
+            "name": "•L3–37",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "STRESS"
+                            "name": "Scum and Villainy",
+                            "pk": 3
                         },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -26293,7 +26329,47 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                1
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que tires los dados, puedes gastar 1 ficha verde para volver a tirar hasta 2 de tus resultados.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_159",
+            "force_side": null,
+            "id": 385,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26316,6 +26392,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Tobias Beckett",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mientras te mueves y efectúas ataques, ignoras los obstáculos que tienes fijados como blanco.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_161",
+            "force_side": null,
+            "id": 387,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Qi’ra",
             "restrictions": [
                 [
                     {
@@ -26369,46 +26485,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Después de que tires los dados, puedes gastar 1 ficha verde para volver a tirar hasta 2 de tus resultados.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_159",
-            "force_side": null,
-            "id": 385,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Antes de que intervengas, puedes realizar una acción <focus> roja.",
             "available_actions": [],
             "available_upgrades": [],
@@ -26444,331 +26520,6 @@
             "subtitle": null,
             "upgrade_types": [
                 16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras te mueves y efectúas ataques, ignoras los obstáculos que tienes fijados como blanco.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_161",
-            "force_side": null,
-            "id": 387,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Qi’ra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que recibas una ficha de Tensión, puedes tirar 1 dado de ataque para retirarla. Si sacas <hit>, sufres 1 de daño <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5851,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5852,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5853,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_5",
-            "force_side": null,
-            "id": 5,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Jek Porkins",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6688,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6689,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6690,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6691,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rojo Seis",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Eres capaz de efectuar ataques principales a alcance 0.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6363,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6364,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6365,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6366,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6367,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_146",
-            "force_side": null,
-            "id": 146,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitán Oicunn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7244,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7245,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7246,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7247,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Estratega inspirado",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mientras una nave enemiga que tienes a alcance 0 se defiende, esa nave tira 1 dado de defensa menos.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_7",
-            "force_side": null,
-            "id": 236,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Intimidación",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Después de que realices una acción <focus>, recibes 1 ficha de Concentración.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_46",
-            "force_side": null,
-            "id": 275,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Copiloto perceptivo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puedes efectuar ataques contra naves aliadas.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_145",
-            "force_side": null,
-            "id": 370,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•R5-TK",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26818,6 +26569,255 @@
             "subtitle": null,
             "upgrade_types": [
                 15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Después de que realices una acción <coordinate>, puedes elegir una nave enemiga que esté situada a alcance 0–3 de la nave que has coordinado. Si lo haces, obtienes un Blanco fijado sobre esa nave enemiga, ignorando las restricciones por alcance.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_124",
+            "force_side": null,
+            "id": 391,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>ST-321</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 26,
+                            "raw_name": "Lambda-class T-4a Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Minibomba utilizando la plantilla [1<nonbreak><straight>].<return>Al comienzo de la fase de Activación, puedes gastar 1 escudo para recuperar 2<nonbreak> <standardcharge>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_63",
+            "force_side": null,
+            "id": 392,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Generador de minibombas",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6622,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12,
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Red Conner utilizando la plantilla [1<nonbreak><straight>].<return>Las <standardcharge> de esta carta no pueden recuperarse.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_64",
+            "force_side": null,
+            "id": 393,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Redes Conner",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6630,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Bomba de protones utilizando la plantilla [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_65",
+            "force_side": null,
+            "id": 394,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Bombas de protones",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6655,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Mina de proximidad utilizando la plantilla [1<nonbreak><straight>].<return>Las <standardcharge> de esta carta no pueden recuperarse.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_66",
+            "force_side": null,
+            "id": 395,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Minas de proximidad",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6662,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la fase de Sistemas, puedes gastar 1<nonbreak><standardcharge> para soltar una Carga sísmica con la plantilla [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_67",
+            "force_side": null,
+            "id": 396,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cargas sísmicas",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6666,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
             ],
             "weapon_no_bonus": false,
             "weapon_range": null

--- a/translation_helper/api_export_fr.json
+++ b/translation_helper/api_export_fr.json
@@ -1,6 +1,745 @@
 {
     "cards": [
         {
+            "ability_text": "Tant que vous effectuez une attaque, le défenseur lance 1 dé de défense en moins.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5839,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5840,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5841,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_1",
+            "force_side": null,
+            "id": 1,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Wedge Antilles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6671,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6672,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6673,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6674,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Deux",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après être devenu le défenseur (avant que les dés ne soient lancés), vous pouvez récupérer 1 <forcecharge>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5842,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5843,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5844,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                17,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "62",
+            "faction_id": 1,
+            "ffg_id": "XW_P_2",
+            "force_side": 2,
+            "id": 2,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Luke Skywalker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6675,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6676,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6677,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6678,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 6679,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Cinq",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque, vous pouvez dépense 1 résultat <focus>, <hit> ou <crit> pour regarder les cartes de dégât face cachée du défenseur, en choisir 1 et l’exposer.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5845,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5846,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5847,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_set_ids": [
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_3",
+            "force_side": null,
+            "id": 3,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Thane Kyrell",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6680,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6681,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6682,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6683,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Corona Quatre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après voir dépensé un marqueur de concentration, vous pouvez choisir 1 vaisseau allié à portée 1–3. Ce vaisseau gagne 1 marqueur de concentration.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5848,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5849,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5850,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_4",
+            "force_side": null,
+            "id": 4,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6684,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6685,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6686,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6687,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir reçu un marqueur de stress, vous pouvez lancer 1 dé d’attaque pour le retirer.<return>Sur un résultat <hit>, subissez 1 dégât <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5851,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5852,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5853,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_5",
+            "force_side": null,
+            "id": 5,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Jek Porkins",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6688,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6689,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6690,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6691,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Six",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une action <barrelroll> ou <boost>, vous pouvez retourner votre carte d’amélioration <config> équipée.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5854,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5855,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5856,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_6",
+            "force_side": null,
+            "id": 6,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kullbee Sperado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6692,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6693,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6694,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6695,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Guérillero Énigmatique",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un autre vaisseau allié à portée 0–1 défend, avant l’étape «<nonbreak>Neutraliser les résultats<nonbreak>», si vous êtes dans l’arc de l’attaque, vous pouvez subir 1 dégât<nonbreak><hit> ou <crit> pour annuler 1 dégât correspondant.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5857,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5858,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5859,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_7",
+            "force_side": null,
+            "id": 7,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Biggs Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6696,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6697,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6698,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6699,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Red Trois",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une action <barrelroll> ou <boost>, vous pouvez effectuer une action <evade> rogue.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5860,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5861,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5862,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_8",
+            "force_side": null,
+            "id": 8,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Leevan Tenza",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6700,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6701,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6702,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6703,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Transfuge de l’Alliance Rebelle",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant votre activation, si vous êtes concentré, vous pouvez effectuer une action.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5863,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5864,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5865,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_9",
+            "force_side": null,
+            "id": 9,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Edrio Deux-Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6704,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6705,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6706,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6707,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Vétéran Anges des Cavernes",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Conçu comme une unité d’élite pour les combats spatiaux, l’Escadron Rouge comprend certains des meilleurs pilotes de l’Alliance Rebelle.</flavor>",
             "available_actions": [
                 {
@@ -84,164 +823,164 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Tant que vous effectuez une attaque, le défenseur lance 1 dé de défense en moins.",
+            "ability_text": "<flavor>Conçu par Incom Corporation, le X-wing T-65 compta rapidement parmi les appareils militaires les plus efficaces de la galaxie et fut d’un réel secours pour la Rébellion.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 5869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 5870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 5871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
             "card_set_ids": [
+                1,
                 4,
                 7
             ],
             "card_type_id": 1,
-            "cost": "52",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_1",
+            "ffg_id": "XW_P_11",
             "force_side": null,
-            "id": 1,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Wedge Antilles",
+            "id": 11,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Escorte de l’Escadron Bleu",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 6712,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 6713,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 6714,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 6715,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Red Deux",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "Tant que vous effectuez une attaque, vous pouvez dépense 1 résultat <focus>, <hit> ou <crit> pour regarder les cartes de dégât face cachée du défenseur, en choisir 1 et l’exposer.",
+            "ability_text": "<flavor>Contrairement à la plupart des cellules Rebelles, les Partisans de Saw Gerrera utilisèrent des méthodes jugées trop radicales pour lutter contre l’Empire Galactique, au cours des sanglants combats qui ravagèrent Géonosis et Jedha.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 5872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 5873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 5874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
+                13,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
             "card_set_ids": [
-                7
+                2
             ],
             "card_type_id": 1,
-            "cost": "48",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_3",
+            "ffg_id": "XW_P_12",
             "force_side": null,
-            "id": 3,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Thane Kyrell",
+            "id": 12,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Extrémiste Anges des Cavernes",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 6716,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 6717,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 6718,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 6719,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Corona Quatre",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -332,343 +1071,6 @@
                 }
             ],
             "subtitle": "Gold Neuf",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après voir dépensé un marqueur de concentration, vous pouvez choisir 1 vaisseau allié à portée 1–3. Ce vaisseau gagne 1 marqueur de concentration.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5848,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5849,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5850,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_4",
-            "force_side": null,
-            "id": 4,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6684,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6685,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6686,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6687,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Conçu par Incom Corporation, le X-wing T-65 compta rapidement parmi les appareils militaires les plus efficaces de la galaxie et fut d’un réel secours pour la Rébellion.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5869,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5870,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5871,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_11",
-            "force_side": null,
-            "id": 11,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Escorte de l’Escadron Bleu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6712,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6713,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6714,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6715,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque, vous pouvez relancer 1 dé d’attaque pour chaque autre vaisseau allié à portée 0–1 du défenseur.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5883,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5884,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5885,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5886,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
-            "card_set_ids": [
-                4,
-                8
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_15",
-            "force_side": null,
-            "id": 15,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Horton Salm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 6728,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6729,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6730,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6731,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gray Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une action <barrelroll> ou <boost>, vous pouvez retourner votre carte d’amélioration <config> équipée.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5854,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5855,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5856,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_6",
-            "force_side": null,
-            "id": 6,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kullbee Sperado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6692,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6693,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6694,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6695,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Guérillero Énigmatique",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -765,42 +1167,183 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Au début de la phase de dénouement, vous pouvez dépenser 1 marqueur de concentration pour réparer 1 de vos cartes de dégât face visible.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+            "ability_text": "Tant que vous effectuez une attaque, vous pouvez relancer 1 dé d’attaque pour chaque autre vaisseau allié à portée 0–1 du défenseur.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5883,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5884,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5885,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5886,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
             "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_157",
-            "force_side": null,
-            "id": 382,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
+                4,
                 8
             ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_15",
+            "force_side": null,
+            "id": 15,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Horton Salm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6728,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6729,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6730,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6731,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gray Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez dépenser 1 marqueur de concentration pour choisir un vaisseau allié à portée 0–1. Dans ce cas, ce vaisseau allié lance 1 dé de défense supplémentaire tant qu’il défend, jusqu’à la fin du round.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5887,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5888,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5889,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5890,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_set_ids": [
+                8
+            ],
+            "card_type_id": 1,
+            "cost": "36",
+            "faction_id": 1,
+            "ffg_id": "XW_P_16",
+            "force_side": null,
+            "id": 16,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Evaan Verlaine",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6732,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6733,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6734,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6735,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gold Trois",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -896,39 +1439,38 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez dépenser 1 marqueur de concentration pour choisir un vaisseau allié à portée 0–1. Dans ce cas, ce vaisseau allié lance 1 dé de défense supplémentaire tant qu’il défend, jusqu’à la fin du round.",
+            "ability_text": "<flavor>Grâce à sa vitesse, sa robustesse et son armement lourd, le Y-wing resta un élément essentiel de la flotte Rebelle longtemps après sa mise en retraite par l’Empire Galactique.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 5895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 5896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 5897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 5898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 4,
                 5,
                 10,
@@ -936,51 +1478,52 @@
                 14,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
             "card_set_ids": [
+                4,
                 8
             ],
             "card_type_id": 1,
-            "cost": "36",
+            "cost": "32",
             "faction_id": 1,
-            "ffg_id": "XW_P_16",
+            "ffg_id": "XW_P_18",
             "force_side": null,
-            "id": 16,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Evaan Verlaine",
+            "id": 18,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Bombardier de l’Escadron Gris",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 6740,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 6741,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 6742,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 6743,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Gold Trois",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1078,167 +1621,179 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Après avoir effectué une action <barrelroll> ou <boost>, vous pouvez effectuer une action <evade> rogue.",
+            "ability_text": "Vous pouvez effectuer des attaques principales à portée 0.<return>Si vous deviez échouer à une action <boost> qui vous amènerait à chevaucher un autre vaisseau, résolvez-la comme si vous exécutiez partiellement une manœuvre à la place.<return><sabold>Propulseurs Vectoriels :</sabold> après avoir effectué une action, vous pouvez effectuer une action <boost> rouge.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 5904,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 5906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 5907,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                5,
-                10,
-                13,
-                14,
-                18
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
             "card_set_ids": [
-                2
+                4
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_8",
+            "ffg_id": "XW_P_20",
             "force_side": null,
-            "id": 8,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "id": 20,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "•Leevan Tenza",
+            "name": "•Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 33,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 6748,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6701,
-                    "recurring": false,
-                    "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 6749,
                     "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
+                    "statistic_id": 1,
+                    "value": "3"
                 },
                 {
-                    "id": 6703,
+                    "id": 6750,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6751,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Transfuge de l’Alliance Rebelle",
+            "subtitle": "Green Leader",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Grâce à sa vitesse, sa robustesse et son armement lourd, le Y-wing resta un élément essentiel de la flotte Rebelle longtemps après sa mise en retraite par l’Empire Galactique.</flavor>",
+            "ability_text": "<flavor>À cause de ses commandes sensibles et de son extrême manœuvrabilité, seuls les meilleurs pilotes﻿ osent prendre place dans le cockpit d’un A-wing.</flavor><return><sabold>Propulseurs Vectoriels :</sabold> après avoir effectué une action, vous pouvez effectuer une action <boost> rouge.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 5909,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 5911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "base_action_side_effect": null,
+                    "id": 5912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
+                1,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
             "card_set_ids": [
-                4,
-                8
+                4
             ],
             "card_type_id": 1,
-            "cost": "32",
+            "cost": "34",
             "faction_id": 1,
-            "ffg_id": "XW_P_18",
+            "ffg_id": "XW_P_21",
             "force_side": null,
-            "id": 18,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-            "initiative": 2,
+            "id": 21,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
+            "initiative": 3,
             "is_unique": false,
-            "name": "Bombardier de l’Escadron Gris",
+            "name": "Pilote de l’Escadron Vert",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 12,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 6752,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 6753,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "1"
+                    "value": "3"
                 },
                 {
-                    "id": 6742,
+                    "id": 6754,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "6"
+                    "value": "2"
                 },
                 {
-                    "id": 6743,
+                    "id": 6755,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1246,46 +1801,6 @@
             ],
             "subtitle": "",
             "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous avez exactement 1 marqueur de désarmement, vous pouvez toujours effectuer des attaques <torpedo> et <missile> contre des cibles que vous avez verrouillées. Dans ce cas, vous ne pouvez pas dépenser votre marqueur de verrouillage pendant cette attaque.<return>Ajoutez des emplacements <torpedo> et <missile>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_125",
-            "force_side": null,
-            "id": 350,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Arsenal Os-1 Embarqué",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 14,
-                            "raw_name": "Alpha-class Star Wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -1381,93 +1896,3985 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Vous pouvez effectuer des attaques principales à portée 0.<return>Si vous deviez échouer à une action <boost> qui vous amènerait à chevaucher un autre vaisseau, résolvez-la comme si vous exécutiez partiellement une manœuvre à la place.<return><sabold>Propulseurs Vectoriels :</sabold> après avoir effectué une action, vous pouvez effectuer une action <boost> rouge.",
+            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez relancer jusqu’à 2 de vos dés.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5905,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
+                    "id": 5919,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 5920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 5921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                6
+                2,
+                3,
+                3,
+                5,
+                14
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_23",
+            "force_side": null,
+            "id": 23,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Braylen Stramm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6760,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6761,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6762,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6763,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Leader Blade",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez ou effectuez une attaque, vous pouvez dépenser 1 marqueur de stress pour changer tous vos résultats <focus> en résultats <evade> ou <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5922,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5923,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5924,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_24",
+            "force_side": null,
+            "id": 24,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Ten Numb",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6764,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6765,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6766,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6767,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Blue Cinq",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Un système de stabilisation gyroscopique unique enveloppe le cockpit du B-wing et assure la stabilité du pilote.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5925,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5926,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5927,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 1,
+            "ffg_id": "XW_P_25",
+            "force_side": null,
+            "id": 25,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Vétéran de l’Escadron Blade",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6768,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6769,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6770,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6771,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Grâce à son impressionnant panel d’armes lourdes et à ses boucliers très résistants, le B-wing s’est imposé comme le plus redoutable chasseur d’assaut de l’Alliance Rebelle.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5928,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5929,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5930,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_26",
+            "force_side": null,
+            "id": 26,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilote de l’Escadron Bleu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6772,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6773,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6774,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6775,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une attaque, vous pouvez choisir 1 vaisseau allié à portée 1. Ce vaisseau peut effectuer une action, en la considérant comme rouge.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5931,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5932,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5933,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 1,
             "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_20",
+            "ffg_id": "XW_P_27",
             "force_side": null,
-            "id": 20,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-            "initiative": 3,
+            "id": 27,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
+            "initiative": 5,
             "is_unique": true,
-            "name": "•Arvel Crynyd",
+            "name": "•Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 35,
+            "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 6776,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 6777,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "3"
+                    "value": "2"
                 },
                 {
-                    "id": 6750,
+                    "id": 6778,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 6779,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Green Leader",
+            "subtitle": "Chef des Renseignements",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque principale, si au moins 1 autre vaisseau allié est à portée 0–1 du défenseur, vous pouvez lancer 1 dé d’attaque supplémentaire.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5934,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5935,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5936,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_28",
+            "force_side": null,
+            "id": 28,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lieutenant Blount",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6780,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6781,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6782,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6783,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Coéquipier",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>L’AF4 est la toute dernière génération du modèle Chasseur de Têtes. Robuste et bon marché, il est très populaire auprès des organisations indépendantes comme la Rébellion.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5937,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5938,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5939,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "25",
+            "faction_id": 1,
+            "ffg_id": "XW_P_29",
+            "force_side": null,
+            "id": 29,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilote de l’Escadron Tala",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6784,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6785,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6786,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6787,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Le Chasseur de Têtes Z-95 a été la principale source d’inspiration d’Incom Corporation pour la conception du X-wing T-65. Bien que considéré comme obsolète, le Chasseur de Têtes Z-95 reste un appareil léger polyvalent et robuste.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5940,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5941,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5942,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "23",
+            "faction_id": 1,
+            "ffg_id": "XW_P_30",
+            "force_side": null,
+            "id": 30,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Pilote de l’Escadron Bandit",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6788,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6789,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6790,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6791,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque principale, si vous êtes endommagé, vous pouvez lancer 1 dé d’attaque supplémentaire.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5943,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5944,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5945,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "56",
+            "faction_id": 1,
+            "ffg_id": "XW_P_31",
+            "force_side": null,
+            "id": 31,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Wullffwarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6792,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6793,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6794,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6795,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Chef Wookie",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après qu’un vaisseau allié à portée 0–1 est devenu le défenseur, vous pouvez dépenser 1 marqueur de renforcement. Dans ce cas, le vaisseau défenseur gagne 1 marqueur d’évasion.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5946,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5947,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5948,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_32",
+            "force_side": null,
+            "id": 32,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Lowhhrick",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6796,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6797,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6798,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6799,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gladiateur Rescapé",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Équipée de trois canons laser jumelés Sureggi longue portée, la canonnière Auzituck donnait du fil à retordre aux esclavagistes dans le système de Kashyyyk.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5949,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5950,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5951,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_33",
+            "force_side": null,
+            "id": 33,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Défenseur de Kashyyyk",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6800,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6801,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6802,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6803,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir révélé une manœuvre bleue ou rouge, vous pouvez régler votre cadran sur une autre manœuvre de même difficulté.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5952,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5953,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5954,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "39",
+            "faction_id": 1,
+            "ffg_id": "XW_P_34",
+            "force_side": null,
+            "id": 34,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6804,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6805,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6806,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6807,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant votre activation, vous pouvez effectuer une action <barrelroll> ou <boost>.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5955,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5956,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5957,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_35",
+            "force_side": null,
+            "id": 35,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6808,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6809,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6810,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6811,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez dépenser 1 <forcecharge> pour changer jusqu’à 2 de vos résultats <focus> en résultats <evade> ou <hit>.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5958,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5959,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5960,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "41",
+            "faction_id": 1,
+            "ffg_id": "XW_P_36",
+            "force_side": 2,
+            "id": 36,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6812,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6813,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6814,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6815,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6816,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez, les résultats <crit> sont neutralisés avant les résultats <hit>.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5961,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5962,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5963,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 1,
+            "ffg_id": "XW_P_37",
+            "force_side": null,
+            "id": 37,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6817,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6818,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6819,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6820,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après qu’un vaisseau ennemi situé dans votre arc de tir vous a engagé, si vous n’êtes pas stressé, vous pouvez gagner 1 marqueur de stress. Dans ce cas, ce vaisseau ennemi ne peut pas dépenser de marqueur pour modifier des dés tant qu’il effectue une attaque pendant cette phase. <return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5964,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5965,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_38",
+            "force_side": null,
+            "id": 38,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6821,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6822,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6823,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6824,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6825,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Rebelle Réticent",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez dépenser 1 <forcecharge> pour changer jusqu’à 2 de vos résultats <focus> en résultats <evade> ou <hit>.<return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5966,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5967,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                10,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_39",
+            "force_side": 2,
+            "id": 39,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6826,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6827,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6828,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6829,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6830,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6831,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez, les résultats <crit> sont neutralisés avant les résultats <hit>.<return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5968,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5969,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_40",
+            "force_side": null,
+            "id": 40,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6832,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6833,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6834,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6835,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6836,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous coordonnez, si vous choisissez un vaisseau qui a exactement 1 marqueur de stress, il peut effectuer des actions. <return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5970,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5971,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_41",
+            "force_side": null,
+            "id": 41,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
+            "initiative": 1,
+            "is_unique": true,
+            "name": "•AP-5",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6837,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6838,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6839,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6840,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6841,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Droïde Analyste Rescapé",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un vaisseau allié situé dans votre arc de tir effectue une attaque principale, si vous n’êtes pas stressé, vous pouvez gagner 1 marqueur de stress. Dans ce cas, ce vaisseau peut lancer 1 dé d’attaque supplémentaire.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5972,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5973,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5974,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5975,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5976,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_42",
+            "force_side": null,
+            "id": 42,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Jan Ors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6842,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6843,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6844,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6845,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Experte en Espionnage",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez transférer 1 de vos marqueurs de concentration à un vaisseau allié situé dans votre arc de tir.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5977,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5978,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5979,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5980,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5981,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_43",
+            "force_side": null,
+            "id": 43,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kyle Katarn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6846,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6847,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6848,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6849,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Agent Implacable",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau situé dans votre arc de tir. Dans ce cas, pendant cette phase, il s’engage à l’initiative 7 au lieu de le faire à sa valeur d’initiative standard.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5982,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5983,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5984,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5985,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5986,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_44",
+            "force_side": null,
+            "id": 44,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Roark Garnet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6850,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6851,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6852,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6853,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Contrebandier au Grand Cœur",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Conçue par la Corporation Technique Corellienne et inspirée d’un oiseau  en vol, la série « hawk » a produit d’excellents cargos légers. Rapide et résistant, le HWK-290 est souvent utilisé par les agents Rebelles en tant que base mobile d’opérations.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5987,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5988,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5989,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5990,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5991,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_45",
+            "force_side": null,
+            "id": 45,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Éclaireur Rebelle",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6854,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6855,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6856,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6857,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez dépenser 1 <forcecharge> pour changer jusqu’à 2 de vos résultats <focus> en résultats <evade> ou <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5992,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5993,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5994,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_46",
+            "force_side": 2,
+            "id": 46,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6858,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6859,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6860,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6861,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant votre activation, vous pouvez effectuer une action <barrelroll> ou <boost>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5995,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5996,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5997,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 1,
+            "ffg_id": "XW_P_47",
+            "force_side": null,
+            "id": 47,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6862,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6863,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6864,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une attaque, assignez l’état Tir de Suppression au défenseur.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5998,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5999,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6000,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_48",
+            "force_side": null,
+            "id": 48,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Capitaine Rex",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6865,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6866,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6867,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Vétéran de la Guerre des Clones",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez, les résultats <crit> sont neutralisés avant les résultats <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6001,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6002,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6003,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "26",
+            "faction_id": 1,
+            "ffg_id": "XW_P_49",
+            "force_side": null,
+            "id": 49,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6868,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6869,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6870,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "À l’initiative 0, vous pouvez effectuer une attaque principale bonus contre un vaisseau ennemi situé dans votre <bullseye>. Dans ce cas, au début de la prochaine phase de préparation, gagnez 1 marqueur de désarmement. <return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6004,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6005,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6006,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6007,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6008,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 1,
+            "ffg_id": "XW_P_50",
+            "force_side": null,
+            "id": 50,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Corran Horn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6871,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6872,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6873,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6874,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Enquêteur Tenace",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un vaisseau allié effectue une attaque, si le défenseur est dans votre <frontarc>, l’attaquant peut changer 1 résultat<nonbreak><hit> en un résultat <crit>.<return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6009,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6010,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6011,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6012,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6013,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 1,
+            "ffg_id": "XW_P_51",
+            "force_side": null,
+            "id": 51,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Gavin Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6875,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6876,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6877,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6878,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Ailier Audacieux",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Les pilotes d’élite de l’Escadron Rogue font partie des meilleurs pilotes de la Rébellion.</flavor><return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6014,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6015,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6016,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6017,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6018,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "63",
+            "faction_id": 1,
+            "ffg_id": "XW_P_52",
+            "force_side": null,
+            "id": 52,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Escorte de l’Escadron Rogue",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6879,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6880,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6881,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6882,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Conçu pour combiner les meilleurs atouts de l’A-wing et du X-wing, l’E-wing dispose d’une puissance de feu, d’une vitesse et d’une manœuvrabilité supérieures.</flavor><return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6019,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6020,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6021,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6022,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6023,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "61",
+            "faction_id": 1,
+            "ffg_id": "XW_P_53",
+            "force_side": null,
+            "id": 53,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Escorte de l’Escadron Knave",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6883,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6884,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6885,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6886,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Les vaisseaux alliés peuvent verrouiller des objets à portée 0–3 de n’importe quel vaisseau allié.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6024,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6025,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6026,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 1,
+            "ffg_id": "XW_P_54",
+            "force_side": null,
+            "id": 54,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Bodhi Rook",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6887,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6888,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6889,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6890,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Déserteur Impérial",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un vaisseau allié endommagé à portée 0–3 effectue une attaque, il peut relancer 1 dé d’attaque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6027,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6028,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6029,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_55",
+            "force_side": null,
+            "id": 55,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Saw Gerrera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6891,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6892,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6893,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6894,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Radical Obsessionnel",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’activation, vous pouvez choisir 1 vaisseau allié à portée 1–3. Dans ce cas, ce vaisseau allié retire 1 marqueur de stress.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6030,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6031,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6032,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_56",
+            "force_side": null,
+            "id": 56,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Cassian Andor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6895,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6896,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6897,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6898,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Recueilli par la Rébellion",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un vaisseau allié à portée 0–2 défend, l’attaquant ne peut pas relancer plus de 1 dé d’attaque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6033,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6034,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6035,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_57",
+            "force_side": null,
+            "id": 57,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6899,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6900,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6901,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6902,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Guetteur Anges des Cavernes",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une action <focus>, vous pouvez transférer 1 de vos marqueurs de concentration à un vaisseau allié à portée 1–2.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6036,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6037,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6038,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_58",
+            "force_side": null,
+            "id": 58,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Benthic Deux-Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6903,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6904,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6905,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6906,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Tireur d’Élite Anges des Cavernes",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après qu’un vaisseau ennemi a exécuté une manœuvre, s’il est à portée 0, vous pouvez effectuer une action.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6039,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6040,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6041,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_59",
+            "force_side": null,
+            "id": 59,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Heff Tobber",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6907,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6908,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6909,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6910,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Blue Huit",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Utilisé pour déployer des troupes sous couvert de l’obscurité ou sur les théâtres d’opérations les plus dangereux, le U-wing UT-60D rendit de fiers services à l’Alliance Rebelle qui avait désespérément besoin de transports résistants.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6042,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6043,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6044,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_60",
+            "force_side": null,
+            "id": 60,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Éclaireur de l’Escadron Bleu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6911,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6912,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6913,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6914,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Les Partisans de Saw Gerrera se rassemblèrent d’abord pour combattre les troupes Séparatistes sur Onderon lors de la Guerre des Clones, puis ils continuèrent de lutter contre la tyrannie galactique instaurée par l’Empire.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6045,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6046,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6047,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_61",
+            "force_side": null,
+            "id": 61,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Renégat Partisan",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6915,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6916,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6917,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6918,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque principale, vous pouvez soit dépenser 1 bouclier pour lancer 1 dé d’attaque supplémentaire, soit, si vous n’êtes pas protégé, vous pouvez lancer 1 dé d’attaque en moins pour récupérer 1 bouclier.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6048,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6049,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6050,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6051,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6052,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_62",
+            "force_side": null,
+            "id": 62,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Miranda Doni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6919,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6920,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6921,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6922,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Poids Lourd",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un vaisseau allié à portée 0–2 défend ou effectue une attaque, il peut dépenser vos marqueurs de concentration comme s’ils étaient à lui.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6053,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6054,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6055,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6056,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6057,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_63",
+            "force_side": null,
+            "id": 63,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Esege Tuketu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6923,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6924,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6925,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6926,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Héros Altruiste",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Le K-wing de Koensayr Manufacturing peut s’enorgueillir de son moteur à accélération subluminique avancé et de dix-huit points d’emport, ce qui lui confère une vitesse et une puissance de feu inégalées.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6058,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6059,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6060,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6061,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6062,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 1,
+            "ffg_id": "XW_P_64",
+            "force_side": null,
+            "id": 64,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilote de l’Escadron Warden",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6927,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6928,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6929,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6930,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez, si un vaisseau ennemi est à portée 0–1, vous pouvez ajouter 1 résultat <evade> aux résultats de vos dés.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6063,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6064,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6065,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "55",
+            "faction_id": 1,
+            "ffg_id": "XW_P_65",
+            "force_side": null,
+            "id": 65,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Norra Wexley",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6931,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6932,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6933,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6934,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6935,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Gold Neuf",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir dépensé un marqueur de concentration, vous pouvez choisir 1 vaisseau allié à portée 1–3. Ce vaisseau allié gagne 1 marqueur de concentration.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6066,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6067,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6068,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "51",
+            "faction_id": 1,
+            "ffg_id": "XW_P_66",
+            "force_side": null,
+            "id": 66,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6936,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6937,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6938,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6939,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6940,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Red Leader",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez ou effectuez une attaque principale, vous pouvez dépenser 1 marqueur de verrouillage que vous avez sur le vaisseau ennemi pour ajouter 1 résultat<nonbreak><focus> aux résultats de vos dés.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6069,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6070,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6071,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "53",
+            "faction_id": 1,
+            "ffg_id": "XW_P_67",
+            "force_side": null,
+            "id": 67,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Shara Bey",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6941,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6942,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6943,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6944,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6945,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Green Quatre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir entièrement exécuté une manœuvre, si vous êtes stressé, vous pouvez lancer 1 dé d’attaque. Sur un résultat <hit> ou <crit>, retirez 1 marqueur de stress.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6072,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6073,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6074,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_68",
+            "force_side": null,
+            "id": 68,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ibtisam",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6946,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6947,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6948,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6949,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6950,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Survivant d’Endor",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir lancé des dés, si vous êtes à portée 0–1 d’un obstacle, vous pouvez relancer tous vos dés. Cela n’est pas considéré comme une relance pour les autres effets.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6075,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6076,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6077,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6078,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "92",
+            "faction_id": 1,
+            "ffg_id": "XW_P_69",
+            "force_side": null,
+            "id": 69,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6951,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6952,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6953,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6954,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Canaille à Louer",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1559,6 +5966,533 @@
                 }
             ],
             "subtitle": "Général de l’Alliance",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant qu’une carte de dégât ne vous soit attribuée face visible, vous pouvez dépenser 1 <standardcharge> pour qu’elle vous soit attribuée face cachée à la place.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6083,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6084,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6085,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6086,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 1,
+            "ffg_id": "XW_P_71",
+            "force_side": null,
+            "id": 71,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Chewbacca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6959,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6960,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6961,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6962,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                },
+                {
+                    "id": 6963,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Le Puissant",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Connu pour sa robustesse et sa conception modulaire, le YT-1300 est l’un des cargos les plus populaires et répandus de la galaxie.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6087,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6088,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6089,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6090,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "78",
+            "faction_id": 1,
+            "ffg_id": "XW_P_72",
+            "force_side": null,
+            "id": 72,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Contrebandier de la Bordure Extérieure",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6964,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6965,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6966,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6967,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir révélé une manœuvre bleue ou rouge, vous pouvez régler votre cadran sur une autre manœuvre de même difficulté.<return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6091,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6092,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6093,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "76",
+            "faction_id": 1,
+            "ffg_id": "XW_P_73",
+            "force_side": null,
+            "id": 73,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6968,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6969,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6970,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6971,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un vaisseau allié situé dans votre arc de tir défend, vous pouvez dépenser 1 <forcecharge>. Dans ce cas, l’attaquant lance 1 dé d’attaque en moins.<return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6094,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6095,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6096,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "90",
+            "faction_id": 1,
+            "ffg_id": "XW_P_74",
+            "force_side": 2,
+            "id": 74,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kanan Jarrus",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6972,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6973,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6974,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6975,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                },
+                {
+                    "id": 6976,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Spectre-1",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, chaque vaisseau ennemi à portée 0 gagne 2 marqueurs de brouillage. <return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6097,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6098,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6099,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 1,
+            "ffg_id": "XW_P_75",
+            "force_side": null,
+            "id": 75,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6977,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6978,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6979,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6980,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-3",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Autre réussite commerciale de la Corporation Technique Corellienne, le cargo VCX-100 est plus gros que les légendaires appareils de la série YT, et propose un espace de vie plus volumineux et de meilleures possibilités de personnalisation.</flavor><return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6100,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6101,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6102,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 1,
+            "ffg_id": "XW_P_76",
+            "force_side": null,
+            "id": 76,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebelle de Lothal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6981,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6982,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6983,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6984,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1973,87 +6907,6 @@
                 }
             ],
             "subtitle": "Leader Obsidian",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Contrairement à la plupart des cellules Rebelles, les Partisans de Saw Gerrera utilisèrent des méthodes jugées trop radicales pour lutter contre l’Empire Galactique, au cours des sanglants combats qui ravagèrent Géonosis et Jedha.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5872,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5873,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5874,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_12",
-            "force_side": null,
-            "id": 12,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Extrémiste Anges des Cavernes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6716,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6717,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6718,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6719,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -2647,9455 +7500,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Après avoir effectué une action, vous pouvez dépenser 1 <forcecharge> pour effectuer une action.<return><shipability><sabold>Ordinateur de Visée Avancé :</sabold> tant que vous effectuez une attaque principale contre un défenseur que vous avez verrouillé, lancez 1 dé d’attaque supplémentaire et changez 1 résultat <hit> en un résultat <crit>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6154,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6155,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6156,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 2,
-            "ffg_id": "XW_P_93",
-            "force_side": 1,
-            "id": 93,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Darth Vader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7038,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7039,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7040,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7041,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7042,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Black Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Le Tie Advanced x1 a été produit en quantités limitées, mais les ingénieurs de Sienar incorporèrent la plus grande partie de ses innovations dans leur nouveau modèle de TIE : l’Intercepteur TIE.</flavor><return><shipability><sabold>Ordinateur de Visée Avancé :</sabold> tant que vous effectuez une attaque principale contre un défenseur que vous avez verrouillé, lancez 1 dé d’attaque supplémentaire et changez 1 résultat <hit> en un résultat <crit>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6166,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6167,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6168,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 2,
-            "ffg_id": "XW_P_97",
-            "force_side": null,
-            "id": 97,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "As de l’Escadron Storm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7055,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7056,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7057,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7058,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Le TIE Advanced v1 de Sienar Fleet Systems est un chasseur révolutionnaire, pourvu de moteurs améliorés, d’un lance-missiles et d’ailes mobiles.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6182,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6183,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6184,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6185,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6186,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_101",
-            "force_side": null,
-            "id": 101,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Baron de l’Empire",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 25,
-            "statistics": [
-                {
-                    "id": 7073,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7074,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7075,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7076,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une action <reload>, vous pouvez récupérer 1 marqueur <standardcharge> sur 1 de vos cartes d’amélioration <talent> équipée. <return><shipability><sabold>Bombardier Agile :</sabold> si vous devez utiliser un gabarit <straight> pour larguer un engin, vous pouvez utiliser un gabarit <leftbank> ou <rightbank> de même vitesse à la place.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6208,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6209,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6210,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6211,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_107",
-            "force_side": null,
-            "id": 107,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Tomax Bren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7094,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7095,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7096,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Franc-Tireur Impétueux",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir été détruit et avant de retirer votre figurine, vous pouvez effectuer une attaque et larguer ou lancer 1 engin. <return><shipability><sabold>Bombardier Agile :</sabold> si vous devez utiliser un gabarit <straight> pour larguer un engin, vous pouvez utiliser un gabarit <leftbank> ou <rightbank> de même vitesse à la place.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6220,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6221,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6222,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6223,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_110",
-            "force_side": null,
-            "id": 110,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Deathfire”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7103,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7104,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7105,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Fanatique Inébranlable",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallbody>Tant que vous défendez, si l’attaquant n’a aucun marqueur vert, vous pouvez changer 1 de vos résultats Vierge ou <focus> en un résultat <evade>.</smallbody><return><sasmall><sabold>Ailerons Adaptables :</sabold> avant de révéler votre cadran, si vous n’êtes pas stressé, vous <bold>devez</bold> exécuter une manœuvre blanche [1<nonbreak><leftbank>], [1<nonbreak><straight>], ou [1<nonbreak><rightbank>].</sasmall>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6236,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6237,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6238,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6239,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 2,
-            "ffg_id": "XW_P_114",
-            "force_side": null,
-            "id": 114,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitaine Feroph",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 43,
-            "statistics": [
-                {
-                    "id": 7116,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7117,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7118,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7119,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Messager Impérial",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez, après l’étape «<nonbreak>Neutraliser les résultats<nonbreak>», si vous n’êtes pas stressé, vous pouvez subit 1 dégât <hit> et gagner 1 marqueur de stress. Dans ce cas, annulez tous les résultats des dés.<return><shipability><sabold>Ailerons Adaptables :</sabold> avant de révéler votre cadran, si vous n’êtes pas stressé, vous devez exécuter une manœuvre blanche [1<nonbreak><leftbank>], [1<nonbreak><straight>] ou [1<nonbreak><rightbank>].</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6251,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6252,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6253,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_118",
-            "force_side": null,
-            "id": 118,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•“Countdown”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 16,
-            "statistics": [
-                {
-                    "id": 7131,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7132,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7133,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Trompe-la-Mort",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une attaque qui touche, si vous avez un marqueur d’évasion, exposez 1 des cartes de dégât du défenseur.<return><shipability><sabold>Plein Gaz :</sabold> après avoir entièrement exécuté une manœuvre à vitesse 3–5, vous pouvez effectuer une action <evade>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6263,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6264,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6265,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6266,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6267,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_122",
-            "force_side": null,
-            "id": 122,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Rexler Brath",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 18,
-            "statistics": [
-                {
-                    "id": 7143,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7144,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7145,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7146,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Leader Onyx",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Lors du développement du TIE Aggressor, Sienar Fleet Systems accorda d’avantage d’importance aux performances et à la polyvalence qu’à la maîtrise des coûts.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6297,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6298,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6299,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 2,
-            "ffg_id": "XW_P_130",
-            "force_side": null,
-            "id": 130,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Spécialiste Sienar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7175,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7176,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7177,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7178,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Conçu dans un centre de recherches secret sur Imdaar Alpha, le TIE Fantôme concrétise ce qui semblait impossible : un petit chasseur furtif équipé d’un système d’occultation avancé.</flavor><return><shipability><sabold>Réseau de Stygium :</sabold> après vous être désocculté, vous pouvez effectuer une action <evade>. Au début de la phase de dénouement, vous pouvez dépenser 1 marqueur d’évasion pour gagner 1 marqueur d’occultation. </shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6312,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6313,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6314,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 7,
-                    "base_action_side_effect": null,
-                    "id": 6315,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_134",
-            "force_side": null,
-            "id": 134,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Pilote d’Essai Imdaar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 27,
-            "statistics": [
-                {
-                    "id": 7191,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7192,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7193,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7194,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>D’une conception similaire aux autres vaisseaux développés par Cygnus Spaceworks, le Star Wing de classe <untalic>Alpha</untalic> est un appareil polyvalent attribué aux unités spécialisées de la Marine Impériale qui ont besoin d’un chasseur facilement adaptable pour des missions variées.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6328,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6329,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6330,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6331,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                6,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "35",
-            "faction_id": 2,
-            "ffg_id": "XW_P_138",
-            "force_side": null,
-            "id": 138,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilote de l’Escadron Nu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 14,
-            "statistics": [
-                {
-                    "id": 7207,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7208,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7209,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7210,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 ou plusieurs vaisseaux alliés à portée 0–3. Dans ce cas, transférez tous les marqueurs de verrouillage ennemis des vaisseaux choisis vers vous.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6347,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6348,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 6349,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6350,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                8,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 2,
-            "ffg_id": "XW_P_142",
-            "force_side": null,
-            "id": 142,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Capitaine Kagi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 26,
-            "statistics": [
-                {
-                    "id": 7223,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7224,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 7225,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7226,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7227,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Pilote de la Navette de l’Empereur",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque, si vous êtes renforcé et si le défenseur est dans l’arc <fullfront> ou <fullrear> correspondant à votre marqueur de renforcement, vous pouvez changer 1 de vos résultats <focus> en un résultat <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6368,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6369,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6370,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6371,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6372,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "88",
-            "faction_id": 2,
-            "ffg_id": "XW_P_147",
-            "force_side": null,
-            "id": 147,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Vice-Amiral Chiraneau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7248,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7249,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7250,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7251,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Conseiller de l’Amiral Piett",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque principale, si au moins 1 vaisseau allié non-limité est à portée 0 du défenseur, lancez 1 dé d’attaque supplémentaire.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6386,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6387,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": "stress",
-                    "id": 6388,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6389,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
-            "card_set_ids": [
-                6,
-                11
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 3,
-            "ffg_id": "XW_P_151",
-            "force_side": null,
-            "id": 151,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kath Scarlet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 10,
-            "statistics": [
-                {
-                    "id": 7266,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7267,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "3"
-                },
-                {
-                    "id": 7268,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7269,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7270,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Capitaine des Pirates Binayre",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque, si la portée d’attaque est 1, vous pouvez lancer 1 dé supplémentaire. <return><shipability><sabold>Opposition Concordia :</sabold> tant que vous défendez, si la portée d’attaque est 1 et que vous êtes dans l’<frontarc> de l’attaquant, changez 1 résultat en un résultat <evade>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6402,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6403,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6404,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6405,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 3,
-            "ffg_id": "XW_P_155",
-            "force_side": null,
-            "id": 155,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7286,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7287,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7288,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Leader Skull",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>À cause de ses commandes sensibles et de son extrême manœuvrabilité, seuls les meilleurs pilotes﻿ osent prendre place dans le cockpit d’un A-wing.</flavor><return><sabold>Propulseurs Vectoriels :</sabold> après avoir effectué une action, vous pouvez effectuer une action <boost> rouge.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5909,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5910,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5911,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5912,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5913,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_21",
-            "force_side": null,
-            "id": 21,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Pilote de l’Escadron Vert",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 35,
-            "statistics": [
-                {
-                    "id": 6752,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6753,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6754,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6755,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Les as de l’Escadron Skull privilégient une approche agressive, profitant de la technologie d’ailes montées sur pivot de leurs appareils, ce qui leur confère une maniabilité exceptionnelle quand ils poursuivent leurs proies. </flavor><return><shipability><sabold>Opposition Concordia :</sabold> tant que vous défendez, si la portée d’attaque est 1 et que vous êtes dans l’<frontarc> de l’attaquant, changez 1 résultat en un résultat <evade>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6418,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6419,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6420,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6421,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_159",
-            "force_side": null,
-            "id": 159,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Pilote de l’Escadron Skull",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7298,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7299,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7300,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, si un ou plusieurs autres vaisseaux sont à portée 0, vous et chaque autre vaisseau à portée 0 gagnez 1 marqueur de rayon tracteur. <return><shipability><sabold>Dispositif Tracteur de Remorqueur Spatial :</sabold> <smallcaps>Action :</smallcaps> choisissez un vaisseau dans votre <frontarc> à portée 1. Il gagne 1 marqueur de rayon tracteur, ou 2 marqueurs de rayon tracteur s’il est dans votre <bullseye> à portée 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6432,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6433,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6434,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 3,
-            "ffg_id": "XW_P_163",
-            "force_side": null,
-            "id": 163,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Unkar Plutt",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7310,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7311,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7312,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Maître des Portions Misérables",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau allié non-limité effectue une attaque, si le défenseur est dans votre arc de tir, l’attaquant peut relancer 1 dé d’attaque.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6442,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6443,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6444,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6445,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 3,
-            "ffg_id": "XW_P_166",
-            "force_side": null,
-            "id": 166,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Drea Renthal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7320,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7321,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7322,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7323,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Seigneur Pirate",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>La simple évocation de crédits Impériaux peut attirer toutes sortes d’individus totalement amoraux dans votre camp.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6446,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6447,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6448,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6449,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 3,
-            "ffg_id": "XW_P_167",
-            "force_side": null,
-            "id": 167,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": " Soudard",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7324,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7325,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7326,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7327,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Vous ne pouvez être déployé que par un déploiement d’urgence, et vous avez le nom, l’initiative, la capacité de pilote, et les <standardcharge> du vaisseau allié Hound’s Tooth qui a été détruit.<return><shipability>Vaisseau de Secours : Mise en Place : nécessite le Hound’s Tooth. Vous devez commencer la partie arrimé au Hound’s Tooth.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6460,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6461,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6462,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "6",
-            "faction_id": 3,
-            "ffg_id": "XW_P_171",
-            "force_side": null,
-            "id": 171,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Nashtah Pup</italic>",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 7340,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7341,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7342,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7343,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Plan d’Urgence",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau ennemi dans votre arc de tir, à portée 0–2. Dans ce cas, transférez 1 marqueur de concentration ou d’évasion de ce vaisseau au vôtre.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6474,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6475,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6476,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6477,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6478,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 3,
-            "ffg_id": "XW_P_175",
-            "force_side": null,
-            "id": 175,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Palob Godalhi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 7357,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7358,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7359,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7360,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Résistant Tethan",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir entièrement exécuté une manœuvre, vous pouvez gagner 1 marqueur de stress pour pivoter votre vaisseau de 90°. <return><shipability><sabold>Micropropulseurs :</sabold> tant que vous effectuez un tonneau, vous devez utiliser le gabarit <leftbank> ou <rightbank> à la place du gabarit <straight>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6493,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6494,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6495,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6496,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_179",
-            "force_side": null,
-            "id": 179,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Dalan Oberos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 3,
-            "statistics": [
-                {
-                    "id": 7373,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7374,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7375,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7376,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Chasseur de Primes d’Élite",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau allié à portée 0–1 défend, il peut relancer 1 de ses dés. <return><shipability><sabold>Emplacement d’Arme :</sabold> vous pouvez vous équiper de 1 amélioration <cannon>, <torpedo> ou <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6509,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6510,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6511,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6512,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_183",
-            "force_side": null,
-            "id": 183,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Serissu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7389,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7390,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7391,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7392,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Instructeur de Vol",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque, vous pouvez subir 1 dégât<nonbreak><hit> pour relancer n’importe quel nombre de vos dés. <return><shipability><sabold>Emplacement d’Arme :</sabold> vous pouvez vous équiper de 1 amélioration <cannon>, <torpedo> ou <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6525,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6526,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6527,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6528,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 3,
-            "ffg_id": "XW_P_187",
-            "force_side": null,
-            "id": 187,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Inaldra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7405,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7406,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7407,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7408,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Boss de Tansarii Point",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez à portée d’attaque 3 ou effectuez une attaque à portée d’attaque 1, lancez 1 dé supplémentaire.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6541,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6542,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6543,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_191",
-            "force_side": null,
-            "id": 191,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Talonbane Cobra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7421,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7422,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7423,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7424,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Fléau de Tansarii Point",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Le chasseur d’assaut Kihraxz fut développé expressément pour l’organisation criminelle du Soleil Noir, dont les as, très généreusement payés, exigeaient des appareils agiles et puissants, à la hauteur de leur talent.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6553,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6554,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6555,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 3,
-            "ffg_id": "XW_P_195",
-            "force_side": null,
-            "id": 195,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "As du Soleil Noir",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7437,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7438,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7439,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7440,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une action <boost>, vous pouvez effectuer une action <evade>.<return><shipability><sabold>Cerveau Droïde Avancé :</sabold> après avoir effectué une action <calculate>, gagnez 1 marqueur de calcul.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6567,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6568,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6569,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6570,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 3,
-            "ffg_id": "XW_P_199",
-            "force_side": null,
-            "id": 199,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•IG-88C",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 21,
-            "statistics": [
-                {
-                    "id": 7453,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7454,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7455,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7456,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Machine Trop Indulgente",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Les légendaires Trouveurs de Gand vouaient un véritable culte aux brumes qui recouvraient leur planète natale et se servaient de signes, d’augures et de rituels mystiques pour traquer leurs proies.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6581,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6582,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6583,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_203",
-            "force_side": null,
-            "id": 203,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Trouveur Gand",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 22,
-            "statistics": [
-                {
-                    "id": 7469,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7470,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7471,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7472,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une attaque, chaque vaisseau ennemi dans votre <bullseye> subit 1 dégât<nonbreak><hit> sauf s’il retire 1 marqueur vert. <return><shipability><sabold>Dans le Mille :</sabold> tant que vous effectuez une attaque, si le défenseur est dans votre <bullseye>, les dés de défense ne peuvent pas être modifiés en utilisant des marqueurs verts.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6593,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6594,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6595,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6596,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                10,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_207",
-            "force_side": null,
-            "id": 207,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Torani Kulda",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 39,
-            "statistics": [
-                {
-                    "id": 7486,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7487,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7488,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "7"
-                },
-                {
-                    "id": 7489,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Free-Lance Rodien",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez relancer jusqu’à 2 de vos dés.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5919,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5920,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5921,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_23",
-            "force_side": null,
-            "id": 23,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Braylen Stramm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6760,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6761,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6762,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6763,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Leader Blade",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Si vous êtes censé fuir, vous pouvez dépenser 1 <standardcharge>. Dans ce cas, mettez-vous en réserve à la place. Au début de la prochaine phase de préparation, placez-vous intégralement à portée 1 du bord de la zone de jeu par lequel vous auriez dû fuir.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6608,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6609,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6610,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                8,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 3,
-            "ffg_id": "XW_P_211",
-            "force_side": null,
-            "id": 211,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Moralo Eval",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 24,
-            "statistics": [
-                {
-                    "id": 7503,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 7504,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7505,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "9"
-                },
-                {
-                    "id": 7506,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                },
-                {
-                    "id": 7507,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Génie Criminel",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir un vaisseau allié à portée 0–1. Dans ce cas, transférez à ce vaisseau tous vos marqueurs verts.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6620,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6621,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6622,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_215",
-            "force_side": null,
-            "id": 215,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Manaroo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 45,
-            "statistics": [
-                {
-                    "id": 7521,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7522,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7523,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7524,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Aruzan Gracieuse",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Grâce à son impressionnant panel d’armes lourdes et à ses boucliers très résistants, le B-wing s’est imposé comme le plus redoutable chasseur d’assaut de l’Alliance Rebelle.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5928,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5929,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5930,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_26",
-            "force_side": null,
-            "id": 26,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilote de l’Escadron Bleu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6772,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6773,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6774,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6775,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque, vous pouvez dépenser 1 marqueur de stress pour changer tous vos résultats <focus> en résultats <evade> ou <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5922,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5923,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5924,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_24",
-            "force_side": null,
-            "id": 24,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Ten Numb",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6764,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6765,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6766,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6767,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Blue Cinq",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Un système de stabilisation gyroscopique unique enveloppe le cockpit du B-wing et assure la stabilité du pilote.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5925,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5926,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5927,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 1,
-            "ffg_id": "XW_P_25",
-            "force_side": null,
-            "id": 25,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Vétéran de l’Escadron Blade",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6768,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6769,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6770,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6771,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque principale, si l’attaque est gênée par un obstacle, vous pouvez lancer 1 dé supplémentaire.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6645,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6646,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6647,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6648,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_222",
-            "force_side": null,
-            "id": 222,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7555,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7556,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7557,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7558,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Le Kid Corellien",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque principale, si au moins 1 autre vaisseau allié est à portée 0–1 du défenseur, vous pouvez lancer 1 dé d’attaque supplémentaire.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5934,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5935,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5936,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_28",
-            "force_side": null,
-            "id": 28,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lieutenant Blount",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6780,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6781,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6782,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6783,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Coéquipier",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Conçu pour les engagements de longue haleine, le TIE/ag est habituellement confié aux pilotes d’élite entraînés pour tirer le meilleur parti de son armement et de sa manœuvrabilité.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6294,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6295,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6296,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_129",
-            "force_side": null,
-            "id": 129,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Éclaireur de l’Escadron Onyx",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7171,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7172,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7173,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7174,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Les vaisseaux alliés à portée 0–1 peuvent effectuer des attaques en étant à portée 0 des obstacles.<return><shipability>Copilote : tant que vous êtes arrimé, votre vaisseau porteur bénéficie de votre capacité de pilote en plus de la sienne.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6664,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6665,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6666,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "24",
-            "faction_id": 3,
-            "ffg_id": "XW_P_227",
-            "force_side": null,
-            "id": 227,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Colon de la Bordure Extérieure",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
-            "statistics": [
-                {
-                    "id": 7575,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7576,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7577,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7578,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Hors-la-loi Habile",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Le Chasseur de Têtes Z-95 a été la principale source d’inspiration d’Incom Corporation pour la conception du X-wing T-65. Bien que considéré comme obsolète, le Chasseur de Têtes Z-95 reste un appareil léger polyvalent et robuste.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5940,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5941,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5942,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "23",
-            "faction_id": 1,
-            "ffg_id": "XW_P_30",
-            "force_side": null,
-            "id": 30,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Pilote de l’Escadron Bandit",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6788,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6789,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6790,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6791,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir lancé des dés, si vous n’êtes pas stressé, vous pouvez gagner 1 marqueur de stress pour relancer tous vos résultats vierges.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6649,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6650,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6651,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6652,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 3,
-            "ffg_id": "XW_P_223",
-            "force_side": null,
-            "id": 223,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7559,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7560,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7561,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7562,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Joueur à la Voix Suave",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un autre vaisseau allié à portée 0–1 défend, avant l’étape «<nonbreak>Neutraliser les résultats<nonbreak>», si vous êtes dans l’arc de l’attaque, vous pouvez subir 1 dégât<nonbreak><hit> ou <crit> pour annuler 1 dégât correspondant.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5857,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5858,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5859,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_7",
-            "force_side": null,
-            "id": 7,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Biggs Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6696,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6697,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6698,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6699,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Trois",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Avant votre activation, si vous êtes concentré, vous pouvez effectuer une action.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5863,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5864,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5865,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_9",
-            "force_side": null,
-            "id": 9,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Edrio Deux-Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6704,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6705,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6706,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6707,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Vétéran Anges des Cavernes",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après qu’un vaisseau allié à portée 0–1 est devenu le défenseur, vous pouvez dépenser 1 marqueur de renforcement. Dans ce cas, le vaisseau défenseur gagne 1 marqueur d’évasion.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5946,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5947,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5948,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_32",
-            "force_side": null,
-            "id": 32,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Lowhhrick",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6796,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6797,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6798,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6799,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gladiateur Rescapé",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>L’AF4 est la toute dernière génération du modèle Chasseur de Têtes. Robuste et bon marché, il est très populaire auprès des organisations indépendantes comme la Rébellion.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5937,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5938,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5939,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "25",
-            "faction_id": 1,
-            "ffg_id": "XW_P_29",
-            "force_side": null,
-            "id": 29,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilote de l’Escadron Tala",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6784,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6785,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6786,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6787,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque principale, si vous êtes endommagé, vous pouvez lancer 1 dé d’attaque supplémentaire.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5943,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5944,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5945,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "56",
-            "faction_id": 1,
-            "ffg_id": "XW_P_31",
-            "force_side": null,
-            "id": 31,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Wullffwarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6792,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6793,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6794,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6795,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Chef Wookie",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une attaque, vous pouvez choisir 1 vaisseau allié à portée 1. Ce vaisseau peut effectuer une action, en la considérant comme rouge.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5931,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5932,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5933,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "36",
-            "faction_id": 1,
-            "ffg_id": "XW_P_27",
-            "force_side": null,
-            "id": 27,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Airen Cracken",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6776,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6777,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6778,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6779,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Chef des Renseignements",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Avant votre activation, vous pouvez effectuer une action <barrelroll> ou <boost>.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5955,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5956,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5957,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_35",
-            "force_side": null,
-            "id": 35,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6808,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6809,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6810,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6811,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Le Remorqueur Spatial de Transfert Quadrimoteur, surnommé « Quad jumper », était aussi manœuvrable sous atmosphère que dans l’espace, ce qui le rendait extrêmement populaire auprès des contrebandiers et des explorateurs. </flavor><return><shipability><sabold>Dispositif Tracteur de Remorqueur Spatial :</sabold> <smallcaps>Action :</smallcaps> choisissez un vaisseau dans votre <frontarc> à portée 1. Il gagne 1 marqueur de rayon tracteur, ou 2 marqueurs de rayon tracteur s’il est dans votre <bullseye> à portée 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6435,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6436,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6437,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 3,
-            "ffg_id": "XW_P_164",
-            "force_side": null,
-            "id": 164,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Trafiquant d’Armes de Jakku",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7313,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7314,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7315,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Équipée de trois canons laser jumelés Sureggi longue portée, la canonnière Auzituck donnait du fil à retordre aux esclavagistes dans le système de Kashyyyk.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5949,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5950,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5951,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_33",
-            "force_side": null,
-            "id": 33,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Défenseur de Kashyyyk",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6800,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6801,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6802,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6803,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez dépenser 1 <forcecharge> pour changer jusqu’à 2 de vos résultats <focus> en résultats <evade> ou <hit>.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5958,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5959,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5960,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_36",
-            "force_side": 2,
-            "id": 36,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6812,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6813,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6814,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6815,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6816,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque principale, vous pouvez soit dépenser 1 bouclier pour lancer 1 dé d’attaque supplémentaire, soit, si vous n’êtes pas protégé, vous pouvez lancer 1 dé d’attaque en moins pour récupérer 1 bouclier.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6048,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6049,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6050,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6051,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6052,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_62",
-            "force_side": null,
-            "id": 62,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Miranda Doni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6919,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6920,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6921,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6922,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Poids Lourd",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Pendant l’étape «<nonbreak>Effectuer une action<nonbreak>», vous pouvez effectuer 1 action, même si vous êtes stressé. Après avoir effectué une action en étant stressé, subissez 1 dégât<nonbreak><hit> sauf si vous exposez 1 de vos cartes de dégât.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_83",
-            "force_side": null,
-            "id": 307,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Action :</smallcaps> dépensez 1<nonbreak><standardcharge> non-récurrente d’une autre amélioration équipée pour récupérer 1 bouclier. <return><smallcaps>Action :</smallcaps> dépensez 2 boucliers pour récupérer 1<nonbreak><standardcharge> non-récurrente sur une amélioration équipée.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_99",
-            "force_side": null,
-            "id": 323,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir entièrement exécuté une manœuvre, si vous n’avez pas largué ou lancé d’engin à ce round, vous pouvez larguer 1 bombe.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_143",
-            "force_side": null,
-            "id": 368,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Genius”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "1 navette d’attaque ou de classe <italic>Sheathipede</italic> peut s’arrimer à vous.<return>Les vaisseaux arrimés ne peuvent être déployés que par vos glissières arrière.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_102",
-            "force_side": null,
-            "id": 326,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Ghost</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 23,
-                            "raw_name": "VCX-100 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "1 Chasseur de Têtes Z-95-AF4 peut s’arrimer à vous.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_148",
-            "force_side": null,
-            "id": 373,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Hound’s Tooth</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 24,
-                            "raw_name": "YV-666 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Vous pouvez vous arrimer à portée 0–1.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_106",
-            "force_side": null,
-            "id": 330,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Phantom</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 32,
-                            "raw_name": "Attack Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    },
-                    {
-                        "kwargs": {
-                            "pk": 8,
-                            "raw_name": "Sheathipede-class Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque principale, si le défenseur est dans votre <frontarc>, lancez 1 dé d’attaque supplémentaire.<return> Retirez un emplacement <crew>. Ajoutez un emplacement <astro>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_152",
-            "force_side": null,
-            "id": 377,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Punishing One</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 45,
-                            "raw_name": "JumpMaster 5000"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau ennemi à portée 0–1. Dans ce cas, vous gagnez 1 marqueur de calcul sauf si ce vaisseau choisit de gagner 1 marqueur de stress.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_127",
-            "force_side": null,
-            "id": 352,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•0-0-0",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 338
-                        },
-                        "type": "CARD_INCLUDED"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 93
-                        },
-                        "type": "CARD_INCLUDED"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après qu’un autre vaisseau allié à portée 0–3 a défendu, s’il est détruit, l’attaquant gagne 2 marqueurs de stress. <return>Tant qu’un vaisseau allié à portée 0–3 effectue une attaque contre un vaisseau stressé, il peut relancer 1 dé d’attaque.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_109",
-            "force_side": null,
-            "id": 335,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Amiral Sloane",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une attaque principale, si vous êtes concentré, vous pouvez effectuer une attaque bonus <turretarc> contre un vaisseau que vous n’avez pas encore attaqué à ce round.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "14",
-            "faction_id": null,
-            "ffg_id": "XW_U_95",
-            "force_side": null,
-            "id": 319,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bistan",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une attaque principale ratée, si vous n’êtes pas stressé, vous devez recevoir 1 marqueur de stress pour effectuer une attaque principale bonus contre la même cible.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_139",
-            "force_side": null,
-            "id": 364,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bossk",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une action <focus>, vous pouvez considérer qu’elle est rouge. Dans ce cas, gagnez 1 marqueur de concentration supplémentaire pour chaque vaisseau ennemi à portée 0–1, pour un maximum de 2.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_79",
-            "force_side": null,
-            "id": 303,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Baze Malbus",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Pendant la phase de dénouement, vous pouvez choisir 2 améliorations <illicit> équipant des vaisseaux alliés à portée 0–1. Dans ce cas, vous pouvez échanger ces améliorations. <return><smallcaps>Fin de Partie<nonbreak>:</smallcaps> remettez toutes les améliorations <illicit> sur leurs vaisseaux d’origine.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_131",
-            "force_side": null,
-            "id": 356,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Cikatro Vizago",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Action :</smallcaps> dépensez 1 <standardcharge> pour effectuer une action <cloak>.<return>Au début de la phase de préparation, lancez 1 dé d’attaque. Sur un résultat <focus>, désoccultez-vous ou défaussez votre marqueur d’occultation.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_57",
-            "force_side": null,
-            "id": 286,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Appareil d’Occultation",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6594,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Pendant la phase d’activation, les vaisseaux ennemis à portée 0–1 ne peuvent pas retirer de marqueurs de stress.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_113",
-            "force_side": null,
-            "id": 339,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Death Troopers",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8,
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Pendant la phase de système, vous pouvez dépenser 2<nonbreak><standardcharge>. Dans ce cas, chaque vaisseau allié peut verrouiller un vaisseau que vous avez verrouillé.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_117",
-            "force_side": null,
-            "id": 343,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Grand Moff Tarkin",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "STRESS"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6601,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Mise en Place :</smallcaps> après avoir placé les forces, choisissez 1 vaisseau ennemi et assignez-lui l’état <smallcaps>Dispositif d’Écoute</smallcaps>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_44",
-            "force_side": null,
-            "id": 273,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Informateur",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Si un vaisseau allié à portée 0–3 est censé gagner un marqueur de concentration, il peut gagner 1 marqueur d’évasion à la place.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_85",
-            "force_side": null,
-            "id": 309,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Jyn Erso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez, si l’attaquant est stressé, vous pouvez retirer 1 marqueur de stress de l’attaquant pour changer 1 de vos résultats Vierge/<focus> en un résultat <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_135",
-            "force_side": null,
-            "id": 360,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Latts Razzi",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou que vous effectuez une attaque, s’il n’y a aucun autre vaisseau allié à portée 0–2, vous pouvez dépenser 1 <standardcharge> pour relancer 1 de vos dés.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_9",
-            "force_side": null,
-            "id": 238,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Loup Solitaire",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6606,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir défendu, si l’attaque touche, vous pouvez verrouiller l’attaquant.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_89",
-            "force_side": null,
-            "id": 313,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous coordonnez, le vaisseau que vous avez choisi peut effectuer une action seulement si celle-ci est également dans votre barre d’action. ",
-            "available_actions": [
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 5830,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_16",
-            "force_side": null,
-            "id": 245,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chef d’Escouade",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Avant de subir des dégâts à cause d’un obstacle ou de l’explosion d’une bombe alliée, vous pouvez dépenser 1<nonbreak><standardcharge>. Dans ce cas, prévenez 1 dégât.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_68",
-            "force_side": null,
-            "id": 292,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Blindage Ablatif",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "LARGE"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6614,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Changez 1 résultat<nonbreak><hit> en un résultat <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_33",
-            "force_side": null,
-            "id": 262,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Torpilles à Protons Avancées",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6615,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "5"
-                },
-                {
-                    "id": 6617,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                5
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1"
-        },
-        {
-            "ability_text": "Après avoir révélé votre cadran, vous pouvez effectuer 1 action.<return>Dans ce cas, vous ne pouvez pas effectuer d’autre action pendant votre activation.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_23",
-            "force_side": null,
-            "id": 252,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Senseurs Avancés",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une action <slam>, si vous avez entièrement exécuté la manœuvre, vous pouvez effectuer une action blanche de votre barre d’action, en la considérant comme rouge.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_69",
-            "force_side": null,
-            "id": 293,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "MASL Avancé",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Slam",
-                            "pk": 13,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bombe</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1<nonbreak><standardcharge> pour larguer une sous-munition avec le gabarit [1<nonbreak><straight>].<return>Au début de la phase d’activation, vous pouvez dépenser 1 bouclier pour récupérer 2 <standardcharge>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_63",
-            "force_side": null,
-            "id": 392,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Générateur de Sous-Munitions",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6622,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12,
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Après cette attaque, vous pouvez effectuer cette attaque en tant qu’attaque bonus contre une cible différente à portée 0–1 du défenseur, en ignorant le prérequis <targetlock>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_37",
-            "force_side": null,
-            "id": 266,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Missiles Groupés",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6623,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6625,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "4"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                6
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<flavor>Utilisé pour déployer des troupes sous couvert de l’obscurité ou sur les théâtres d’opérations les plus dangereux, le U-wing UT-60D rendit de fiers services à l’Alliance Rebelle qui avait désespérément besoin de transports résistants.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6042,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6043,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6044,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_60",
-            "force_side": null,
-            "id": 60,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Éclaireur de l’Escadron Bleu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6911,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6912,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6913,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6914,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous accélérez ou que vous effectuez un tonneau, vous pouvez vous déplacer à travers ou chevaucher les obstacles. <return>Après vous être déplacé à travers ou avoir chevauché un obstacle, vous pouvez dépenser 1<nonbreak><standardcharge> pour ignorer ses effets jusqu’à la fin du round.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_24",
-            "force_side": null,
-            "id": 253,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Détecteur Anti-Collision",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6626,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Avant votre activation, vous pouvez dépenser 1 <standardcharge>. Dans ce cas, jusqu’à la fin du round, vous pouvez effectuer des actions et exécuter des manœuvres rouges, même si vous êtes stressé.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_58",
-            "force_side": null,
-            "id": 287,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Cybernétique de Contrebande",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6631,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une action <boost> blanche, vous pouvez considérer qu’elle est rouge pour utiliser le gabarit [1<nonbreak><leftturn>] ou [1<nonbreak><rightturn>] à la place.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                12
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_2",
-            "force_side": null,
-            "id": 231,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Casse-Cou",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Boost",
-                            "pk": 1,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Mise en Place :</smallcaps> perdez 1 <standardcharge>.<return><smallcaps>Action :</smallcaps> récupérez 1 <standardcharge>.<return><smallcaps>Action :</smallcaps> dépensez 1 <standardcharge> pour récupérer 1 bouclier.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_43",
-            "force_side": null,
-            "id": 272,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Droïde “Gonk” GNK",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6636,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque <turretarc>, après l’étape «<nonbreak>Modifier les dés de défense<nonbreak>», le défenseur retire 1 marqueur de concentration ou de calcul.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_49",
-            "force_side": null,
-            "id": 278,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Artilleur Hors Pair",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Quand on ne peut pas s’offrir un générateur de boucliers améliorés, souder des plaques de blindage sur la coque du vaisseau peut être un bon substitut.</flavor>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "*",
-            "faction_id": null,
-            "ffg_id": "XW_U_73",
-            "force_side": null,
-            "id": 297,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Coque Améliorée",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6642,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât <hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_28",
-            "force_side": null,
-            "id": 257,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Canon Ionique",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6643,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                3
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque <frontarc>, si vous n’êtes pas dans l’arc de tir du défenseur, il lance 1 dé de défense en moins.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_11",
-            "force_side": null,
-            "id": 240,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Manœuvre Improbable",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir révélé votre cadran, vous pouvez dépenser 1 <standardcharge> et gagner 1 marqueur de désarmement pour récupérer 1 bouclier.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-            "card_set_ids": [
-                1,
-                4,
-                6,
-                7
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_53",
-            "force_side": null,
-            "id": 282,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Astromech R2",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6663,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez, les résultats <crit> sont neutralisés avant les résultats <hit>.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5961,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5962,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5963,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_37",
-            "force_side": null,
-            "id": 37,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6817,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6818,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6819,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6820,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après qu’un vaisseau ennemi situé dans votre arc de tir vous a engagé, si vous n’êtes pas stressé, vous pouvez gagner 1 marqueur de stress. Dans ce cas, ce vaisseau ennemi ne peut pas dépenser de marqueur pour modifier des dés tant qu’il effectue une attaque pendant cette phase. <return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5964,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5965,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_38",
-            "force_side": null,
-            "id": 38,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6821,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6822,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6823,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6824,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6825,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Rebelle Réticent",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Conçue par la Corporation Technique Corellienne et inspirée d’un oiseau  en vol, la série « hawk » a produit d’excellents cargos légers. Rapide et résistant, le HWK-290 est souvent utilisé par les agents Rebelles en tant que base mobile d’opérations.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5987,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5988,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5989,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5990,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5991,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_45",
-            "force_side": null,
-            "id": 45,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Éclaireur Rebelle",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6854,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6855,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6856,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6857,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez dépenser 1 <forcecharge> pour changer jusqu’à 2 de vos résultats <focus> en résultats <evade> ou <hit>.<return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5966,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5967,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                10,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_39",
-            "force_side": 2,
-            "id": 39,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6826,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6827,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6828,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6829,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6830,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6831,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez, les résultats <crit> sont neutralisés avant les résultats <hit>.<return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5968,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5969,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_40",
-            "force_side": null,
-            "id": 40,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6832,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6833,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6834,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6835,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6836,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous coordonnez, si vous choisissez un vaisseau qui a exactement 1 marqueur de stress, il peut effectuer des actions. <return><sabold>Navette de Communication :</sabold> tant que vous êtes arrimé, votre vaisseau porteur gagne <coordinate>. Avant que votre vaisseau porteur ne s’active, il peut effectuer une action <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5970,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5971,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_41",
-            "force_side": null,
-            "id": 41,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-            "initiative": 1,
-            "is_unique": true,
-            "name": "•AP-5",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6837,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6838,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6839,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6840,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6841,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Droïde Analyste Rescapé",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau allié situé dans votre arc de tir effectue une attaque principale, si vous n’êtes pas stressé, vous pouvez gagner 1 marqueur de stress. Dans ce cas, ce vaisseau peut lancer 1 dé d’attaque supplémentaire.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5972,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5973,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5974,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5975,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5976,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_42",
-            "force_side": null,
-            "id": 42,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Jan Ors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6842,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6843,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6844,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6845,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Experte en Espionnage",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez transférer 1 de vos marqueurs de concentration à un vaisseau allié situé dans votre arc de tir.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5977,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5978,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5979,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5980,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5981,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_43",
-            "force_side": null,
-            "id": 43,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kyle Katarn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6846,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6847,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6848,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6849,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Agent Implacable",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau situé dans votre arc de tir. Dans ce cas, pendant cette phase, il s’engage à l’initiative 7 au lieu de le faire à sa valeur d’initiative standard.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5982,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5983,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5984,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5985,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5986,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_44",
-            "force_side": null,
-            "id": 44,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Roark Garnet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6850,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6851,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6852,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6853,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Contrebandier au Grand Cœur",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Avant votre activation, vous pouvez effectuer une action <barrelroll> ou <boost>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5995,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5996,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5997,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 1,
-            "ffg_id": "XW_P_47",
-            "force_side": null,
-            "id": 47,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6862,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6863,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6864,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après être devenu le défenseur (avant que les dés ne soient lancés), vous pouvez récupérer 1 <forcecharge>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5842,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5843,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5844,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                17,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "62",
-            "faction_id": 1,
-            "ffg_id": "XW_P_2",
-            "force_side": 2,
-            "id": 2,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Luke Skywalker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6675,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6676,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6677,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6678,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 6679,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Cinq",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau allié effectue une attaque, si le défenseur est dans votre <frontarc>, l’attaquant peut changer 1 résultat<nonbreak><hit> en un résultat <crit>.<return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6009,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6010,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6011,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6012,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6013,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 1,
-            "ffg_id": "XW_P_51",
-            "force_side": null,
-            "id": 51,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Gavin Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6875,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6876,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6877,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6878,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Ailier Audacieux",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Les pilotes d’élite de l’Escadron Rogue font partie des meilleurs pilotes de la Rébellion.</flavor><return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6014,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6015,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6016,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6017,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6018,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "63",
-            "faction_id": 1,
-            "ffg_id": "XW_P_52",
-            "force_side": null,
-            "id": 52,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Escorte de l’Escadron Rogue",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6879,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6880,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6881,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6882,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Conçu pour combiner les meilleurs atouts de l’A-wing et du X-wing, l’E-wing dispose d’une puissance de feu, d’une vitesse et d’une manœuvrabilité supérieures.</flavor><return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6019,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6020,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6021,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6022,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6023,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "61",
-            "faction_id": 1,
-            "ffg_id": "XW_P_53",
-            "force_side": null,
-            "id": 53,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Escorte de l’Escadron Knave",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6883,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6884,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6885,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6886,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir révélé une manœuvre bleue ou rouge, vous pouvez régler votre cadran sur une autre manœuvre de même difficulté.<return><sabold>Chargé et Prêt à Tirer :</sabold> tant que vous êtes arrimé, après que votre vaisseau porteur a effectué une attaque principale <frontarc> ou <turret>, il peut effectuer une attaque principale <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5952,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5953,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5954,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "39",
-            "faction_id": 1,
-            "ffg_id": "XW_P_34",
-            "force_side": null,
-            "id": 34,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6804,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6805,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6806,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6807,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après qu’un vaisseau ennemi a exécuté une manœuvre, s’il est à portée 0, vous pouvez effectuer une action.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6039,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6040,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6041,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_59",
-            "force_side": null,
-            "id": 59,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Heff Tobber",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6907,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6908,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6909,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6910,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Blue Huit",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Les Partisans de Saw Gerrera se rassemblèrent d’abord pour combattre les troupes Séparatistes sur Onderon lors de la Guerre des Clones, puis ils continuèrent de lutter contre la tyrannie galactique instaurée par l’Empire.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6045,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6046,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6047,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_61",
-            "force_side": null,
-            "id": 61,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Renégat Partisan",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6915,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6916,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6917,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6918,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Le K-wing de Koensayr Manufacturing peut s’enorgueillir de son moteur à accélération subluminique avancé et de dix-huit points d’emport, ce qui lui confère une vitesse et une puissance de feu inégalées.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6058,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6059,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6060,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6061,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6062,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 1,
-            "ffg_id": "XW_P_64",
-            "force_side": null,
-            "id": 64,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilote de l’Escadron Warden",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6927,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6928,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6929,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6930,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque, si vous êtes stressé, vous pouvez dépenser 1 <forcecharge> pour changer jusqu’à 2 de vos résultats <focus> en résultats <evade> ou <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5992,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5993,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5994,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_46",
-            "force_side": 2,
-            "id": 46,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6858,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6859,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6860,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6861,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une attaque, assignez l’état Tir de Suppression au défenseur.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5998,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5999,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6000,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_48",
-            "force_side": null,
-            "id": 48,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Capitaine Rex",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6865,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6866,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6867,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Vétéran de la Guerre des Clones",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez, les résultats <crit> sont neutralisés avant les résultats <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6001,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6002,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6003,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "26",
-            "faction_id": 1,
-            "ffg_id": "XW_P_49",
-            "force_side": null,
-            "id": 49,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6868,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6869,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6870,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "À l’initiative 0, vous pouvez effectuer une attaque principale bonus contre un vaisseau ennemi situé dans votre <bullseye>. Dans ce cas, au début de la prochaine phase de préparation, gagnez 1 marqueur de désarmement. <return><sabold>Scanners Expérimentaux :</sabold> vous pouvez verrouiller une cible au-delà de la portée 3. Vous ne pouvez pas verrouiller de cible à portée 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6004,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6005,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6006,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6007,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6008,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 1,
-            "ffg_id": "XW_P_50",
-            "force_side": null,
-            "id": 50,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Corran Horn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6871,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6872,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6873,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6874,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Enquêteur Tenace",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez, si un vaisseau ennemi est à portée 0–1, vous pouvez ajouter 1 résultat <evade> aux résultats de vos dés.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6063,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6064,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6065,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "55",
-            "faction_id": 1,
-            "ffg_id": "XW_P_65",
-            "force_side": null,
-            "id": 65,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Norra Wexley",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6931,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6932,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6933,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6934,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6935,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Gold Neuf",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Les vaisseaux alliés peuvent verrouiller des objets à portée 0–3 de n’importe quel vaisseau allié.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6024,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6025,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6026,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 1,
-            "ffg_id": "XW_P_54",
-            "force_side": null,
-            "id": 54,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Bodhi Rook",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6887,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6888,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6889,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6890,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Déserteur Impérial",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’activation, vous pouvez choisir 1 vaisseau allié à portée 1–3. Dans ce cas, ce vaisseau allié retire 1 marqueur de stress.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6030,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6031,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6032,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_56",
-            "force_side": null,
-            "id": 56,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Cassian Andor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6895,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6896,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6897,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6898,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Recueilli par la Rébellion",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau allié à portée 0–2 défend, l’attaquant ne peut pas relancer plus de 1 dé d’attaque.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6033,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6034,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6035,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_57",
-            "force_side": null,
-            "id": 57,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6899,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6900,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6901,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6902,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Guetteur Anges des Cavernes",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une action <focus>, vous pouvez transférer 1 de vos marqueurs de concentration à un vaisseau allié à portée 1–2.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6036,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6037,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6038,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_58",
-            "force_side": null,
-            "id": 58,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Benthic Deux-Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6903,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6904,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6905,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6906,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Tireur d’Élite Anges des Cavernes",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau allié à portée 0–2 défend ou effectue une attaque, il peut dépenser vos marqueurs de concentration comme s’ils étaient à lui.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6053,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6054,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6055,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6056,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6057,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_63",
-            "force_side": null,
-            "id": 63,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Esege Tuketu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6923,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6924,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6925,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6926,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Héros Altruiste",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir dépensé un marqueur de concentration, vous pouvez choisir 1 vaisseau allié à portée 1–3. Ce vaisseau allié gagne 1 marqueur de concentration.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6066,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6067,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6068,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "51",
-            "faction_id": 1,
-            "ffg_id": "XW_P_66",
-            "force_side": null,
-            "id": 66,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6936,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6937,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6938,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6939,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6940,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Red Leader",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous défendez ou effectuez une attaque principale, vous pouvez dépenser 1 marqueur de verrouillage que vous avez sur le vaisseau ennemi pour ajouter 1 résultat<nonbreak><focus> aux résultats de vos dés.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6069,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6070,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6071,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "53",
-            "faction_id": 1,
-            "ffg_id": "XW_P_67",
-            "force_side": null,
-            "id": 67,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Shara Bey",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6941,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6942,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6943,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6944,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6945,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Green Quatre",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir entièrement exécuté une manœuvre, si vous êtes stressé, vous pouvez lancer 1 dé d’attaque. Sur un résultat <hit> ou <crit>, retirez 1 marqueur de stress.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6072,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6073,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6074,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_68",
-            "force_side": null,
-            "id": 68,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ibtisam",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6946,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6947,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6948,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6949,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6950,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Survivant d’Endor",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir lancé des dés, si vous êtes à portée 0–1 d’un obstacle, vous pouvez relancer tous vos dés. Cela n’est pas considéré comme une relance pour les autres effets.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6075,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6076,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6077,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6078,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "92",
-            "faction_id": 1,
-            "ffg_id": "XW_P_69",
-            "force_side": null,
-            "id": 69,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6951,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6952,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6953,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6954,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Canaille à Louer",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Avant qu’une carte de dégât ne vous soit attribuée face visible, vous pouvez dépenser 1 <standardcharge> pour qu’elle vous soit attribuée face cachée à la place.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6083,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6084,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6085,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6086,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 1,
-            "ffg_id": "XW_P_71",
-            "force_side": null,
-            "id": 71,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6959,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6960,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6961,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6962,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                },
-                {
-                    "id": 6963,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Le Puissant",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Connu pour sa robustesse et sa conception modulaire, le YT-1300 est l’un des cargos les plus populaires et répandus de la galaxie.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6087,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6088,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6089,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6090,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "78",
-            "faction_id": 1,
-            "ffg_id": "XW_P_72",
-            "force_side": null,
-            "id": 72,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Contrebandier de la Bordure Extérieure",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6964,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6965,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6966,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6967,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir révélé une manœuvre bleue ou rouge, vous pouvez régler votre cadran sur une autre manœuvre de même difficulté.<return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6091,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6092,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6093,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "76",
-            "faction_id": 1,
-            "ffg_id": "XW_P_73",
-            "force_side": null,
-            "id": 73,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6968,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6969,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6970,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6971,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau allié situé dans votre arc de tir défend, vous pouvez dépenser 1 <forcecharge>. Dans ce cas, l’attaquant lance 1 dé d’attaque en moins.<return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6094,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6095,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6096,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "90",
-            "faction_id": 1,
-            "ffg_id": "XW_P_74",
-            "force_side": 2,
-            "id": 74,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kanan Jarrus",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6972,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6973,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6974,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6975,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                },
-                {
-                    "id": 6976,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Spectre-1",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Au début de la phase d’engagement, chaque vaisseau ennemi à portée 0 gagne 2 marqueurs de brouillage. <return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6097,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6098,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6099,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 1,
-            "ffg_id": "XW_P_75",
-            "force_side": null,
-            "id": 75,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6977,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6978,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6979,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6980,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-3",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Autre réussite commerciale de la Corporation Technique Corellienne, le cargo VCX-100 est plus gros que les légendaires appareils de la série YT, et propose un espace de vie plus volumineux et de meilleures possibilités de personnalisation.</flavor><return><sabold>Artillerie de Poupe :</sabold> tant que vous avez un vaisseau arrimé, vous bénéficiez d’une arme principale <reararc> avec une valeur d’attaque égale à celle de l’attaque principale <frontarc> du vaisseau arrimé.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6100,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6101,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6102,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 1,
-            "ffg_id": "XW_P_76",
-            "force_side": null,
-            "id": 76,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebelle de Lothal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6981,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6982,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6983,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6984,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>Au cours de la Bataille de Yavin, les pilotes d’élite des chasseurs TIE/ln de l’Escadron Noir escortèrent Dark Vador lors d’une attaque dévastatrice contre les forces Rebelles.</flavor>",
             "available_actions": [
                 {
@@ -12311,6 +7715,93 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une action, vous pouvez dépenser 1 <forcecharge> pour effectuer une action.<return><shipability><sabold>Ordinateur de Visée Avancé :</sabold> tant que vous effectuez une attaque principale contre un défenseur que vous avez verrouillé, lancez 1 dé d’attaque supplémentaire et changez 1 résultat <hit> en un résultat <crit>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6154,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6155,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6156,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 2,
+            "ffg_id": "XW_P_93",
+            "force_side": 1,
+            "id": 93,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Darth Vader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7038,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7039,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7040,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7041,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7042,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Black Leader",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12552,6 +8043,87 @@
                 }
             ],
             "subtitle": " Administrateur Impitoyable",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Le Tie Advanced x1 a été produit en quantités limitées, mais les ingénieurs de Sienar incorporèrent la plus grande partie de ses innovations dans leur nouveau modèle de TIE : l’Intercepteur TIE.</flavor><return><shipability><sabold>Ordinateur de Visée Avancé :</sabold> tant que vous effectuez une attaque principale contre un défenseur que vous avez verrouillé, lancez 1 dé d’attaque supplémentaire et changez 1 résultat <hit> en un résultat <crit>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6166,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6167,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6168,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 2,
+            "ffg_id": "XW_P_97",
+            "force_side": null,
+            "id": 97,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "As de l’Escadron Storm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7055,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7056,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7057,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7058,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12835,6 +8407,278 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Le TIE Advanced v1 de Sienar Fleet Systems est un chasseur révolutionnaire, pourvu de moteurs améliorés, d’un lance-missiles et d’ailes mobiles.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6182,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6183,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6184,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6185,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6186,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_101",
+            "force_side": null,
+            "id": 101,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Baron de l’Empire",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7073,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7074,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7075,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7076,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Les redoutables Inquisiteurs bénéficient d’une grande autonomie et ont accès aux technologies les plus récentes de l’Empire, comme le prototype TIE Advanced v1.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6187,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6188,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6189,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6190,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6191,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 2,
+            "ffg_id": "XW_P_102",
+            "force_side": 1,
+            "id": 102,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Inquisiteur",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7077,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7078,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7079,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7080,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7081,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, si un vaisseau ennemi est dans votre <bullseye>, gagnez 1 marqueur de concentration. <return><shipability><sabold>Autopropulseurs :</sabold> après avoir effectué une action, vous pouvez effectuer une action <barrelroll> rouge ou <boost> rouge.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6192,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6193,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6194,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6195,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 2,
+            "ffg_id": "XW_P_103",
+            "force_side": null,
+            "id": 103,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Soontir Fel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 41,
+            "statistics": [
+                {
+                    "id": 7082,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7083,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7084,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "As Légendaire",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Après avoir effectué une attaque, vous pouvez effectuer une action <barrelroll> ou <boost>, même si vous êtes stressé.<return><shipability><sabold>Autopropulseurs :</sabold> après avoir effectué une action, vous pouvez effectuer une action <barrelroll> rouge ou <boost> rouge.</shipability>",
             "available_actions": [
                 {
@@ -12995,86 +8839,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Au début de la phase d’engagement, si un vaisseau ennemi est dans votre <bullseye>, gagnez 1 marqueur de concentration. <return><shipability><sabold>Autopropulseurs :</sabold> après avoir effectué une action, vous pouvez effectuer une action <barrelroll> rouge ou <boost> rouge.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6192,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6193,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6194,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6195,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 2,
-            "ffg_id": "XW_P_103",
-            "force_side": null,
-            "id": 103,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Soontir Fel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 41,
-            "statistics": [
-                {
-                    "id": 7082,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7083,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7084,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "As Légendaire",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>Sienar Fleet Systems a doté les ailes de l’intercepteur TIE de quatre canons laser qui lui confèrent une puissance de feu bien supérieure à celle des précédents modèles.</flavor><return><shipability><sabold>Autopropulseurs :</sabold> après avoir effectué une action, vous pouvez effectuer une action <barrelroll> rouge ou <boost> rouge.</shipability>",
             "available_actions": [
                 {
@@ -13149,6 +8913,91 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une action <reload>, vous pouvez récupérer 1 marqueur <standardcharge> sur 1 de vos cartes d’amélioration <talent> équipée. <return><shipability><sabold>Bombardier Agile :</sabold> si vous devez utiliser un gabarit <straight> pour larguer un engin, vous pouvez utiliser un gabarit <leftbank> ou <rightbank> de même vitesse à la place.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6208,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6209,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6210,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6211,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_107",
+            "force_side": null,
+            "id": 107,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Tomax Bren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7094,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7095,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7096,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Franc-Tireur Impétueux",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13319,6 +9168,90 @@
                 }
             ],
             "subtitle": "Leader Cimeterre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir été détruit et avant de retirer votre figurine, vous pouvez effectuer une attaque et larguer ou lancer 1 engin. <return><shipability><sabold>Bombardier Agile :</sabold> si vous devez utiliser un gabarit <straight> pour larguer un engin, vous pouvez utiliser un gabarit <leftbank> ou <rightbank> de même vitesse à la place.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6220,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6221,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6222,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6223,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_110",
+            "force_side": null,
+            "id": 110,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Deathfire”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7103,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7104,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7105,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Fanatique Inébranlable",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13580,6 +9513,93 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallbody>Tant que vous défendez, si l’attaquant n’a aucun marqueur vert, vous pouvez changer 1 de vos résultats Vierge ou <focus> en un résultat <evade>.</smallbody><return><sasmall><sabold>Ailerons Adaptables :</sabold> avant de révéler votre cadran, si vous n’êtes pas stressé, vous <bold>devez</bold> exécuter une manœuvre blanche [1<nonbreak><leftbank>], [1<nonbreak><straight>], ou [1<nonbreak><rightbank>].</sasmall>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6236,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6237,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6238,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6239,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 2,
+            "ffg_id": "XW_P_114",
+            "force_side": null,
+            "id": 114,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitaine Feroph",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 43,
+            "statistics": [
+                {
+                    "id": 7116,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7117,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7118,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7119,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Messager Impérial",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallbody>Après avoir entièrement exécuté une manœuvre à vitesse 1 en utilisant votre capacité <smallcaps>Ailerons Adaptables</smallcaps>, vous pouvez effectuer une action <coordinate>. Dans ce cas, sautez votre étape “Effectuer une action”.</smallbody><return><sasmall><sabold>Ailerons Adaptables :</sabold> avant de révéler votre cadran, si vous n’êtes pas stressé, vous <bold>devez</bold> exécuter une manœuvre blanche [1<nonbreak><leftbank>], [1<nonbreak><straight>], ou [1<nonbreak><rightbank>].</sasmall>",
             "available_actions": [
                 {
@@ -13826,6 +9846,80 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant que vous défendez, après l’étape «<nonbreak>Neutraliser les résultats<nonbreak>», si vous n’êtes pas stressé, vous pouvez subit 1 dégât <hit> et gagner 1 marqueur de stress. Dans ce cas, annulez tous les résultats des dés.<return><shipability><sabold>Ailerons Adaptables :</sabold> avant de révéler votre cadran, si vous n’êtes pas stressé, vous devez exécuter une manœuvre blanche [1<nonbreak><leftbank>], [1<nonbreak><straight>] ou [1<nonbreak><rightbank>].</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6251,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6252,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6253,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_118",
+            "force_side": null,
+            "id": 118,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•“Countdown”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 16,
+            "statistics": [
+                {
+                    "id": 7131,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7132,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7133,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Trompe-la-Mort",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous effectuez une attaque, si vous avez 1 carte de dégât ou moins, vous pouvez lancer 1 dé d’attaque supplémentaire. <return><shipability>Ailerons Adaptables : avant de révéler votre cadran, si vous n’êtes pas stressé, vous devez exécuter une manœuvre blanche [1<nonbreak><leftbank>], [1<nonbreak><straight>] ou [1<nonbreak><rightbank>].</shipability>",
             "available_actions": [
                 {
@@ -14047,26 +10141,40 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Tant qu’un vaisseau allié endommagé à portée 0–3 effectue une attaque, il peut relancer 1 dé d’attaque.",
+            "ability_text": "Après avoir effectué une attaque qui touche, si vous avez un marqueur d’évasion, exposez 1 des cartes de dégât du défenseur.<return><shipability><sabold>Plein Gaz :</sabold> après avoir entièrement exécuté une manœuvre à vitesse 3–5, vous pouvez effectuer une action <evade>.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6263,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6266,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14074,156 +10182,54 @@
             "available_upgrades": [
                 1,
                 2,
-                8,
-                8,
-                13,
-                14,
-                18
+                3,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_55",
-            "force_side": null,
-            "id": 55,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6891,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6892,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6893,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6894,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Radical Obsessionnel",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Les redoutables Inquisiteurs bénéficient d’une grande autonomie et ont accès aux technologies les plus récentes de l’Empire, comme le prototype TIE Advanced v1.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6187,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6188,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6189,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6190,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6191,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 1,
-            "cost": "40",
+            "cost": "84",
             "faction_id": 2,
-            "ffg_id": "XW_P_102",
-            "force_side": 1,
-            "id": 102,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Inquisiteur",
+            "ffg_id": "XW_P_122",
+            "force_side": null,
+            "id": 122,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 25,
+            "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7143,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7078,
+                    "id": 7144,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7145,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7080,
+                    "id": 7146,
                     "recurring": false,
                     "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7081,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
+                    "value": "4"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Leader Onyx",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -14768,6 +10774,169 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Conçu pour les engagements de longue haleine, le TIE/ag est habituellement confié aux pilotes d’élite entraînés pour tirer le meilleur parti de son armement et de sa manœuvrabilité.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6294,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6295,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6296,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_129",
+            "force_side": null,
+            "id": 129,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Éclaireur de l’Escadron Onyx",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7171,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7172,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7173,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7174,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Lors du développement du TIE Aggressor, Sienar Fleet Systems accorda d’avantage d’importance aux performances et à la polyvalence qu’à la maîtrise des coûts.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6297,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6298,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6299,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 2,
+            "ffg_id": "XW_P_130",
+            "force_side": null,
+            "id": 130,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Spécialiste Sienar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7175,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7176,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7177,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7178,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Après avoir effectué une attaque qui touche, gagnez 1 marqueur d’évasion. <return><shipability><sabold>Réseau de Stygium :</sabold> après vous être désocculté, vous pouvez effectuer une action <evade>. Au début de la phase de dénouement, vous pouvez dépenser 1 marqueur d’évasion pour gagner 1 marqueur d’occultation. </shipability>",
             "available_actions": [
                 {
@@ -15018,6 +11187,92 @@
                 },
                 {
                     "id": 7190,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Conçu dans un centre de recherches secret sur Imdaar Alpha, le TIE Fantôme concrétise ce qui semblait impossible : un petit chasseur furtif équipé d’un système d’occultation avancé.</flavor><return><shipability><sabold>Réseau de Stygium :</sabold> après vous être désocculté, vous pouvez effectuer une action <evade>. Au début de la phase de dénouement, vous pouvez dépenser 1 marqueur d’évasion pour gagner 1 marqueur d’occultation. </shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6312,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6313,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6314,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 7,
+                    "base_action_side_effect": null,
+                    "id": 6315,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_134",
+            "force_side": null,
+            "id": 134,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Pilote d’Essai Imdaar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 27,
+            "statistics": [
+                {
+                    "id": 7191,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7192,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7193,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7194,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15285,6 +11540,94 @@
                 },
                 {
                     "id": 7206,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>D’une conception similaire aux autres vaisseaux développés par Cygnus Spaceworks, le Star Wing de classe <untalic>Alpha</untalic> est un appareil polyvalent attribué aux unités spécialisées de la Marine Impériale qui ont besoin d’un chasseur facilement adaptable pour des missions variées.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6328,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6329,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6330,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6331,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                6,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "35",
+            "faction_id": 2,
+            "ffg_id": "XW_P_138",
+            "force_side": null,
+            "id": 138,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilote de l’Escadron Nu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 14,
+            "statistics": [
+                {
+                    "id": 7207,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7208,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7209,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7210,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -15590,6 +11933,101 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 ou plusieurs vaisseaux alliés à portée 0–3. Dans ce cas, transférez tous les marqueurs de verrouillage ennemis des vaisseaux choisis vers vous.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6347,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6348,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 6349,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6350,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                8,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 2,
+            "ffg_id": "XW_P_142",
+            "force_side": null,
+            "id": 142,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Capitaine Kagi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 26,
+            "statistics": [
+                {
+                    "id": 7223,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7224,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 7225,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7226,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7227,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Pilote de la Navette de l’Empereur",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Au début de la phase d’activation, vous pouvez dépenser 1 <standardcharge>. Dans ce cas, lorsqu’un vaisseau allié verrouille une cible à ce round, il doit le faire au-delà de la portée 3 à la place de la portée 0–3.",
             "available_actions": [
                 {
@@ -15876,6 +12314,202 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Vous pouvez effectuer vos attaques principales à portée 0.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6363,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6364,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6365,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6366,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6367,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 2,
+            "ffg_id": "XW_P_146",
+            "force_side": null,
+            "id": 146,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitaine Oicunn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7244,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7245,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7246,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7247,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Tacticien Inspiré",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque, si vous êtes renforcé et si le défenseur est dans l’arc <fullfront> ou <fullrear> correspondant à votre marqueur de renforcement, vous pouvez changer 1 de vos résultats <focus> en un résultat <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6368,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6369,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6370,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6371,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6372,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "88",
+            "faction_id": 2,
+            "ffg_id": "XW_P_147",
+            "force_side": null,
+            "id": 147,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Vice-Amiral Chiraneau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7248,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7249,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7250,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7251,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Conseiller de l’Amiral Piett",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -16174,6 +12808,104 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant que vous effectuez une attaque principale, si au moins 1 vaisseau allié non-limité est à portée 0 du défenseur, lancez 1 dé d’attaque supplémentaire.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6386,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6387,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": "stress",
+                    "id": 6388,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6389,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
+            "card_set_ids": [
+                6,
+                11
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 3,
+            "ffg_id": "XW_P_151",
+            "force_side": null,
+            "id": 151,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kath Scarlet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 10,
+            "statistics": [
+                {
+                    "id": 7266,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7267,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "3"
+                },
+                {
+                    "id": 7268,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7269,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7270,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Capitaine des Pirates Binayre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous défendez ou effectuez une attaque, si le vaisseau ennemi est stressé, vous pouvez relancer 1 de vos dés.",
             "available_actions": [
                 {
@@ -16466,6 +13198,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant que vous défendez ou effectuez une attaque, si la portée d’attaque est 1, vous pouvez lancer 1 dé supplémentaire. <return><shipability><sabold>Opposition Concordia :</sabold> tant que vous défendez, si la portée d’attaque est 1 et que vous êtes dans l’<frontarc> de l’attaquant, changez 1 résultat en un résultat <evade>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6402,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6403,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6404,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6405,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 3,
+            "ffg_id": "XW_P_155",
+            "force_side": null,
+            "id": 155,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7286,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7287,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7288,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Leader Skull",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau ennemi à portée 1. Dans ce cas, si vous êtes dans son <frontarc>, il retire tous ses marqueurs verts.<return><shipability><sabold>Opposition Concordia :</sabold> tant que vous défendez, si la portée d’attaque est 1 et que vous êtes dans l’<frontarc> de l’attaquant, changez 1 résultat en un résultat <evade>.</shipability>",
             "available_actions": [
                 {
@@ -16705,6 +13517,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Les as de l’Escadron Skull privilégient une approche agressive, profitant de la technologie d’ailes montées sur pivot de leurs appareils, ce qui leur confère une maniabilité exceptionnelle quand ils poursuivent leurs proies. </flavor><return><shipability><sabold>Opposition Concordia :</sabold> tant que vous défendez, si la portée d’attaque est 1 et que vous êtes dans l’<frontarc> de l’attaquant, changez 1 résultat en un résultat <evade>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6418,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6419,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6420,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6421,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_159",
+            "force_side": null,
+            "id": 159,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Pilote de l’Escadron Skull",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7298,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7299,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7300,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Les pilotes de Chasseur Fang Mandalorien doivent maîtriser la manœuvre dite de l’Opposition Concordia, profitant du profil de leurs appareils pour mener des charges sans concession. </flavor><return><shipability><sabold>Opposition Concordia :</sabold> tant que vous défendez, si la portée d’attaque est 1 et que vous êtes dans l’<frontarc> de l’attaquant, changez 1 résultat en un résultat <evade>.</shipability>",
             "available_actions": [
                 {
@@ -16935,6 +13827,156 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Au début de la phase d’engagement, si un ou plusieurs autres vaisseaux sont à portée 0, vous et chaque autre vaisseau à portée 0 gagnez 1 marqueur de rayon tracteur. <return><shipability><sabold>Dispositif Tracteur de Remorqueur Spatial :</sabold> <smallcaps>Action :</smallcaps> choisissez un vaisseau dans votre <frontarc> à portée 1. Il gagne 1 marqueur de rayon tracteur, ou 2 marqueurs de rayon tracteur s’il est dans votre <bullseye> à portée 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6432,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6433,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6434,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 3,
+            "ffg_id": "XW_P_163",
+            "force_side": null,
+            "id": 163,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Unkar Plutt",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7310,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7311,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7312,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Maître des Portions Misérables",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Le Remorqueur Spatial de Transfert Quadrimoteur, surnommé « Quad jumper », était aussi manœuvrable sous atmosphère que dans l’espace, ce qui le rendait extrêmement populaire auprès des contrebandiers et des explorateurs. </flavor><return><shipability><sabold>Dispositif Tracteur de Remorqueur Spatial :</sabold> <smallcaps>Action :</smallcaps> choisissez un vaisseau dans votre <frontarc> à portée 1. Il gagne 1 marqueur de rayon tracteur, ou 2 marqueurs de rayon tracteur s’il est dans votre <bullseye> à portée 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6435,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6436,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6437,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 3,
+            "ffg_id": "XW_P_164",
+            "force_side": null,
+            "id": 164,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Trafiquant d’Armes de Jakku",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7313,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7314,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7315,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous effectuez une attaque non-<frontarc>, lancez 1 dé d’attaque supplémentaire.",
             "available_actions": [
                 {
@@ -17021,6 +14063,188 @@
                 }
             ],
             "subtitle": "Corsaire Sans Pitié",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant qu’un vaisseau allié non-limité effectue une attaque, si le défenseur est dans votre arc de tir, l’attaquant peut relancer 1 dé d’attaque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6442,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6443,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6444,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6445,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 3,
+            "ffg_id": "XW_P_166",
+            "force_side": null,
+            "id": 166,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Drea Renthal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7320,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7321,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7322,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7323,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Seigneur Pirate",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>La simple évocation de crédits Impériaux peut attirer toutes sortes d’individus totalement amoraux dans votre camp.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6446,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6447,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6448,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6449,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 3,
+            "ffg_id": "XW_P_167",
+            "force_side": null,
+            "id": 167,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": " Soudard",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7324,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7325,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7326,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7327,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17271,6 +14495,85 @@
                 }
             ],
             "subtitle": "Maraudeur Imposant",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Vous ne pouvez être déployé que par un déploiement d’urgence, et vous avez le nom, l’initiative, la capacité de pilote, et les <standardcharge> du vaisseau allié Hound’s Tooth qui a été détruit.<return><shipability>Vaisseau de Secours : Mise en Place : nécessite le Hound’s Tooth. Vous devez commencer la partie arrimé au Hound’s Tooth.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6460,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6461,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6462,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "6",
+            "faction_id": 3,
+            "ffg_id": "XW_P_171",
+            "force_side": null,
+            "id": 171,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Nashtah Pup</italic>",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 7340,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7341,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7342,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7343,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Plan d’Urgence",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17532,6 +14835,102 @@
                 }
             ],
             "subtitle": "Mercenaire de la Bordure Extérieure",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau ennemi dans votre arc de tir, à portée 0–2. Dans ce cas, transférez 1 marqueur de concentration ou d’évasion de ce vaisseau au vôtre.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6474,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6475,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6476,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6477,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6478,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 3,
+            "ffg_id": "XW_P_175",
+            "force_side": null,
+            "id": 175,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Palob Godalhi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 7357,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7358,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7359,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7360,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Résistant Tethan",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17815,6 +15214,94 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Après avoir entièrement exécuté une manœuvre, vous pouvez gagner 1 marqueur de stress pour pivoter votre vaisseau de 90°. <return><shipability><sabold>Micropropulseurs :</sabold> tant que vous effectuez un tonneau, vous devez utiliser le gabarit <leftbank> ou <rightbank> à la place du gabarit <straight>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6493,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6494,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6495,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6496,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_179",
+            "force_side": null,
+            "id": 179,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Dalan Oberos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 3,
+            "statistics": [
+                {
+                    "id": 7373,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7374,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7375,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7376,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Chasseur de Primes d’Élite",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous défendez, après l’étape «<nonbreak>Neutraliser les résultats<nonbreak>», un autre vaisseau allié à portée 0–1 et dans l’arc de l’attaque peut subir 1 dégât<nonbreak><hit> ou <crit>. Dans ce cas, annulez 1 dégât correspondant.<return><shipability><sabold>Micropropulseurs :</sabold> tant que vous effectuez un tonneau, vous devez utiliser le gabarit <leftbank> ou <rightbank> à la place du gabarit <straight>.</shipability>",
             "available_actions": [
                 {
@@ -18078,6 +15565,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant qu’un vaisseau allié à portée 0–1 défend, il peut relancer 1 de ses dés. <return><shipability><sabold>Emplacement d’Arme :</sabold> vous pouvez vous équiper de 1 amélioration <cannon>, <torpedo> ou <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6509,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6510,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6511,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6512,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_183",
+            "force_side": null,
+            "id": 183,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Serissu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7389,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7390,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7391,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7392,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Instructeur de Vol",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Après avoir verrouillé une cible, vous devez retirer tous vos marqueurs de concentration et d’évasion. Puis, gagnez autant de marqueurs de concentration et d’évasion qu’a le vaisseau verrouillé. <return><shipability><sabold>Emplacement d’Arme :</sabold> vous pouvez vous équiper de 1 amélioration <cannon>, <torpedo> ou <missile>.</shipability>",
             "available_actions": [
                 {
@@ -18331,6 +15904,91 @@
                 }
             ],
             "subtitle": "Chercheur de Fortune",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez ou effectuez une attaque, vous pouvez subir 1 dégât<nonbreak><hit> pour relancer n’importe quel nombre de vos dés. <return><shipability><sabold>Emplacement d’Arme :</sabold> vous pouvez vous équiper de 1 amélioration <cannon>, <torpedo> ou <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6525,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6526,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6527,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6528,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 3,
+            "ffg_id": "XW_P_187",
+            "force_side": null,
+            "id": 187,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Inaldra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7405,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7406,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7407,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7408,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Boss de Tansarii Point",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -18592,6 +16250,88 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant que vous défendez à portée d’attaque 3 ou effectuez une attaque à portée d’attaque 1, lancez 1 dé supplémentaire.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6541,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6542,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6543,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_191",
+            "force_side": null,
+            "id": 191,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Talonbane Cobra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7421,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7422,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7423,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7424,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Fléau de Tansarii Point",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous défendez, si vous êtes derrière l’attaquant, lancez 1 dé de défense supplémentaire. <return>Tant que vous effectuez une attaque, si vous êtes derrière le défenseur, lancez 1 dé d’attaque supplémentaire.",
             "available_actions": [
                 {
@@ -18832,6 +16572,88 @@
                 }
             ],
             "subtitle": "Opportuniste Agressif",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Le chasseur d’assaut Kihraxz fut développé expressément pour l’organisation criminelle du Soleil Noir, dont les as, très généreusement payés, exigeaient des appareils agiles et puissants, à la hauteur de leur talent.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6553,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6554,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6555,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 3,
+            "ffg_id": "XW_P_195",
+            "force_side": null,
+            "id": 195,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "As du Soleil Noir",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7437,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7438,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7439,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7440,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19100,6 +16922,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Après avoir effectué une action <boost>, vous pouvez effectuer une action <evade>.<return><shipability><sabold>Cerveau Droïde Avancé :</sabold> après avoir effectué une action <calculate>, gagnez 1 marqueur de calcul.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6567,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6568,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6569,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6570,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 3,
+            "ffg_id": "XW_P_199",
+            "force_side": null,
+            "id": 199,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•IG-88C",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 21,
+            "statistics": [
+                {
+                    "id": 7453,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7454,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7455,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7456,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Machine Trop Indulgente",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous exécutez une manœuvre Boucle de Segnor (<leftsloop> ou <rightsloop>), vous pouvez utiliser un autre gabarit de même vitesse à la place : soit le gabarit de virage (<leftturn> ou <rightturn>) de même direction, soit le gabarit de ligne droite (<straight>).<return><shipability><sabold>Cerveau Droïde Avancé :</sabold> après avoir effectué une action <calculate>, gagnez 1 marqueur de calcul.</shipability>",
             "available_actions": [
                 {
@@ -19355,6 +17268,87 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Les légendaires Trouveurs de Gand vouaient un véritable culte aux brumes qui recouvraient leur planète natale et se servaient de signes, d’augures et de rituels mystiques pour traquer leurs proies.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6581,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6582,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6583,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_203",
+            "force_side": null,
+            "id": 203,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Trouveur Gand",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 22,
+            "statistics": [
+                {
+                    "id": 7469,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7470,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7471,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7472,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Avant qu’une bombe ou mine alliée n’explose, vous pouvez dépenser 1 <standardcharge> pour empêcher son explosion.<return> Tant que vous défendez contre une attaque gênée par une bombe ou une mine, lancez 1 dé de défense supplémentaire.",
             "available_actions": [
                 {
@@ -19604,6 +17598,95 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une attaque, chaque vaisseau ennemi dans votre <bullseye> subit 1 dégât<nonbreak><hit> sauf s’il retire 1 marqueur vert. <return><shipability><sabold>Dans le Mille :</sabold> tant que vous effectuez une attaque, si le défenseur est dans votre <bullseye>, les dés de défense ne peuvent pas être modifiés en utilisant des marqueurs verts.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6593,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6594,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6595,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6596,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                10,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_207",
+            "force_side": null,
+            "id": 207,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Torani Kulda",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 39,
+            "statistics": [
+                {
+                    "id": 7486,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7487,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7488,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "7"
+                },
+                {
+                    "id": 7489,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Free-Lance Rodien",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19878,6 +17961,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Si vous êtes censé fuir, vous pouvez dépenser 1 <standardcharge>. Dans ce cas, mettez-vous en réserve à la place. Au début de la prochaine phase de préparation, placez-vous intégralement à portée 1 du bord de la zone de jeu par lequel vous auriez dû fuir.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6608,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6609,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6610,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                8,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 3,
+            "ffg_id": "XW_P_211",
+            "force_side": null,
+            "id": 211,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Moralo Eval",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 24,
+            "statistics": [
+                {
+                    "id": 7503,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 7504,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7505,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "9"
+                },
+                {
+                    "id": 7506,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                },
+                {
+                    "id": 7507,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Génie Criminel",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Au début de la phase d’engagement, vous pouvez choisir un vaisseau à portée 1 et dépenser un marqueur de verrouillage que vous avez sur ce vaisseau. Dans ce cas, ce vaisseau gagne 1 marqueur de rayon tracteur.",
             "available_actions": [
                 {
@@ -20130,6 +18304,88 @@
                 }
             ],
             "subtitle": "Corellien Revanchard",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir un vaisseau allié à portée 0–1. Dans ce cas, transférez à ce vaisseau tous vos marqueurs verts.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6620,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6621,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6622,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_215",
+            "force_side": null,
+            "id": 215,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Manaroo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 45,
+            "statistics": [
+                {
+                    "id": 7521,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7522,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7523,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7524,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Aruzan Gracieuse",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20689,38 +18945,39 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>De nombreux astropilotes gagnent leur vie en parcourant la Bordure Extérieure, un secteur où la différence entre contrebandier et marchand honnête est souvent ténue. Aux frontières de la civilisation, les clients sont beaucoup moins exigeants sur l’origine des marchandises, tant que les prix sont suffisamment attractifs.</flavor>",
+            "ability_text": "Tant que vous défendez ou effectuez une attaque principale, si l’attaque est gênée par un obstacle, vous pouvez lancer 1 dé supplémentaire.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 6645,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 6646,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 6647,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 6648,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
+                1,
                 6,
                 8,
                 8,
@@ -20729,51 +18986,142 @@
                 15,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "54",
             "faction_id": 3,
-            "ffg_id": "XW_P_225",
+            "ffg_id": "XW_P_222",
             "force_side": null,
-            "id": 225,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Capitaine de Cargo",
+            "id": 222,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 7555,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 7556,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 7557,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 7558,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Le Kid Corellien",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir lancé des dés, si vous n’êtes pas stressé, vous pouvez gagner 1 marqueur de stress pour relancer tous vos résultats vierges.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6649,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6650,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6651,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6652,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 3,
+            "ffg_id": "XW_P_223",
+            "force_side": null,
+            "id": 223,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7559,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7560,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7561,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7562,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Joueur à la Voix Suave",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20869,6 +19217,96 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>De nombreux astropilotes gagnent leur vie en parcourant la Bordure Extérieure, un secteur où la différence entre contrebandier et marchand honnête est souvent ténue. Aux frontières de la civilisation, les clients sont beaucoup moins exigeants sur l’origine des marchandises, tant que les prix sont suffisamment attractifs.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6657,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6658,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6659,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6660,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 3,
+            "ffg_id": "XW_P_225",
+            "force_side": null,
+            "id": 225,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Capitaine de Cargo",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7567,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7568,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7569,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7570,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Après avoir lancé des dés, si vous n’êtes pas stressé, vous pouvez gagner 1 marqueur de stress pour relancer tous vos résultats vierges.<return><shipability><smallcaps>Copilote :</smallcaps> tant que vous êtes arrimé, votre vaisseau porteur bénéficie de votre capacité de pilote en plus de la sienne.</shipability>",
             "available_actions": [
                 {
@@ -20948,42 +19386,160 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Tant que vous effectuez une attaque principale, si le défenseur est dans votre <bullseye>, avant l’étape « Neutraliser les résultats », vous pouvez dépenser 1<nonbreak><standardcharge> pour annuler 1 résultat <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                9
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_1",
-            "force_side": null,
-            "id": 230,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Tireur Hors Pair",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
+            "ability_text": "Les vaisseaux alliés à portée 0–1 peuvent effectuer des attaques en étant à portée 0 des obstacles.<return><shipability>Copilote : tant que vous êtes arrimé, votre vaisseau porteur bénéficie de votre capacité de pilote en plus de la sienne.</shipability>",
+            "available_actions": [
                 {
-                    "id": 6632,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6664,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6665,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6666,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
                 }
             ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+            "available_upgrades": [
+                1,
+                8,
+                14
             ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "24",
+            "faction_id": 3,
+            "ffg_id": "XW_P_227",
+            "force_side": null,
+            "id": 227,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Colon de la Bordure Extérieure",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7575,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7576,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7577,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7578,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Hors-la-loi Habile",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Si vous n'êtes pas protégé, diminuez la difficulté de vos manœuvres de virages sur l’aile (<leftbank> et <rightbank>).<return><shipability>Copilote : tant que vous êtes arrimé, votre vaisseau porteur bénéficie de votre capacité de pilote en plus de la sienne.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6667,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6668,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6669,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "22",
+            "faction_id": 3,
+            "ffg_id": "XW_P_228",
+            "force_side": null,
+            "id": 228,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•L3-37",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7579,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7580,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7581,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7582,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Droïde Révolutionnaire",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21069,81 +19625,94 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Si vous n'êtes pas protégé, diminuez la difficulté de vos manœuvres de virages sur l’aile (<leftbank> et <rightbank>).<return><shipability>Copilote : tant que vous êtes arrimé, votre vaisseau porteur bénéficie de votre capacité de pilote en plus de la sienne.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6667,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6668,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6669,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "ability_text": "Tant que vous effectuez une attaque principale, si le défenseur est dans votre <bullseye>, avant l’étape « Neutraliser les résultats », vous pouvez dépenser 1<nonbreak><standardcharge> pour annuler 1 résultat <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
             "card_set_ids": [
-                13
+                4,
+                5,
+                6,
+                9
             ],
-            "card_type_id": 1,
-            "cost": "22",
-            "faction_id": 3,
-            "ffg_id": "XW_P_228",
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_1",
             "force_side": null,
-            "id": 228,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•L3-37",
+            "id": 230,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Tireur Hors Pair",
             "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 6632,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7580,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7581,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7582,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
+                    "statistic_id": 7,
+                    "value": "1"
                 }
             ],
-            "subtitle": "Droïde Révolutionnaire",
-            "upgrade_types": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une action <boost> blanche, vous pouvez considérer qu’elle est rouge pour utiliser le gabarit [1<nonbreak><leftturn>] ou [1<nonbreak><rightturn>] à la place.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                12
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_2",
+            "force_side": null,
+            "id": 231,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Casse-Cou",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Boost",
+                            "pk": 1,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21351,6 +19920,39 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant qu’un vaisseau ennemi à portée 0 défend, il lance un dé de défense en moins.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_7",
+            "force_side": null,
+            "id": 236,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Intimidation",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous effectuez une attaque, si vous avez un marqueur d’évasion, vous pouvez changer 1 des résultats <evade> du défenseur en un résultat <focus>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21400,6 +20002,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant que vous défendez ou que vous effectuez une attaque, s’il n’y a aucun autre vaisseau allié à portée 0–2, vous pouvez dépenser 1 <standardcharge> pour relancer 1 de vos dés.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_9",
+            "force_side": null,
+            "id": 238,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Loup Solitaire",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6606,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous effectuez une attaque, si le défenseur est dans votre <bullseye>, vous pouvez changer 1 résultat <hit> en un résultat <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21420,6 +20062,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Adresse au Tir",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque <frontarc>, si vous n’êtes pas dans l’arc de tir du défenseur, il lance 1 dé de défense en moins.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_11",
+            "force_side": null,
+            "id": 240,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Manœuvre Improbable",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21558,37 +20233,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Au début de la phase d’engagement, vous pouvez dépenser 1<nonbreak><forcecharge>. Dans ce cas, pendant cette phase, engagez-vous à l’initiative 7 au lieu de le faire à votre valeur d’initiative standard.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-            "card_set_ids": [
-                1,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_19",
-            "force_side": null,
-            "id": 248,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Perception Renforcée",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                17
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Tant qu’un autre vaisseau allié à portée 0–1 défend, avant l’étape «<nonbreak>Neutraliser les résultats<nonbreak>», si vous êtes dans l’arc de l’attaque, vous pouvez subir 1 dégât <crit> pour annuler 1 résultat <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21630,6 +20274,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Tant que vous coordonnez, le vaisseau que vous avez choisi peut effectuer une action seulement si celle-ci est également dans votre barre d’action. ",
+            "available_actions": [
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 5830,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_16",
+            "force_side": null,
+            "id": 245,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Chef d’Escouade",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau allié à portée 1. Dans ce cas, considérez que son initiative est égale à la vôtre jusqu’à la fin du round.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21658,6 +20343,70 @@
             "subtitle": null,
             "upgrade_types": [
                 1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque qui est gênée par un obstacle, lancez 1 dé d’attaque supplémentaire.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_18",
+            "force_side": null,
+            "id": 247,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Tir Habile",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez dépenser 1<nonbreak><forcecharge>. Dans ce cas, pendant cette phase, engagez-vous à l’initiative 7 au lieu de le faire à votre valeur d’initiative standard.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+            "card_set_ids": [
+                1,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_19",
+            "force_side": null,
+            "id": 248,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Perception Renforcée",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                17
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -21763,6 +20512,78 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Après avoir révélé votre cadran, vous pouvez effectuer 1 action.<return>Dans ce cas, vous ne pouvez pas effectuer d’autre action pendant votre activation.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_23",
+            "force_side": null,
+            "id": 252,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Senseurs Avancés",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous accélérez ou que vous effectuez un tonneau, vous pouvez vous déplacer à travers ou chevaucher les obstacles. <return>Après vous être déplacé à travers ou avoir chevauché un obstacle, vous pouvez dépenser 1<nonbreak><standardcharge> pour ignorer ses effets jusqu’à la fin du round.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_24",
+            "force_side": null,
+            "id": 253,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Détecteur Anti-Collision",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6626,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous effectuez une attaque, si vous avez un verrouillage sur le défenseur, vous pouvez relancer 1 dé d’attaque. Dans ce cas, vous ne pouvez pas dépenser votre marqueur de verrouillage pendant cette attaque.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21783,6 +20604,37 @@
             "initiative": null,
             "is_unique": false,
             "name": "Système de Commande de Tir",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Pendant la phase de système, si vous êtes censé larguer ou lancer une bombe, vous pouvez la lancer en utilisant le gabarit [5<nonbreak><straight>] à la place.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_set_ids": [
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_26",
+            "force_side": null,
+            "id": 255,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Simulateur de Trajectoire",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21836,83 +20688,43 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Pendant la phase de système, si vous êtes censé larguer ou lancer une bombe, vous pouvez la lancer en utilisant le gabarit [5<nonbreak><straight>] à la place.",
+            "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât <hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
             "card_set_ids": [
+                4,
                 5,
                 6
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "5",
             "faction_id": null,
-            "ffg_id": "XW_U_26",
+            "ffg_id": "XW_U_28",
             "force_side": null,
-            "id": 255,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "id": 257,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Simulateur de Trajectoire",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât<nonbreak><hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5835,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_32",
-            "force_side": null,
-            "id": 261,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Tourelle à Canons Ioniques",
+            "name": "Canon Ionique",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6645,
+                    "id": 6643,
                     "recurring": false,
-                    "statistic_id": 12,
+                    "statistic_id": 10,
                     "value": "3"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
-                4
+                3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 - 3"
         },
         {
             "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, tous les résultats <hit>/<crit> infligent des marqueurs de brouillage au lieu des dégâts.",
@@ -21993,48 +20805,144 @@
             "weapon_range": "1 - 3"
         },
         {
-            "ability_text": "<smallcaps>Attaque (<focus>) :</smallcaps> dépensez 1 <standardcharge>. Si le défenseur est dans votre <bullseye>, vous pouvez dépenser 1 ou plusieurs <standardcharge> pour relancer autant de dés d’attaque.",
-            "available_actions": [],
+            "ability_text": "<smallcaps>Attaque</smallcaps>",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5832,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
             "card_set_ids": [
-                5
+                4,
+                5,
+                6
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_36",
+            "ffg_id": "XW_U_31",
             "force_side": null,
-            "id": 265,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "id": 260,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Roquettes de Barrage",
+            "name": "Tourelle Dorsale",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6619,
+                    "id": 6633,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6621,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "5"
+                    "statistic_id": 12,
+                    "value": "2"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât<nonbreak><hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5835,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+            "card_set_ids": [
+                4,
+                5,
                 6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_32",
+            "force_side": null,
+            "id": 261,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Tourelle à Canons Ioniques",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6645,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Changez 1 résultat<nonbreak><hit> en un résultat <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+            "card_set_ids": [
+                4,
+                5,
                 6
             ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_33",
+            "force_side": null,
+            "id": 262,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Torpilles à Protons Avancées",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6615,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "5"
+                },
+                {
+                    "id": 6617,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                5
+            ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "1"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât<nonbreak><hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
@@ -22129,6 +21037,96 @@
             ],
             "weapon_no_bonus": true,
             "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Attaque (<focus>) :</smallcaps> dépensez 1 <standardcharge>. Si le défenseur est dans votre <bullseye>, vous pouvez dépenser 1 ou plusieurs <standardcharge> pour relancer autant de dés d’attaque.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_36",
+            "force_side": null,
+            "id": 265,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Roquettes de Barrage",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6619,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6621,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "5"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6,
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Après cette attaque, vous pouvez effectuer cette attaque en tant qu’attaque bonus contre une cible différente à portée 0–1 du défenseur, en ignorant le prérequis <targetlock>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_37",
+            "force_side": null,
+            "id": 266,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Missiles Groupés",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6623,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6625,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "4"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "1 - 2"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Après que cette attaque a touché, chaque vaisseau à portée 0–1 du défenseur expose 1 de ses cartes de dégât.",
@@ -22267,38 +21265,6 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Tant que vous défendez et avant que les dés d’attaque ne soient lancés, vous pouvez dépenser un marqueur de verrouillage que vous avez sur l’attaquant pour lancer 1 dé d’attaque. Dans ce cas, l’attaquant gagne 1 marqueur de brouillage. Puis, sur un résultat <hit> ou <crit>, gagnez 1 marqueur de brouillage.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_42",
-            "force_side": null,
-            "id": 271,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Slicer Free-lance",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Attaque (<focus>) :</smallcaps> dépensez 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22344,6 +21310,109 @@
             "weapon_range": "1 - 2"
         },
         {
+            "ability_text": "Tant que vous défendez et avant que les dés d’attaque ne soient lancés, vous pouvez dépenser un marqueur de verrouillage que vous avez sur l’attaquant pour lancer 1 dé d’attaque. Dans ce cas, l’attaquant gagne 1 marqueur de brouillage. Puis, sur un résultat <hit> ou <crit>, gagnez 1 marqueur de brouillage.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_42",
+            "force_side": null,
+            "id": 271,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Slicer Free-lance",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Mise en Place :</smallcaps> perdez 1 <standardcharge>.<return><smallcaps>Action :</smallcaps> récupérez 1 <standardcharge>.<return><smallcaps>Action :</smallcaps> dépensez 1 <standardcharge> pour récupérer 1 bouclier.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_43",
+            "force_side": null,
+            "id": 272,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Droïde “Gonk” GNK",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6636,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Mise en Place :</smallcaps> après avoir placé les forces, choisissez 1 vaisseau ennemi et assignez-lui l’état <smallcaps>Dispositif d’Écoute</smallcaps>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_44",
+            "force_side": null,
+            "id": 273,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Informateur",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "À la fin du round, vous pouvez lancer 1 dé d’attaque pour réparer 1 carte de dégât face visible. Puis, sur un résultat <hit>, exposez 1 carte de dégât.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22363,6 +21432,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Apprenti Technicien",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une action <focus>, gagnez 1 marqueur de concentration.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_46",
+            "force_side": null,
+            "id": 275,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Copilote Perspicace",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -22456,6 +21558,38 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque <turretarc>, après l’étape «<nonbreak>Modifier les dés de défense<nonbreak>», le défenseur retire 1 marqueur de concentration ou de calcul.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_49",
+            "force_side": null,
+            "id": 278,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Artilleur Hors Pair",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -22587,6 +21721,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Après avoir révélé votre cadran, vous pouvez dépenser 1 <standardcharge> et gagner 1 marqueur de désarmement pour récupérer 1 bouclier.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+            "card_set_ids": [
+                1,
+                4,
+                6,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_53",
+            "force_side": null,
+            "id": 282,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Astromech R2",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6663,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Vous pouvez maintenir jusqu’à 2 cibles verrouillées. Chaque verrouillage doit être sur un objet différent. <return>Après avoir effectué une action <targetlock>, vous pouvez verrouiller une cible.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22702,6 +21876,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallcaps>Action :</smallcaps> dépensez 1 <standardcharge> pour effectuer une action <cloak>.<return>Au début de la phase de préparation, lancez 1 dé d’attaque. Sur un résultat <focus>, désoccultez-vous ou défaussez votre marqueur d’occultation.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_57",
+            "force_side": null,
+            "id": 286,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Appareil d’Occultation",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6594,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant votre activation, vous pouvez dépenser 1 <standardcharge>. Dans ce cas, jusqu’à la fin du round, vous pouvez effectuer des actions et exécuter des manœuvres rouges, même si vous êtes stressé.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_58",
+            "force_side": null,
+            "id": 287,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cybernétique de Contrebande",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6631,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Après que vous avez été détruit, chaque autre vaisseau à portée 0–1 subit 1 dégât<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22797,45 +22062,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mine</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1 <standardcharge> pour larguer un filet Conner en utilisant le gabarit [1<nonbreak><straight>].<return>La <standardcharge> de cette carte ne peut pas être récupérée.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_64",
-            "force_side": null,
-            "id": 393,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Filet Conner",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6630,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Action :</smallcaps> dépensez 1 <standardcharge>. Larguez 1 cargaison égarée en utilisant le gabarit [1<nonbreak><straight>].",
             "available_actions": [],
             "available_upgrades": [],
@@ -22890,18 +22116,10 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Attaque</smallcaps>",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5832,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
+            "ability_text": "Avant de subir des dégâts à cause d’un obstacle ou de l’explosion d’une bombe alliée, vous pouvez dépenser 1<nonbreak><standardcharge>. Dans ce cas, prévenez 1 dégât.",
+            "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
             "card_set_ids": [
                 4,
                 5,
@@ -22910,60 +22128,35 @@
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_31",
+            "ffg_id": "XW_U_68",
             "force_side": null,
-            "id": 260,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+            "id": 292,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Tourelle Dorsale",
-            "restrictions": [],
+            "name": "Blindage Ablatif",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "LARGE"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6633,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                4
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<bitalic>Bombe</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1<nonbreak><standardcharge> pour larguer une bombe à protons en utilisant le gabarit [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_65",
-            "force_side": null,
-            "id": 394,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Bombe à Protons",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6655,
+                    "id": 6614,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -22971,88 +22164,50 @@
             ],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mine</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1 <standardcharge> pour larguer une mine de proximité en utilisant le gabarit [1<nonbreak><straight>].<return>Les <standardcharge> de cette carte ne peuvent pas être récupérées.",
+            "ability_text": "Après avoir effectué une action <slam>, si vous avez entièrement exécuté la manœuvre, vous pouvez effectuer une action blanche de votre barre d’action, en la considérant comme rouge.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
             "card_set_ids": [
                 4,
                 5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_66",
-            "force_side": null,
-            "id": 395,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Mine de Proximité",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6662,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bombe</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1 <standardcharge> pour larguer une charge sismique en utilisant le gabarit [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8,
-                11
+                6
             ],
             "card_type_id": 2,
             "cost": "3",
             "faction_id": null,
-            "ffg_id": "XW_U_67",
+            "ffg_id": "XW_U_69",
             "force_side": null,
-            "id": 396,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "id": 293,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Charges Sismiques",
-            "restrictions": [],
+            "name": "MASL Avancé",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Slam",
+                            "pk": 13,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6666,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23187,6 +22342,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Quand on ne peut pas s’offrir un générateur de boucliers améliorés, souder des plaques de blindage sur la coque du vaisseau peut être un bon substitut.</flavor>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "*",
+            "faction_id": null,
+            "ffg_id": "XW_U_73",
+            "force_side": null,
+            "id": 297,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Coque Améliorée",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6642,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "+1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous effectuez une attaque <torpedo> ou <missile>, après avoir lancé les dés d’attaque, vous pouvez annuler tous les résultats des dés pour récupérer 1 <standardcharge> que vous avez dépensée comme coût pour l’attaque.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23291,54 +22486,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Avant de lancer les dés de défense, vous pouvez dépenser 1 marqueur de calcul pour dire à voix haute un nombre supérieur ou égal à 1. Dans ce cas et si vous obtenez exactement cette quantité de résultats <evade> sur votre lancer, ajoutez 1<nonbreak>résultat <evade>.<return>Après avoir effectué l’action <calculate>, gagnez 1 marqueur de calcul. ",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5827,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_80",
-            "force_side": null,
-            "id": 304,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•C-3PO",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Tant que vous défendez, si votre <standardcharge> est active, lancez 1 dé de défense supplémentaire.<return>Après avoir subi des dégâts, perdez 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23422,6 +22569,94 @@
             "subtitle": null,
             "upgrade_types": [
                 14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une action <focus>, vous pouvez considérer qu’elle est rouge. Dans ce cas, gagnez 1 marqueur de concentration supplémentaire pour chaque vaisseau ennemi à portée 0–1, pour un maximum de 2.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_79",
+            "force_side": null,
+            "id": 303,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Baze Malbus",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant de lancer les dés de défense, vous pouvez dépenser 1 marqueur de calcul pour dire à voix haute un nombre supérieur ou égal à 1. Dans ce cas et si vous obtenez exactement cette quantité de résultats <evade> sur votre lancer, ajoutez 1<nonbreak>résultat <evade>.<return>Après avoir effectué l’action <calculate>, gagnez 1 marqueur de calcul. ",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5827,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "12",
+            "faction_id": null,
+            "ffg_id": "XW_U_80",
+            "force_side": null,
+            "id": 304,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•C-3PO",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23514,6 +22749,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Pendant l’étape «<nonbreak>Effectuer une action<nonbreak>», vous pouvez effectuer 1 action, même si vous êtes stressé. Après avoir effectué une action en étant stressé, subissez 1 dégât<nonbreak><hit> sauf si vous exposez 1 de vos cartes de dégât.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_83",
+            "force_side": null,
+            "id": 307,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Vous pouvez exécuter des manœuvres rouges même si vous êtes stressé. Après avoir entièrement exécuté une manœuvre rouge, si vous avez au moins 3 marqueurs de stress, retirez 1 marqueur de stress et subissez 1 dégât<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23531,6 +22806,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Hera Syndulla",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Si un vaisseau allié à portée 0–3 est censé gagner un marqueur de concentration, il peut gagner 1 marqueur d’évasion à la place.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_85",
+            "force_side": null,
+            "id": 309,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Jyn Erso",
             "restrictions": [
                 [
                     {
@@ -23688,6 +23003,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Après avoir défendu, si l’attaque touche, vous pouvez verrouiller l’attaquant.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_89",
+            "force_side": null,
+            "id": 313,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Diminuez la difficulté de vos manœuvres de virages sur l’aile (<leftbank> et <rightbank>).",
             "available_actions": [],
             "available_upgrades": [],
@@ -23705,6 +23060,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Nien Nunb",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Pendant la phase de dénouement, si vous êtes endommagé et n’êtes pas protégé, vous pouvez lancer 1 dé d’attaque pour récupérer 1 bouclier. Sur un résultat <hit>, exposez 1 de vos cartes de dégât.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_91",
+            "force_side": null,
+            "id": 315,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R2-D2",
             "restrictions": [
                 [
                     {
@@ -23768,23 +23163,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Pendant la phase de dénouement, si vous êtes endommagé et n’êtes pas protégé, vous pouvez lancer 1 dé d’attaque pour récupérer 1 bouclier. Sur un résultat <hit>, exposez 1 de vos cartes de dégât.",
+            "ability_text": "Tant que vous effectuez une attaque, vous pouvez subir 1 dégât <hit> pour changer tous vos résultats <focus> en résultats <crit>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
             "card_set_ids": [
-                4
+                2
             ],
             "card_type_id": 2,
             "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_91",
+            "ffg_id": "XW_U_93",
             "force_side": null,
-            "id": 315,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "id": 317,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R2-D2",
+            "name": "•Saw Gerrera",
             "restrictions": [
                 [
                     {
@@ -23803,6 +23198,86 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Vous pouvez effectuer des attaques principales à portée 0. Les vaisseaux ennemis à portée 0 peuvent effectuer des attaques principales contre vous.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_94",
+            "force_side": null,
+            "id": 318,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une attaque principale, si vous êtes concentré, vous pouvez effectuer une attaque bonus <turretarc> contre un vaisseau que vous n’avez pas encore attaqué à ce round.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "14",
+            "faction_id": null,
+            "ffg_id": "XW_U_95",
+            "force_side": null,
+            "id": 319,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bistan",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23895,46 +23370,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Tant que vous effectuez une attaque, vous pouvez subir 1 dégât <hit> pour changer tous vos résultats <focus> en résultats <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_93",
-            "force_side": null,
-            "id": 317,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Au début de la phase d’engagement, vous pouvez dépenser 1<nonbreak><forcecharge> pour faire pivoter votre indicateur <turretarc>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23977,6 +23412,46 @@
             "subtitle": null,
             "upgrade_types": [
                 16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Action :</smallcaps> dépensez 1<nonbreak><standardcharge> non-récurrente d’une autre amélioration équipée pour récupérer 1 bouclier. <return><smallcaps>Action :</smallcaps> dépensez 2 boucliers pour récupérer 1<nonbreak><standardcharge> non-récurrente sur une amélioration équipée.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_99",
+            "force_side": null,
+            "id": 323,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24076,23 +23551,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Vous pouvez effectuer des attaques principales à portée 0. Les vaisseaux ennemis à portée 0 peuvent effectuer des attaques principales contre vous.",
+            "ability_text": "1 navette d’attaque ou de classe <italic>Sheathipede</italic> peut s’arrimer à vous.<return>Les vaisseaux arrimés ne peuvent être déployés que par vos glissières arrière.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 2,
-            "cost": "1",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_94",
+            "ffg_id": "XW_U_102",
             "force_side": null,
-            "id": 318,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "id": 326,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•“Zeb” Orrelios",
+            "name": "•<italic>Ghost</italic>",
             "restrictions": [
                 [
                     {
@@ -24102,6 +23577,15 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 23,
+                            "raw_name": "VCX-100 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
@@ -24110,40 +23594,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous effectuez une attaque qui est gênée par un obstacle, lancez 1 dé d’attaque supplémentaire.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_18",
-            "force_side": null,
-            "id": 247,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Tir Habile",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24311,6 +23762,103 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Vous pouvez vous arrimer à portée 0–1.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_106",
+            "force_side": null,
+            "id": 330,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Phantom</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 32,
+                            "raw_name": "Attack Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    },
+                    {
+                        "kwargs": {
+                            "pk": 8,
+                            "raw_name": "Sheathipede-class Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant votre activation, vous pouvez retourner cette carte.<return>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+            "card_set_ids": [
+                2,
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_107",
+            "force_side": null,
+            "id": 331,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Aile Pivot (dépliée)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 15,
+                            "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous défendez, lancez 1 dé de défense en moins.<return>Après avoir exécuté une manœuvre [0<nonbreak><stop>], vous pouvez faire pivoter votre vaisseau de 90° ou 180°.<return>Avant votre activation, vous pouvez retourner cette carte.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24332,6 +23880,49 @@
                         "kwargs": {
                             "pk": 15,
                             "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Avant votre activation, vous pouvez retourner cette carte.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_set_ids": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_108",
+            "force_side": null,
+            "id": 333,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Servomoteur S-foils (déplié)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 33,
+                            "raw_name": "T-65 X-wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -24402,34 +23993,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Avant votre activation, vous pouvez retourner cette carte.",
+            "ability_text": "Après qu’un autre vaisseau allié à portée 0–3 a défendu, s’il est détruit, l’attaquant gagne 2 marqueurs de stress. <return>Tant qu’un vaisseau allié à portée 0–3 effectue une attaque contre un vaisseau stressé, il peut relancer 1 dé d’attaque.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
             "card_set_ids": [
-                1,
-                2,
-                4,
-                7
+                5
             ],
             "card_type_id": 2,
-            "cost": "0",
+            "cost": "10",
             "faction_id": null,
-            "ffg_id": "XW_U_108",
+            "ffg_id": "XW_U_109",
             "force_side": null,
-            "id": 333,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "id": 335,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Servomoteur S-foils (déplié)",
+            "is_unique": true,
+            "name": "•Amiral Sloane",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "pk": 33,
-                            "raw_name": "T-65 X-wing"
+                            "name": "Galactic Empire",
+                            "pk": 2
                         },
-                        "type": "SHIP_TYPE"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -24439,7 +24027,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                18
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24590,6 +24178,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Pendant la phase d’activation, les vaisseaux ennemis à portée 0–1 ne peuvent pas retirer de marqueurs de stress.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_113",
+            "force_side": null,
+            "id": 339,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Death Troopers",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8,
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallcaps>Mise en Place :</smallcaps> avant de placer les forces, assignez l’état <smallcaps>Prototype Optimisé</smallcaps> à un autre vaisseau allié.",
             "available_actions": [
                 {
@@ -24733,6 +24362,111 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Pendant la phase de système, vous pouvez dépenser 2<nonbreak><standardcharge>. Dans ce cas, chaque vaisseau allié peut verrouiller un vaisseau que vous avez verrouillé.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_117",
+            "force_side": null,
+            "id": 343,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Grand Moff Tarkin",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6601,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Pendant la phase de dénouement, les vaisseaux ennemis à portée 1–2 ne peuvent pas retirer de marqueurs de brouillage.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_118",
+            "force_side": null,
+            "id": 344,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Slicer du BSI",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Au début de la phase d’engagement, si vous êtes endommagé, vous pouvez effectuer une action <reinforce> rouge.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24838,23 +24572,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Pendant la phase de dénouement, les vaisseaux ennemis à portée 1–2 ne peuvent pas retirer de marqueurs de brouillage.",
+            "ability_text": "Si un vaisseau ennemi à portée 0–1 est censé gagner un marqueur de stress, vous pouvez dépenser 1 <forcecharge> pour qu’il gagne 1 marqueur de brouillage ou de rayon tracteur à la place.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
             "card_set_ids": [
-                3
+                5
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "12",
             "faction_id": null,
-            "ffg_id": "XW_U_118",
+            "ffg_id": "XW_U_121",
             "force_side": null,
-            "id": 344,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "id": 347,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Slicer du BSI",
+            "is_unique": true,
+            "name": "•La Septième Sœur<return>",
             "restrictions": [
                 [
                     {
@@ -24869,7 +24603,14 @@
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [],
+            "statistics": [
+                {
+                    "id": 6613,
+                    "recurring": false,
+                    "statistic_id": 4,
+                    "value": "+1"
+                }
+            ],
             "subtitle": null,
             "upgrade_types": [
                 8
@@ -24925,94 +24666,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Si un vaisseau ennemi à portée 0–1 est censé gagner un marqueur de stress, vous pouvez dépenser 1 <forcecharge> pour qu’il gagne 1 marqueur de brouillage ou de rayon tracteur à la place.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_121",
-            "force_side": null,
-            "id": 347,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•La Septième Sœur<return>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6613,
-                    "recurring": false,
-                    "statistic_id": 4,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Avant votre activation, vous pouvez retourner cette carte.<return>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
-            "card_set_ids": [
-                2,
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_107",
-            "force_side": null,
-            "id": 331,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Aile Pivot (dépliée)",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 15,
-                            "raw_name": "UT-60D U-wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Après avoir partiellement exécuté une manœuvre, vous pouvez effectuer 1 action blanche, en la considérant comme rouge.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25062,38 +24715,29 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Après avoir effectué une action <coordinate>, vous pouvez choisir un vaisseau ennemi à portée 0–3 du vaisseau coordonné. Dans ce cas, verrouillez ce vaisseau ennemi, en ignorant toute restriction de portée.",
+            "ability_text": "Tant que vous avez exactement 1 marqueur de désarmement, vous pouvez toujours effectuer des attaques <torpedo> et <missile> contre des cibles que vous avez verrouillées. Dans ce cas, vous ne pouvez pas dépenser votre marqueur de verrouillage pendant cette attaque.<return>Ajoutez des emplacements <torpedo> et <missile>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_124",
+            "ffg_id": "XW_U_125",
             "force_side": null,
-            "id": 391,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "id": 350,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
             "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>ST-321</italic>",
+            "is_unique": false,
+            "name": "Arsenal Os-1 Embarqué",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 26,
-                            "raw_name": "Lambda-class T-4a Shuttle"
+                            "pk": 14,
+                            "raw_name": "Alpha-class Star Wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -25105,7 +24749,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                15
+                18
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25146,6 +24790,60 @@
             "subtitle": null,
             "upgrade_types": [
                 18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase d’engagement, vous pouvez choisir 1 vaisseau ennemi à portée 0–1. Dans ce cas, vous gagnez 1 marqueur de calcul sauf si ce vaisseau choisit de gagner 1 marqueur de stress.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_127",
+            "force_side": null,
+            "id": 352,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•0-0-0",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 338
+                        },
+                        "type": "CARD_INCLUDED"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 93
+                        },
+                        "type": "CARD_INCLUDED"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25249,6 +24947,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Cad Bane",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Pendant la phase de dénouement, vous pouvez choisir 2 améliorations <illicit> équipant des vaisseaux alliés à portée 0–1. Dans ce cas, vous pouvez échanger ces améliorations. <return><smallcaps>Fin de Partie<nonbreak>:</smallcaps> remettez toutes les améliorations <illicit> sur leurs vaisseaux d’origine.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_131",
+            "force_side": null,
+            "id": 356,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Cikatro Vizago",
             "restrictions": [
                 [
                     {
@@ -25385,6 +25123,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Ketsu Onyo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous défendez, si l’attaquant est stressé, vous pouvez retirer 1 marqueur de stress de l’attaquant pour changer 1 de vos résultats Vierge/<focus> en un résultat <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_135",
+            "force_side": null,
+            "id": 360,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Latts Razzi",
             "restrictions": [
                 [
                     {
@@ -25563,6 +25341,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Après avoir effectué une attaque principale ratée, si vous n’êtes pas stressé, vous devez recevoir 1 marqueur de stress pour effectuer une attaque principale bonus contre la même cible.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_139",
+            "force_side": null,
+            "id": 364,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bossk",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Tant que vous effectuez une attaque, vous pouvez changer 1 résultat<nonbreak><hit> en un résultat <crit> pour chaque marqueur de stress qu’a le défenseur.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25711,6 +25529,133 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Après avoir entièrement exécuté une manœuvre, si vous n’avez pas largué ou lancé d’engin à ce round, vous pouvez larguer 1 bombe.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_143",
+            "force_side": null,
+            "id": 368,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Genius”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous effectuez une attaque contre un défenseur dans votre <frontarc>, vous pouvez dépenser 1<nonbreak><standardcharge> pour relancer 1 dé d’attaque. Si le résultat relancé est un résultat <crit>, subissez 1 dégât<nonbreak><crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_144",
+            "force_side": null,
+            "id": 369,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-P8",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6612,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Vous pouvez effectuer des attaques contre des vaisseaux alliés.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_145",
+            "force_side": null,
+            "id": 370,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-TK",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Ajoutez un emplacement <bomb>.",
             "available_actions": [
                 {
@@ -25818,23 +25763,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Tant que vous effectuez une attaque contre un défenseur dans votre <frontarc>, vous pouvez dépenser 1<nonbreak><standardcharge> pour relancer 1 dé d’attaque. Si le résultat relancé est un résultat <crit>, subissez 1 dégât<nonbreak><crit>.",
+            "ability_text": "1 Chasseur de Têtes Z-95-AF4 peut s’arrimer à vous.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "4",
+            "cost": "1",
             "faction_id": null,
-            "ffg_id": "XW_U_144",
+            "ffg_id": "XW_U_148",
             "force_side": null,
-            "id": 369,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "id": 373,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R5-P8",
+            "name": "•<italic>Hound’s Tooth</italic>",
             "restrictions": [
                 [
                     {
@@ -25844,22 +25789,73 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 24,
+                            "raw_name": "YV-666 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6612,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "3"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                10
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Vous avez la capacité de pilote de chaque autre vaisseau allié qui possède l’amélioration <sabold>IG-2000</sabold>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_149",
+            "force_side": null,
+            "id": 374,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "<italic>IG-2000</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 21,
+                            "raw_name": "Aggressor Assault Fighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25971,23 +25967,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Vous avez la capacité de pilote de chaque autre vaisseau allié qui possède l’amélioration <sabold>IG-2000</sabold>.",
+            "ability_text": "Tant que vous effectuez une attaque principale, si le défenseur est dans votre <frontarc>, lancez 1 dé d’attaque supplémentaire.<return> Retirez un emplacement <crew>. Ajoutez un emplacement <astro>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_149",
+            "ffg_id": "XW_U_152",
             "force_side": null,
-            "id": 374,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "id": 377,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "<italic>IG-2000</italic>",
+            "is_unique": true,
+            "name": "•<italic>Punishing One</italic>",
             "restrictions": [
                 [
                     {
@@ -26001,8 +25997,8 @@
                 [
                     {
                         "kwargs": {
-                            "pk": 21,
-                            "raw_name": "Aggressor Assault Fighter"
+                            "pk": 45,
+                            "raw_name": "JumpMaster 5000"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -26172,23 +26168,72 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Mise en Place :</smallcaps> équipez-vous avec cette face visible.<return>Tant que vous défendez, vous pouvez retourner cette carte. Dans ce cas, l’attaquant doit relancer tous les dés d’attaque.",
+            "ability_text": "Après avoir échoué à une action, si vous n’avez aucun marqueur vert, vous pouvez effectuer une action <focus>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_156",
+            "force_side": null,
+            "id": 381,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Maîtrise de Soi",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Au début de la phase de dénouement, vous pouvez dépenser 1 marqueur de concentration pour réparer 1 de vos cartes de dégât face visible.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_158",
+            "ffg_id": "XW_U_157",
             "force_side": null,
-            "id": 384,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+            "id": 382,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•L3–37",
+            "name": "•Chewbacca",
             "restrictions": [
                 [
                     {
@@ -26250,40 +26295,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Après avoir échoué à une action, si vous n’avez aucun marqueur vert, vous pouvez effectuer une action <focus>.",
+            "ability_text": "<smallcaps>Mise en Place :</smallcaps> équipez-vous avec cette face visible.<return>Tant que vous défendez, vous pouvez retourner cette carte. Dans ce cas, l’attaquant doit relancer tous les dés d’attaque.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_156",
+            "ffg_id": "XW_U_158",
             "force_side": null,
-            "id": 381,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "id": 384,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Maîtrise de Soi",
+            "is_unique": true,
+            "name": "•L3–37",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "STRESS"
+                            "name": "Scum and Villainy",
+                            "pk": 3
                         },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -26293,7 +26329,47 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                1
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir lancé des dés, vous pouvez dépenser 1 marqueur vert pour relancer jusqu’à 2 de vos résultats.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_159",
+            "force_side": null,
+            "id": 385,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26316,6 +26392,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Tobias Beckett",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Tant que vous vous déplacez et effectuez des attaques, vous ignorez les obstacles que vous verrouillez.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_161",
+            "force_side": null,
+            "id": 387,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Qi’ra",
             "restrictions": [
                 [
                     {
@@ -26369,46 +26485,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Après avoir lancé des dés, vous pouvez dépenser 1 marqueur vert pour relancer jusqu’à 2 de vos résultats.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_159",
-            "force_side": null,
-            "id": 385,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Avant de vous engager, vous pouvez effectuer une action <focus> rouge.",
             "available_actions": [],
             "available_upgrades": [],
@@ -26444,331 +26520,6 @@
             "subtitle": null,
             "upgrade_types": [
                 16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant que vous vous déplacez et effectuez des attaques, vous ignorez les obstacles que vous verrouillez.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_161",
-            "force_side": null,
-            "id": 387,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Qi’ra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir reçu un marqueur de stress, vous pouvez lancer 1 dé d’attaque pour le retirer.<return>Sur un résultat <hit>, subissez 1 dégât <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5851,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5852,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5853,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_5",
-            "force_side": null,
-            "id": 5,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Jek Porkins",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6688,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6689,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6690,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6691,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Red Six",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Vous pouvez effectuer vos attaques principales à portée 0.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6363,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6364,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6365,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6366,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6367,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_146",
-            "force_side": null,
-            "id": 146,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitaine Oicunn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7244,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7245,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7246,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7247,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Tacticien Inspiré",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Tant qu’un vaisseau ennemi à portée 0 défend, il lance un dé de défense en moins.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_7",
-            "force_side": null,
-            "id": 236,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Intimidation",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Après avoir effectué une action <focus>, gagnez 1 marqueur de concentration.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_46",
-            "force_side": null,
-            "id": 275,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Copilote Perspicace",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Vous pouvez effectuer des attaques contre des vaisseaux alliés.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_145",
-            "force_side": null,
-            "id": 370,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•R5-TK",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26818,6 +26569,255 @@
             "subtitle": null,
             "upgrade_types": [
                 15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Après avoir effectué une action <coordinate>, vous pouvez choisir un vaisseau ennemi à portée 0–3 du vaisseau coordonné. Dans ce cas, verrouillez ce vaisseau ennemi, en ignorant toute restriction de portée.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_124",
+            "force_side": null,
+            "id": 391,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>ST-321</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 26,
+                            "raw_name": "Lambda-class T-4a Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bombe</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1<nonbreak><standardcharge> pour larguer une sous-munition avec le gabarit [1<nonbreak><straight>].<return>Au début de la phase d’activation, vous pouvez dépenser 1 bouclier pour récupérer 2 <standardcharge>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_63",
+            "force_side": null,
+            "id": 392,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Générateur de Sous-Munitions",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6622,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12,
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mine</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1 <standardcharge> pour larguer un filet Conner en utilisant le gabarit [1<nonbreak><straight>].<return>La <standardcharge> de cette carte ne peut pas être récupérée.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_64",
+            "force_side": null,
+            "id": 393,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Filet Conner",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6630,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bombe</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1<nonbreak><standardcharge> pour larguer une bombe à protons en utilisant le gabarit [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_65",
+            "force_side": null,
+            "id": 394,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Bombe à Protons",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6655,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mine</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1 <standardcharge> pour larguer une mine de proximité en utilisant le gabarit [1<nonbreak><straight>].<return>Les <standardcharge> de cette carte ne peuvent pas être récupérées.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_66",
+            "force_side": null,
+            "id": 395,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Mine de Proximité",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6662,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bombe</bitalic><return>Pendant la phase de système, vous pouvez dépenser 1 <standardcharge> pour larguer une charge sismique en utilisant le gabarit [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_67",
+            "force_side": null,
+            "id": 396,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Charges Sismiques",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6666,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
             ],
             "weapon_no_bonus": false,
             "weapon_range": null

--- a/translation_helper/api_export_fr.json
+++ b/translation_helper/api_export_fr.json
@@ -6,21 +6,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 6673,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 6674,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 6675,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -53,25 +53,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 7588,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 7589,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 7590,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 7591,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -88,21 +88,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5842,
+                    "id": 6676,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5843,
+                    "id": 6677,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5844,
+                    "id": 6678,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -134,31 +134,31 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6675,
+                    "id": 7592,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6676,
+                    "id": 7593,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6677,
+                    "id": 7594,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6678,
+                    "id": 7595,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 6679,
+                    "id": 7596,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -175,21 +175,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 6679,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 6680,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 6681,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -221,25 +221,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 7597,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 7598,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 7599,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 7600,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -256,21 +256,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5848,
+                    "id": 6682,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5849,
+                    "id": 6683,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5850,
+                    "id": 6684,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -303,25 +303,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6684,
+                    "id": 7601,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6685,
+                    "id": 7602,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6686,
+                    "id": 7603,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6687,
+                    "id": 7604,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -338,21 +338,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5851,
+                    "id": 6685,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5852,
+                    "id": 6686,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5853,
+                    "id": 6687,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -384,25 +384,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6688,
+                    "id": 7605,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6689,
+                    "id": 7606,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6690,
+                    "id": 7607,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6691,
+                    "id": 7608,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -419,21 +419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5854,
+                    "id": 6688,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5855,
+                    "id": 6689,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5856,
+                    "id": 6690,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -466,25 +466,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6692,
+                    "id": 7609,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6693,
+                    "id": 7610,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6694,
+                    "id": 7611,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6695,
+                    "id": 7612,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -501,21 +501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5857,
+                    "id": 6691,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5858,
+                    "id": 6692,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5859,
+                    "id": 6693,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -547,25 +547,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6696,
+                    "id": 7613,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6697,
+                    "id": 7614,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6698,
+                    "id": 7615,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6699,
+                    "id": 7616,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -582,21 +582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 6694,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 6695,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 6696,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -629,25 +629,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 7617,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6701,
+                    "id": 7618,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 7619,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6703,
+                    "id": 7620,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -664,21 +664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5863,
+                    "id": 6697,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5864,
+                    "id": 6698,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5865,
+                    "id": 6699,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -710,25 +710,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6704,
+                    "id": 7621,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6705,
+                    "id": 7622,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6706,
+                    "id": 7623,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6707,
+                    "id": 7624,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -745,21 +745,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5866,
+                    "id": 6700,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5867,
+                    "id": 6701,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5868,
+                    "id": 6702,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -793,25 +793,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6708,
+                    "id": 7625,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6709,
+                    "id": 7626,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6710,
+                    "id": 7627,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6711,
+                    "id": 7628,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -828,21 +828,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5869,
+                    "id": 6703,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5870,
+                    "id": 6704,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5871,
+                    "id": 6705,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -875,25 +875,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6712,
+                    "id": 7629,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6713,
+                    "id": 7630,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6714,
+                    "id": 7631,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6715,
+                    "id": 7632,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -910,21 +910,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5872,
+                    "id": 6706,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5873,
+                    "id": 6707,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5874,
+                    "id": 6708,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -956,25 +956,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6716,
+                    "id": 7633,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6717,
+                    "id": 7634,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6718,
+                    "id": 7635,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6719,
+                    "id": 7636,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -991,28 +991,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5875,
+                    "id": 6709,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5876,
+                    "id": 6710,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5877,
+                    "id": 6711,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5878,
+                    "id": 6712,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1046,25 +1046,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6720,
+                    "id": 7637,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6721,
+                    "id": 7638,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6722,
+                    "id": 7639,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6723,
+                    "id": 7640,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1081,28 +1081,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5879,
+                    "id": 6713,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5880,
+                    "id": 6714,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5881,
+                    "id": 6715,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5882,
+                    "id": 6716,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1137,25 +1137,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6724,
+                    "id": 7641,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6725,
+                    "id": 7642,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6726,
+                    "id": 7643,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6727,
+                    "id": 7644,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1172,28 +1172,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5883,
+                    "id": 6717,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5884,
+                    "id": 6718,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5885,
+                    "id": 6719,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5886,
+                    "id": 6720,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1228,25 +1228,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6728,
+                    "id": 7645,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6729,
+                    "id": 7646,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6730,
+                    "id": 7647,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6731,
+                    "id": 7648,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1263,28 +1263,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 6721,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 6722,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 6723,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 6724,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1318,25 +1318,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 7649,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 7650,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 7651,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 7652,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1353,28 +1353,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5891,
+                    "id": 6725,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5892,
+                    "id": 6726,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5893,
+                    "id": 6727,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5894,
+                    "id": 6728,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1409,25 +1409,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6736,
+                    "id": 7653,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6737,
+                    "id": 7654,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6738,
+                    "id": 7655,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6739,
+                    "id": 7656,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1444,28 +1444,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 6729,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 6730,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "id": 6731,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "id": 6732,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1499,25 +1499,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 7657,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 7658,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6742,
+                    "id": 7659,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6743,
+                    "id": 7660,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1534,35 +1534,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5899,
+                    "id": 6733,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5900,
+                    "id": 6734,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5901,
+                    "id": 6735,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5902,
+                    "id": 6736,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5903,
+                    "id": 6737,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1591,25 +1591,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6744,
+                    "id": 7661,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6745,
+                    "id": 7662,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6746,
+                    "id": 7663,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6747,
+                    "id": 7664,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1626,35 +1626,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
+                    "id": 6738,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5905,
+                    "id": 6739,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 6740,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
+                    "id": 6741,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 6742,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1683,25 +1683,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 7665,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 7666,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6750,
+                    "id": 7667,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 7668,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1718,35 +1718,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5909,
+                    "id": 6743,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5910,
+                    "id": 6744,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5911,
+                    "id": 6745,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5912,
+                    "id": 6746,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5913,
+                    "id": 6747,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1775,25 +1775,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6752,
+                    "id": 7669,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6753,
+                    "id": 7670,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6754,
+                    "id": 7671,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6755,
+                    "id": 7672,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1810,35 +1810,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5914,
+                    "id": 6748,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5915,
+                    "id": 6749,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5916,
+                    "id": 6750,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5917,
+                    "id": 6751,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5918,
+                    "id": 6752,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1866,25 +1866,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6756,
+                    "id": 7673,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6757,
+                    "id": 7674,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6758,
+                    "id": 7675,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6759,
+                    "id": 7676,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1901,21 +1901,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5919,
+                    "id": 6753,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5920,
+                    "id": 6754,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5921,
+                    "id": 6755,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1948,25 +1948,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6760,
+                    "id": 7677,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6761,
+                    "id": 7678,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6762,
+                    "id": 7679,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6763,
+                    "id": 7680,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -1983,21 +1983,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5922,
+                    "id": 6756,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5923,
+                    "id": 6757,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5924,
+                    "id": 6758,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2030,25 +2030,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6764,
+                    "id": 7681,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6765,
+                    "id": 7682,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6766,
+                    "id": 7683,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6767,
+                    "id": 7684,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2065,21 +2065,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5925,
+                    "id": 6759,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5926,
+                    "id": 6760,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5927,
+                    "id": 6761,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2112,25 +2112,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6768,
+                    "id": 7685,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6769,
+                    "id": 7686,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6770,
+                    "id": 7687,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6771,
+                    "id": 7688,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2147,21 +2147,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5928,
+                    "id": 6762,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5929,
+                    "id": 6763,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5930,
+                    "id": 6764,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2193,25 +2193,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6772,
+                    "id": 7689,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6773,
+                    "id": 7690,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6774,
+                    "id": 7691,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6775,
+                    "id": 7692,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2228,21 +2228,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5931,
+                    "id": 6765,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5932,
+                    "id": 6766,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5933,
+                    "id": 6767,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2272,25 +2272,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6776,
+                    "id": 7693,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6777,
+                    "id": 7694,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6778,
+                    "id": 7695,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6779,
+                    "id": 7696,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2307,21 +2307,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5934,
+                    "id": 6768,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5935,
+                    "id": 6769,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5936,
+                    "id": 6770,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2351,25 +2351,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6780,
+                    "id": 7697,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6781,
+                    "id": 7698,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6782,
+                    "id": 7699,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6783,
+                    "id": 7700,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2386,21 +2386,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5937,
+                    "id": 6771,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5938,
+                    "id": 6772,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5939,
+                    "id": 6773,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2430,25 +2430,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6784,
+                    "id": 7701,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6785,
+                    "id": 7702,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6786,
+                    "id": 7703,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6787,
+                    "id": 7704,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2465,21 +2465,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5940,
+                    "id": 6774,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5941,
+                    "id": 6775,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5942,
+                    "id": 6776,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2508,25 +2508,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6788,
+                    "id": 7705,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6789,
+                    "id": 7706,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6790,
+                    "id": 7707,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6791,
+                    "id": 7708,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2543,21 +2543,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5943,
+                    "id": 6777,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5944,
+                    "id": 6778,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5945,
+                    "id": 6779,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2588,25 +2588,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6792,
+                    "id": 7709,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6793,
+                    "id": 7710,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6794,
+                    "id": 7711,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6795,
+                    "id": 7712,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2623,21 +2623,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5946,
+                    "id": 6780,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5947,
+                    "id": 6781,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5948,
+                    "id": 6782,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2668,25 +2668,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6796,
+                    "id": 7713,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6797,
+                    "id": 7714,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6798,
+                    "id": 7715,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6799,
+                    "id": 7716,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2703,21 +2703,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5949,
+                    "id": 6783,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5950,
+                    "id": 6784,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5951,
+                    "id": 6785,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2747,25 +2747,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6800,
+                    "id": 7717,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6801,
+                    "id": 7718,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6802,
+                    "id": 7719,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6803,
+                    "id": 7720,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2782,21 +2782,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5952,
+                    "id": 6786,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5953,
+                    "id": 6787,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5954,
+                    "id": 6788,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2828,25 +2828,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6804,
+                    "id": 7721,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6805,
+                    "id": 7722,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6806,
+                    "id": 7723,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6807,
+                    "id": 7724,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2863,21 +2863,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5955,
+                    "id": 6789,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5956,
+                    "id": 6790,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5957,
+                    "id": 6791,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2909,25 +2909,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6808,
+                    "id": 7725,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6809,
+                    "id": 7726,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6810,
+                    "id": 7727,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6811,
+                    "id": 7728,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2944,21 +2944,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5958,
+                    "id": 6792,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5959,
+                    "id": 6793,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5960,
+                    "id": 6794,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2990,31 +2990,31 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6812,
+                    "id": 7729,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6813,
+                    "id": 7730,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6814,
+                    "id": 7731,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6815,
+                    "id": 7732,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6816,
+                    "id": 7733,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3031,21 +3031,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5961,
+                    "id": 6795,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5962,
+                    "id": 6796,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5963,
+                    "id": 6797,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -3076,25 +3076,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6817,
+                    "id": 7734,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6818,
+                    "id": 7735,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6819,
+                    "id": 7736,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6820,
+                    "id": 7737,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3111,14 +3111,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5964,
+                    "id": 6798,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5965,
+                    "id": 6799,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3150,31 +3150,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6821,
+                    "id": 7738,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6822,
+                    "id": 7739,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6823,
+                    "id": 7740,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6824,
+                    "id": 7741,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6825,
+                    "id": 7742,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3191,14 +3191,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5966,
+                    "id": 6800,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5967,
+                    "id": 6801,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3230,37 +3230,37 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6826,
+                    "id": 7743,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6827,
+                    "id": 7744,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6828,
+                    "id": 7745,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6829,
+                    "id": 7746,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6830,
+                    "id": 7747,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6831,
+                    "id": 7748,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3277,14 +3277,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5968,
+                    "id": 6802,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5969,
+                    "id": 6803,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3316,31 +3316,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6832,
+                    "id": 7749,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6833,
+                    "id": 7750,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6834,
+                    "id": 7751,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6835,
+                    "id": 7752,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6836,
+                    "id": 7753,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3357,14 +3357,14 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 5970,
+                    "id": 6804,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5971,
+                    "id": 6805,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3396,31 +3396,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6837,
+                    "id": 7754,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6838,
+                    "id": 7755,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6839,
+                    "id": 7756,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6840,
+                    "id": 7757,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6841,
+                    "id": 7758,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3437,35 +3437,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5972,
+                    "id": 6806,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5973,
+                    "id": 6807,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5974,
+                    "id": 6808,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5975,
+                    "id": 6809,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5976,
+                    "id": 6810,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3498,25 +3498,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6842,
+                    "id": 7759,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6843,
+                    "id": 7760,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6844,
+                    "id": 7761,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6845,
+                    "id": 7762,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3533,35 +3533,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5977,
+                    "id": 6811,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5978,
+                    "id": 6812,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5979,
+                    "id": 6813,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5980,
+                    "id": 6814,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5981,
+                    "id": 6815,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3594,25 +3594,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6846,
+                    "id": 7763,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6847,
+                    "id": 7764,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6848,
+                    "id": 7765,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6849,
+                    "id": 7766,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3629,35 +3629,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5982,
+                    "id": 6816,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5983,
+                    "id": 6817,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5984,
+                    "id": 6818,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5985,
+                    "id": 6819,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5986,
+                    "id": 6820,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3690,25 +3690,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6850,
+                    "id": 7767,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6851,
+                    "id": 7768,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6852,
+                    "id": 7769,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6853,
+                    "id": 7770,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3725,35 +3725,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5987,
+                    "id": 6821,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5988,
+                    "id": 6822,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5989,
+                    "id": 6823,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5990,
+                    "id": 6824,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5991,
+                    "id": 6825,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3785,25 +3785,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6854,
+                    "id": 7771,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6855,
+                    "id": 7772,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6856,
+                    "id": 7773,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6857,
+                    "id": 7774,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3820,21 +3820,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5992,
+                    "id": 6826,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5993,
+                    "id": 6827,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5994,
+                    "id": 6828,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3863,25 +3863,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6858,
+                    "id": 7775,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6859,
+                    "id": 7776,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6860,
+                    "id": 7777,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6861,
+                    "id": 7778,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3898,21 +3898,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5995,
+                    "id": 6829,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5996,
+                    "id": 6830,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5997,
+                    "id": 6831,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3941,19 +3941,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6862,
+                    "id": 7779,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6863,
+                    "id": 7780,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6864,
+                    "id": 7781,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -3970,21 +3970,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5998,
+                    "id": 6832,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5999,
+                    "id": 6833,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6000,
+                    "id": 6834,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4012,19 +4012,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6865,
+                    "id": 7782,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6866,
+                    "id": 7783,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6867,
+                    "id": 7784,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4041,21 +4041,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6001,
+                    "id": 6835,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6002,
+                    "id": 6836,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6003,
+                    "id": 6837,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4083,19 +4083,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6868,
+                    "id": 7785,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6869,
+                    "id": 7786,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6870,
+                    "id": 7787,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4112,35 +4112,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6004,
+                    "id": 6838,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6005,
+                    "id": 6839,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6006,
+                    "id": 6840,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6007,
+                    "id": 6841,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6008,
+                    "id": 6842,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4172,25 +4172,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6871,
+                    "id": 7788,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6872,
+                    "id": 7789,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6873,
+                    "id": 7790,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6874,
+                    "id": 7791,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4207,35 +4207,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6009,
+                    "id": 6843,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6010,
+                    "id": 6844,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6011,
+                    "id": 6845,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6012,
+                    "id": 6846,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6013,
+                    "id": 6847,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4267,25 +4267,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6875,
+                    "id": 7792,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6876,
+                    "id": 7793,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6877,
+                    "id": 7794,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6878,
+                    "id": 7795,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4302,35 +4302,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6014,
+                    "id": 6848,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6015,
+                    "id": 6849,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6016,
+                    "id": 6850,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6017,
+                    "id": 6851,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6018,
+                    "id": 6852,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4362,25 +4362,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6879,
+                    "id": 7796,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6880,
+                    "id": 7797,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6881,
+                    "id": 7798,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6882,
+                    "id": 7799,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4397,35 +4397,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6019,
+                    "id": 6853,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6020,
+                    "id": 6854,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6021,
+                    "id": 6855,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6022,
+                    "id": 6856,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6023,
+                    "id": 6857,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4456,25 +4456,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6883,
+                    "id": 7800,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6884,
+                    "id": 7801,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6885,
+                    "id": 7802,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6886,
+                    "id": 7803,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4491,21 +4491,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6024,
+                    "id": 6858,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6025,
+                    "id": 6859,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6026,
+                    "id": 6860,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4538,25 +4538,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6887,
+                    "id": 7804,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6888,
+                    "id": 7805,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6889,
+                    "id": 7806,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6890,
+                    "id": 7807,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4573,21 +4573,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6861,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6862,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "id": 6863,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4621,25 +4621,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6891,
+                    "id": 7808,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6892,
+                    "id": 7809,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6893,
+                    "id": 7810,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6894,
+                    "id": 7811,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4656,21 +4656,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6030,
+                    "id": 6864,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6031,
+                    "id": 6865,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6032,
+                    "id": 6866,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4703,25 +4703,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6895,
+                    "id": 7812,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6896,
+                    "id": 7813,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6897,
+                    "id": 7814,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6898,
+                    "id": 7815,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4738,21 +4738,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6033,
+                    "id": 6867,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6034,
+                    "id": 6868,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6035,
+                    "id": 6869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4786,25 +4786,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6899,
+                    "id": 7816,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6900,
+                    "id": 7817,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6901,
+                    "id": 7818,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6902,
+                    "id": 7819,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4821,21 +4821,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6036,
+                    "id": 6870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6037,
+                    "id": 6871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6038,
+                    "id": 6872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4868,25 +4868,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6903,
+                    "id": 7820,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6904,
+                    "id": 7821,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6905,
+                    "id": 7822,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6906,
+                    "id": 7823,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4903,21 +4903,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6039,
+                    "id": 6873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6040,
+                    "id": 6874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6041,
+                    "id": 6875,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4950,25 +4950,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6907,
+                    "id": 7824,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6908,
+                    "id": 7825,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6909,
+                    "id": 7826,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6910,
+                    "id": 7827,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4985,21 +4985,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6042,
+                    "id": 6876,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6043,
+                    "id": 6877,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6044,
+                    "id": 6878,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5031,25 +5031,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6911,
+                    "id": 7828,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6912,
+                    "id": 7829,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6913,
+                    "id": 7830,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6914,
+                    "id": 7831,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5066,21 +5066,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6045,
+                    "id": 6879,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6046,
+                    "id": 6880,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6047,
+                    "id": 6881,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5113,25 +5113,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6915,
+                    "id": 7832,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6916,
+                    "id": 7833,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6917,
+                    "id": 7834,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6918,
+                    "id": 7835,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5148,35 +5148,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6048,
+                    "id": 6882,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6049,
+                    "id": 6883,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6050,
+                    "id": 6884,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6051,
+                    "id": 6885,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6052,
+                    "id": 6886,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5211,25 +5211,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6919,
+                    "id": 7836,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6920,
+                    "id": 7837,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6921,
+                    "id": 7838,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6922,
+                    "id": 7839,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5246,35 +5246,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6053,
+                    "id": 6887,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6054,
+                    "id": 6888,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6055,
+                    "id": 6889,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6056,
+                    "id": 6890,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6057,
+                    "id": 6891,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5309,25 +5309,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6923,
+                    "id": 7840,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6924,
+                    "id": 7841,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6925,
+                    "id": 7842,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6926,
+                    "id": 7843,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5344,35 +5344,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6058,
+                    "id": 6892,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6059,
+                    "id": 6893,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6060,
+                    "id": 6894,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6061,
+                    "id": 6895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6062,
+                    "id": 6896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5407,25 +5407,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6927,
+                    "id": 7844,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6928,
+                    "id": 7845,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6929,
+                    "id": 7846,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6930,
+                    "id": 7847,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5442,21 +5442,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6063,
+                    "id": 6897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6064,
+                    "id": 6898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6065,
+                    "id": 6899,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5489,31 +5489,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6931,
+                    "id": 7848,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6932,
+                    "id": 7849,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6933,
+                    "id": 7850,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6934,
+                    "id": 7851,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6935,
+                    "id": 7852,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5530,21 +5530,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6066,
+                    "id": 6900,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6067,
+                    "id": 6901,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6068,
+                    "id": 6902,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5577,31 +5577,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6936,
+                    "id": 7853,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6937,
+                    "id": 7854,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6938,
+                    "id": 7855,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6939,
+                    "id": 7856,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6940,
+                    "id": 7857,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5618,21 +5618,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6069,
+                    "id": 6903,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6070,
+                    "id": 6904,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6071,
+                    "id": 6905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5665,31 +5665,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6941,
+                    "id": 7858,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6942,
+                    "id": 7859,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6943,
+                    "id": 7860,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6944,
+                    "id": 7861,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6945,
+                    "id": 7862,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5706,21 +5706,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6072,
+                    "id": 6906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6073,
+                    "id": 6907,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6074,
+                    "id": 6908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5753,31 +5753,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6946,
+                    "id": 7863,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6947,
+                    "id": 7864,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6948,
+                    "id": 7865,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6949,
+                    "id": 7866,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6950,
+                    "id": 7867,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5794,28 +5794,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6075,
+                    "id": 6909,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6076,
+                    "id": 6910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6077,
+                    "id": 6911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6078,
+                    "id": 6912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5850,25 +5850,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6951,
+                    "id": 7868,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6952,
+                    "id": 7869,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6953,
+                    "id": 7870,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6954,
+                    "id": 7871,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5885,28 +5885,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6079,
+                    "id": 6913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6080,
+                    "id": 6914,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6081,
+                    "id": 6915,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6082,
+                    "id": 6916,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5941,25 +5941,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6955,
+                    "id": 7872,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6956,
+                    "id": 7873,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6957,
+                    "id": 7874,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6958,
+                    "id": 7875,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5976,28 +5976,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6083,
+                    "id": 6917,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6084,
+                    "id": 6918,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6085,
+                    "id": 6919,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6086,
+                    "id": 6920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6032,31 +6032,31 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6959,
+                    "id": 7876,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6960,
+                    "id": 7877,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6961,
+                    "id": 7878,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6962,
+                    "id": 7879,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
                 },
                 {
-                    "id": 6963,
+                    "id": 7880,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -6073,28 +6073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6087,
+                    "id": 6921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6088,
+                    "id": 6922,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6089,
+                    "id": 6923,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6090,
+                    "id": 6924,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6128,25 +6128,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6964,
+                    "id": 7881,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6965,
+                    "id": 7882,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6966,
+                    "id": 7883,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6967,
+                    "id": 7884,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -6163,21 +6163,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6091,
+                    "id": 6925,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6092,
+                    "id": 6926,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6093,
+                    "id": 6927,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6212,25 +6212,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6968,
+                    "id": 7885,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6969,
+                    "id": 7886,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6970,
+                    "id": 7887,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6971,
+                    "id": 7888,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6247,21 +6247,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6094,
+                    "id": 6928,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6095,
+                    "id": 6929,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6096,
+                    "id": 6930,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6296,31 +6296,31 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6972,
+                    "id": 7889,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6973,
+                    "id": 7890,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6974,
+                    "id": 7891,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6975,
+                    "id": 7892,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 6976,
+                    "id": 7893,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -6337,21 +6337,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6097,
+                    "id": 6931,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6098,
+                    "id": 6932,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6099,
+                    "id": 6933,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6385,25 +6385,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6977,
+                    "id": 7894,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6978,
+                    "id": 7895,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6979,
+                    "id": 7896,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6980,
+                    "id": 7897,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6420,21 +6420,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6100,
+                    "id": 6934,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6101,
+                    "id": 6935,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6102,
+                    "id": 6936,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6468,25 +6468,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6981,
+                    "id": 7898,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6982,
+                    "id": 7899,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6983,
+                    "id": 7900,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6984,
+                    "id": 7901,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6503,28 +6503,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6103,
+                    "id": 6937,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6104,
+                    "id": 6938,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6105,
+                    "id": 6939,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6106,
+                    "id": 6940,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6558,25 +6558,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6985,
+                    "id": 7902,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6986,
+                    "id": 7903,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6987,
+                    "id": 7904,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6988,
+                    "id": 7905,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6593,28 +6593,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6107,
+                    "id": 6941,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6108,
+                    "id": 6942,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6109,
+                    "id": 6943,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6110,
+                    "id": 6944,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6647,25 +6647,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6989,
+                    "id": 7906,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6990,
+                    "id": 7907,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6991,
+                    "id": 7908,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6992,
+                    "id": 7909,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6682,28 +6682,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6111,
+                    "id": 6945,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6112,
+                    "id": 6946,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6113,
+                    "id": 6947,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6114,
+                    "id": 6948,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6736,25 +6736,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6993,
+                    "id": 7910,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6994,
+                    "id": 7911,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6995,
+                    "id": 7912,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6996,
+                    "id": 7913,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6771,21 +6771,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6115,
+                    "id": 6949,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6116,
+                    "id": 6950,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6117,
+                    "id": 6951,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6815,19 +6815,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6997,
+                    "id": 7914,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6998,
+                    "id": 7915,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6999,
+                    "id": 7916,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6844,21 +6844,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6118,
+                    "id": 6952,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6119,
+                    "id": 6953,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6120,
+                    "id": 6954,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6888,19 +6888,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7000,
+                    "id": 7917,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7001,
+                    "id": 7918,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7002,
+                    "id": 7919,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6917,21 +6917,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6121,
+                    "id": 6955,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6122,
+                    "id": 6956,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6123,
+                    "id": 6957,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6961,19 +6961,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7003,
+                    "id": 7920,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7004,
+                    "id": 7921,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7005,
+                    "id": 7922,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6990,21 +6990,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6124,
+                    "id": 6958,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6125,
+                    "id": 6959,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6126,
+                    "id": 6960,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7033,25 +7033,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7006,
+                    "id": 7923,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7007,
+                    "id": 7924,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7008,
+                    "id": 7925,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7009,
+                    "id": 7926,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -7068,21 +7068,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6127,
+                    "id": 6961,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6128,
+                    "id": 6962,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6129,
+                    "id": 6963,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7111,19 +7111,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7010,
+                    "id": 7927,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7011,
+                    "id": 7928,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7012,
+                    "id": 7929,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7140,21 +7140,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6130,
+                    "id": 6964,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6131,
+                    "id": 6965,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6132,
+                    "id": 6966,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7183,19 +7183,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7013,
+                    "id": 7930,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7014,
+                    "id": 7931,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7015,
+                    "id": 7932,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7212,21 +7212,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6133,
+                    "id": 6967,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6134,
+                    "id": 6968,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6135,
+                    "id": 6969,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7255,19 +7255,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7016,
+                    "id": 7933,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7017,
+                    "id": 7934,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7018,
+                    "id": 7935,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7284,21 +7284,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6136,
+                    "id": 6970,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6137,
+                    "id": 6971,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6138,
+                    "id": 6972,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7327,19 +7327,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7019,
+                    "id": 7936,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7020,
+                    "id": 7937,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7021,
+                    "id": 7938,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7356,21 +7356,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6139,
+                    "id": 6973,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6140,
+                    "id": 6974,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6141,
+                    "id": 6975,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7398,19 +7398,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7022,
+                    "id": 7939,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7023,
+                    "id": 7940,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7024,
+                    "id": 7941,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7427,21 +7427,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6142,
+                    "id": 6976,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6143,
+                    "id": 6977,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6144,
+                    "id": 6978,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7470,25 +7470,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7025,
+                    "id": 7942,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7026,
+                    "id": 7943,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7027,
+                    "id": 7944,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7028,
+                    "id": 7945,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -7505,21 +7505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6145,
+                    "id": 6979,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6146,
+                    "id": 6980,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6147,
+                    "id": 6981,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7550,19 +7550,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7029,
+                    "id": 7946,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7030,
+                    "id": 7947,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7031,
+                    "id": 7948,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7579,21 +7579,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6148,
+                    "id": 6982,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6149,
+                    "id": 6983,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6150,
+                    "id": 6984,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7623,19 +7623,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7032,
+                    "id": 7949,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7033,
+                    "id": 7950,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7034,
+                    "id": 7951,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7652,21 +7652,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6151,
+                    "id": 6985,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6152,
+                    "id": 6986,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6153,
+                    "id": 6987,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7696,19 +7696,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7035,
+                    "id": 7952,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7036,
+                    "id": 7953,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7037,
+                    "id": 7954,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7725,21 +7725,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6154,
+                    "id": 6988,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6155,
+                    "id": 6989,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6156,
+                    "id": 6990,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7771,31 +7771,31 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7038,
+                    "id": 7955,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7039,
+                    "id": 7956,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7040,
+                    "id": 7957,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7041,
+                    "id": 7958,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7042,
+                    "id": 7959,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "3"
@@ -7812,21 +7812,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6157,
+                    "id": 6991,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6158,
+                    "id": 6992,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6159,
+                    "id": 6993,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7858,25 +7858,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7043,
+                    "id": 7960,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7044,
+                    "id": 7961,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7045,
+                    "id": 7962,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7046,
+                    "id": 7963,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7893,21 +7893,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6160,
+                    "id": 6994,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6161,
+                    "id": 6995,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6162,
+                    "id": 6996,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7938,25 +7938,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7047,
+                    "id": 7964,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7048,
+                    "id": 7965,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7049,
+                    "id": 7966,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7050,
+                    "id": 7967,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7973,21 +7973,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6163,
+                    "id": 6997,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6164,
+                    "id": 6998,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6165,
+                    "id": 6999,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8018,25 +8018,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7051,
+                    "id": 7968,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7052,
+                    "id": 7969,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7053,
+                    "id": 7970,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7054,
+                    "id": 7971,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8053,21 +8053,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6166,
+                    "id": 7000,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6167,
+                    "id": 7001,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6168,
+                    "id": 7002,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8099,25 +8099,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7055,
+                    "id": 7972,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7056,
+                    "id": 7973,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7057,
+                    "id": 7974,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7058,
+                    "id": 7975,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8134,21 +8134,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6169,
+                    "id": 7003,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6170,
+                    "id": 7004,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6171,
+                    "id": 7005,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8179,25 +8179,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7059,
+                    "id": 7976,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7060,
+                    "id": 7977,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7061,
+                    "id": 7978,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7062,
+                    "id": 7979,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8214,35 +8214,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6172,
+                    "id": 7006,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6173,
+                    "id": 7007,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6174,
+                    "id": 7008,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6175,
+                    "id": 7009,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6176,
+                    "id": 7010,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8272,31 +8272,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7063,
+                    "id": 7980,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7064,
+                    "id": 7981,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7065,
+                    "id": 7982,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7066,
+                    "id": 7983,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7067,
+                    "id": 7984,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8313,35 +8313,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6177,
+                    "id": 7011,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6178,
+                    "id": 7012,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6179,
+                    "id": 7013,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6180,
+                    "id": 7014,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6181,
+                    "id": 7015,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8371,31 +8371,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7068,
+                    "id": 7985,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7069,
+                    "id": 7986,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7070,
+                    "id": 7987,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7071,
+                    "id": 7988,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7072,
+                    "id": 7989,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8412,35 +8412,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6182,
+                    "id": 7016,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6183,
+                    "id": 7017,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6184,
+                    "id": 7018,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6185,
+                    "id": 7019,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6186,
+                    "id": 7020,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8470,25 +8470,25 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7073,
+                    "id": 7990,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7074,
+                    "id": 7991,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7075,
+                    "id": 7992,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7076,
+                    "id": 7993,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8505,35 +8505,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6187,
+                    "id": 7021,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6188,
+                    "id": 7022,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6189,
+                    "id": 7023,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6190,
+                    "id": 7024,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6191,
+                    "id": 7025,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8563,31 +8563,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7994,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7078,
+                    "id": 7995,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7996,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7080,
+                    "id": 7997,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7081,
+                    "id": 7998,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -8604,28 +8604,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6192,
+                    "id": 7026,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6193,
+                    "id": 7027,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6194,
+                    "id": 7028,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6195,
+                    "id": 7029,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8655,19 +8655,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7082,
+                    "id": 7999,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7083,
+                    "id": 8000,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7084,
+                    "id": 8001,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8684,28 +8684,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6196,
+                    "id": 7030,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6197,
+                    "id": 7031,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6198,
+                    "id": 7032,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6199,
+                    "id": 7033,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8735,19 +8735,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7085,
+                    "id": 8002,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7086,
+                    "id": 8003,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7087,
+                    "id": 8004,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8764,28 +8764,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6200,
+                    "id": 7034,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6201,
+                    "id": 7035,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6202,
+                    "id": 7036,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6203,
+                    "id": 7037,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8815,19 +8815,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7088,
+                    "id": 8005,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7089,
+                    "id": 8006,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7090,
+                    "id": 8007,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8844,28 +8844,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6204,
+                    "id": 7038,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6205,
+                    "id": 7039,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6206,
+                    "id": 7040,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6207,
+                    "id": 7041,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8894,19 +8894,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7091,
+                    "id": 8008,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7092,
+                    "id": 8009,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7093,
+                    "id": 8010,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8923,28 +8923,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6208,
+                    "id": 7042,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6209,
+                    "id": 7043,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6210,
+                    "id": 7044,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6211,
+                    "id": 7045,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8979,19 +8979,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7094,
+                    "id": 8011,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7095,
+                    "id": 8012,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7096,
+                    "id": 8013,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9008,28 +9008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6212,
+                    "id": 7046,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6213,
+                    "id": 7047,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6214,
+                    "id": 7048,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6215,
+                    "id": 7049,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9064,19 +9064,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7097,
+                    "id": 8014,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7098,
+                    "id": 8015,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7099,
+                    "id": 8016,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9093,28 +9093,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6216,
+                    "id": 7050,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6217,
+                    "id": 7051,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6218,
+                    "id": 7052,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6219,
+                    "id": 7053,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9149,19 +9149,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7100,
+                    "id": 8017,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7101,
+                    "id": 8018,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7102,
+                    "id": 8019,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9178,28 +9178,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6220,
+                    "id": 7054,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6221,
+                    "id": 7055,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6222,
+                    "id": 7056,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6223,
+                    "id": 7057,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9233,19 +9233,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7103,
+                    "id": 8020,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7104,
+                    "id": 8021,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7105,
+                    "id": 8022,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9262,28 +9262,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6224,
+                    "id": 7058,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6225,
+                    "id": 7059,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6226,
+                    "id": 7060,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6227,
+                    "id": 7061,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9318,19 +9318,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7106,
+                    "id": 8023,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7107,
+                    "id": 8024,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7108,
+                    "id": 8025,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9347,28 +9347,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6228,
+                    "id": 7062,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6229,
+                    "id": 7063,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6230,
+                    "id": 7064,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6231,
+                    "id": 7065,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9402,19 +9402,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7109,
+                    "id": 8026,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7110,
+                    "id": 8027,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7111,
+                    "id": 8028,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9431,28 +9431,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6232,
+                    "id": 7066,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6233,
+                    "id": 7067,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6234,
+                    "id": 7068,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6235,
+                    "id": 7069,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9483,25 +9483,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7112,
+                    "id": 8029,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7113,
+                    "id": 8030,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7114,
+                    "id": 8031,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7115,
+                    "id": 8032,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9518,28 +9518,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6236,
+                    "id": 7070,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6237,
+                    "id": 7071,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6238,
+                    "id": 7072,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6239,
+                    "id": 7073,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9570,25 +9570,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7116,
+                    "id": 8033,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7117,
+                    "id": 8034,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7118,
+                    "id": 8035,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7119,
+                    "id": 8036,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9605,28 +9605,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6240,
+                    "id": 7074,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6241,
+                    "id": 7075,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6242,
+                    "id": 7076,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6243,
+                    "id": 7077,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9656,25 +9656,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7120,
+                    "id": 8037,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7121,
+                    "id": 8038,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7122,
+                    "id": 8039,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7123,
+                    "id": 8040,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9691,28 +9691,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6244,
+                    "id": 7078,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6245,
+                    "id": 7079,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6246,
+                    "id": 7080,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6247,
+                    "id": 7081,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9742,25 +9742,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7124,
+                    "id": 8041,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7125,
+                    "id": 8042,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7126,
+                    "id": 8043,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7127,
+                    "id": 8044,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9777,21 +9777,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6248,
+                    "id": 7082,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6249,
+                    "id": 7083,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6250,
+                    "id": 7084,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9822,19 +9822,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7128,
+                    "id": 8045,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7129,
+                    "id": 8046,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7130,
+                    "id": 8047,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9851,21 +9851,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6251,
+                    "id": 7085,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6252,
+                    "id": 7086,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6253,
+                    "id": 7087,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9896,19 +9896,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7131,
+                    "id": 8048,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7132,
+                    "id": 8049,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7133,
+                    "id": 8050,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9925,21 +9925,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6254,
+                    "id": 7088,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6255,
+                    "id": 7089,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6256,
+                    "id": 7090,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9970,19 +9970,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7134,
+                    "id": 8051,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7135,
+                    "id": 8052,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7136,
+                    "id": 8053,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9999,21 +9999,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6257,
+                    "id": 7091,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6258,
+                    "id": 7092,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6259,
+                    "id": 7093,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10044,19 +10044,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7137,
+                    "id": 8054,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7138,
+                    "id": 8055,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7139,
+                    "id": 8056,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10073,21 +10073,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6260,
+                    "id": 7094,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6261,
+                    "id": 7095,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6262,
+                    "id": 7096,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10117,19 +10117,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7140,
+                    "id": 8057,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7141,
+                    "id": 8058,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7142,
+                    "id": 8059,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10146,35 +10146,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6263,
+                    "id": 7097,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6264,
+                    "id": 7098,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6265,
+                    "id": 7099,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6266,
+                    "id": 7100,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6267,
+                    "id": 7101,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10205,25 +10205,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7143,
+                    "id": 8060,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7144,
+                    "id": 8061,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7145,
+                    "id": 8062,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7146,
+                    "id": 8063,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10240,35 +10240,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6268,
+                    "id": 7102,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6269,
+                    "id": 7103,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6270,
+                    "id": 7104,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6271,
+                    "id": 7105,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6272,
+                    "id": 7106,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10299,25 +10299,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7147,
+                    "id": 8064,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7148,
+                    "id": 8065,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7149,
+                    "id": 8066,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7150,
+                    "id": 8067,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10334,35 +10334,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6273,
+                    "id": 7107,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6274,
+                    "id": 7108,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6275,
+                    "id": 7109,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6276,
+                    "id": 7110,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6277,
+                    "id": 7111,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10393,25 +10393,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7151,
+                    "id": 8068,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7152,
+                    "id": 8069,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7153,
+                    "id": 8070,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7154,
+                    "id": 8071,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10428,35 +10428,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6278,
+                    "id": 7112,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6279,
+                    "id": 7113,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6280,
+                    "id": 7114,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6281,
+                    "id": 7115,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6282,
+                    "id": 7116,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10487,25 +10487,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7155,
+                    "id": 8072,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7156,
+                    "id": 8073,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7157,
+                    "id": 8074,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7158,
+                    "id": 8075,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10522,35 +10522,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6283,
+                    "id": 7117,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6284,
+                    "id": 7118,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6285,
+                    "id": 7119,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6286,
+                    "id": 7120,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6287,
+                    "id": 7121,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10580,25 +10580,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7159,
+                    "id": 8076,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7160,
+                    "id": 8077,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7161,
+                    "id": 8078,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7162,
+                    "id": 8079,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10615,21 +10615,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6288,
+                    "id": 7122,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6289,
+                    "id": 7123,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6290,
+                    "id": 7124,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10662,25 +10662,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7163,
+                    "id": 8080,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7164,
+                    "id": 8081,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7165,
+                    "id": 8082,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7166,
+                    "id": 8083,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10697,21 +10697,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6291,
+                    "id": 7125,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6292,
+                    "id": 7126,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6293,
+                    "id": 7127,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10744,25 +10744,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7167,
+                    "id": 8084,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7168,
+                    "id": 8085,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7169,
+                    "id": 8086,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7170,
+                    "id": 8087,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10779,21 +10779,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6294,
+                    "id": 7128,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6295,
+                    "id": 7129,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6296,
+                    "id": 7130,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10826,25 +10826,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7171,
+                    "id": 8088,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7172,
+                    "id": 8089,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7173,
+                    "id": 8090,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7174,
+                    "id": 8091,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10861,21 +10861,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6297,
+                    "id": 7131,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6298,
+                    "id": 7132,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6299,
+                    "id": 7133,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10907,25 +10907,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7175,
+                    "id": 8092,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7176,
+                    "id": 8093,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7177,
+                    "id": 8094,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7178,
+                    "id": 8095,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10942,28 +10942,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6300,
+                    "id": 7134,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6301,
+                    "id": 7135,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6302,
+                    "id": 7136,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6303,
+                    "id": 7137,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10994,25 +10994,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7179,
+                    "id": 8096,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7180,
+                    "id": 8097,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7181,
+                    "id": 8098,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7182,
+                    "id": 8099,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11029,28 +11029,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6304,
+                    "id": 7138,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6305,
+                    "id": 7139,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6306,
+                    "id": 7140,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6307,
+                    "id": 7141,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11081,25 +11081,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7183,
+                    "id": 8100,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7184,
+                    "id": 8101,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7185,
+                    "id": 8102,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7186,
+                    "id": 8103,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11116,28 +11116,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6308,
+                    "id": 7142,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6309,
+                    "id": 7143,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6310,
+                    "id": 7144,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6311,
+                    "id": 7145,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11168,25 +11168,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7187,
+                    "id": 8104,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7188,
+                    "id": 8105,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7189,
+                    "id": 8106,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7190,
+                    "id": 8107,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11203,28 +11203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6312,
+                    "id": 7146,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6313,
+                    "id": 7147,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6314,
+                    "id": 7148,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6315,
+                    "id": 7149,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11254,25 +11254,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7191,
+                    "id": 8108,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7192,
+                    "id": 8109,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7193,
+                    "id": 8110,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7194,
+                    "id": 8111,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11289,28 +11289,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6316,
+                    "id": 7150,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6317,
+                    "id": 7151,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6318,
+                    "id": 7152,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6319,
+                    "id": 7153,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11343,25 +11343,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7195,
+                    "id": 8112,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7196,
+                    "id": 8113,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7197,
+                    "id": 8114,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7198,
+                    "id": 8115,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11378,28 +11378,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6320,
+                    "id": 7154,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6321,
+                    "id": 7155,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6322,
+                    "id": 7156,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6323,
+                    "id": 7157,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11432,25 +11432,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7199,
+                    "id": 8116,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7200,
+                    "id": 8117,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7201,
+                    "id": 8118,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7202,
+                    "id": 8119,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11467,28 +11467,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6324,
+                    "id": 7158,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6325,
+                    "id": 7159,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6326,
+                    "id": 7160,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6327,
+                    "id": 7161,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11521,25 +11521,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7203,
+                    "id": 8120,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7204,
+                    "id": 8121,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7205,
+                    "id": 8122,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7206,
+                    "id": 8123,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11556,28 +11556,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6328,
+                    "id": 7162,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6329,
+                    "id": 7163,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6330,
+                    "id": 7164,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6331,
+                    "id": 7165,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11609,25 +11609,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7207,
+                    "id": 8124,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7208,
+                    "id": 8125,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7209,
+                    "id": 8126,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7210,
+                    "id": 8127,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11644,35 +11644,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6332,
+                    "id": 7166,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6333,
+                    "id": 7167,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6334,
+                    "id": 7168,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6335,
+                    "id": 7169,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6336,
+                    "id": 7170,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11707,25 +11707,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7211,
+                    "id": 8128,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7212,
+                    "id": 8129,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7213,
+                    "id": 8130,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7214,
+                    "id": 8131,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11742,35 +11742,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6337,
+                    "id": 7171,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6338,
+                    "id": 7172,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6339,
+                    "id": 7173,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6340,
+                    "id": 7174,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6341,
+                    "id": 7175,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11805,25 +11805,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7215,
+                    "id": 8132,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7216,
+                    "id": 8133,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7217,
+                    "id": 8134,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7218,
+                    "id": 8135,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11840,35 +11840,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6342,
+                    "id": 7176,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6343,
+                    "id": 7177,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6344,
+                    "id": 7178,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6345,
+                    "id": 7179,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6346,
+                    "id": 7180,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11903,25 +11903,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7219,
+                    "id": 8136,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7220,
+                    "id": 8137,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7221,
+                    "id": 8138,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7222,
+                    "id": 8139,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11938,28 +11938,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6347,
+                    "id": 7181,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6348,
+                    "id": 7182,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6349,
+                    "id": 7183,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6350,
+                    "id": 7184,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11992,31 +11992,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7223,
+                    "id": 8140,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7224,
+                    "id": 8141,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7225,
+                    "id": 8142,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7226,
+                    "id": 8143,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7227,
+                    "id": 8144,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12033,28 +12033,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6351,
+                    "id": 7185,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6352,
+                    "id": 7186,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6353,
+                    "id": 7187,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6354,
+                    "id": 7188,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12087,37 +12087,37 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7228,
+                    "id": 8145,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7229,
+                    "id": 8146,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7230,
+                    "id": 8147,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7231,
+                    "id": 8148,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7232,
+                    "id": 8149,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7233,
+                    "id": 8150,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -12134,28 +12134,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6355,
+                    "id": 7189,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6356,
+                    "id": 7190,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6357,
+                    "id": 7191,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6358,
+                    "id": 7192,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12188,31 +12188,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7234,
+                    "id": 8151,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7235,
+                    "id": 8152,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7236,
+                    "id": 8153,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7237,
+                    "id": 8154,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7238,
+                    "id": 8155,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12229,28 +12229,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6359,
+                    "id": 7193,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6360,
+                    "id": 7194,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6361,
+                    "id": 7195,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6362,
+                    "id": 7196,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12283,31 +12283,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7239,
+                    "id": 8156,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7240,
+                    "id": 8157,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7241,
+                    "id": 8158,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7242,
+                    "id": 8159,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7243,
+                    "id": 8160,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12324,35 +12324,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6363,
+                    "id": 7197,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6364,
+                    "id": 7198,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6365,
+                    "id": 7199,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6366,
+                    "id": 7200,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6367,
+                    "id": 7201,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12387,25 +12387,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7244,
+                    "id": 8161,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7245,
+                    "id": 8162,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7246,
+                    "id": 8163,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7247,
+                    "id": 8164,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12422,35 +12422,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6368,
+                    "id": 7202,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6369,
+                    "id": 7203,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6370,
+                    "id": 7204,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6371,
+                    "id": 7205,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6372,
+                    "id": 7206,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12485,25 +12485,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7248,
+                    "id": 8165,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7249,
+                    "id": 8166,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7250,
+                    "id": 8167,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7251,
+                    "id": 8168,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12520,35 +12520,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6373,
+                    "id": 7207,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6374,
+                    "id": 7208,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6375,
+                    "id": 7209,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6376,
+                    "id": 7210,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6377,
+                    "id": 7211,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12582,25 +12582,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7252,
+                    "id": 8169,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7253,
+                    "id": 8170,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7254,
+                    "id": 8171,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7255,
+                    "id": 8172,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12617,28 +12617,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6378,
+                    "id": 7212,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6379,
+                    "id": 7213,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6380,
+                    "id": 7214,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6381,
+                    "id": 7215,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12674,31 +12674,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7256,
+                    "id": 8173,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7257,
+                    "id": 8174,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7258,
+                    "id": 8175,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7259,
+                    "id": 8176,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7260,
+                    "id": 8177,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12715,28 +12715,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6382,
+                    "id": 7216,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6383,
+                    "id": 7217,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6384,
+                    "id": 7218,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6385,
+                    "id": 7219,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12772,31 +12772,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7261,
+                    "id": 8178,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7262,
+                    "id": 8179,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7263,
+                    "id": 8180,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7264,
+                    "id": 8181,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7265,
+                    "id": 8182,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12813,28 +12813,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6386,
+                    "id": 7220,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6387,
+                    "id": 7221,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6388,
+                    "id": 7222,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6389,
+                    "id": 7223,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12870,31 +12870,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7266,
+                    "id": 8183,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7267,
+                    "id": 8184,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7268,
+                    "id": 8185,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7269,
+                    "id": 8186,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7270,
+                    "id": 8187,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12911,28 +12911,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6390,
+                    "id": 7224,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6391,
+                    "id": 7225,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6392,
+                    "id": 7226,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6393,
+                    "id": 7227,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12967,31 +12967,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7271,
+                    "id": 8188,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7272,
+                    "id": 8189,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7273,
+                    "id": 8190,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7274,
+                    "id": 8191,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7275,
+                    "id": 8192,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13008,28 +13008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6394,
+                    "id": 7228,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6395,
+                    "id": 7229,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6396,
+                    "id": 7230,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6397,
+                    "id": 7231,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13065,31 +13065,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7276,
+                    "id": 8193,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7277,
+                    "id": 8194,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7278,
+                    "id": 8195,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7279,
+                    "id": 8196,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7280,
+                    "id": 8197,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13106,28 +13106,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6398,
+                    "id": 7232,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6399,
+                    "id": 7233,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6400,
+                    "id": 7234,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6401,
+                    "id": 7235,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13162,31 +13162,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7281,
+                    "id": 8198,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7282,
+                    "id": 8199,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7283,
+                    "id": 8200,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7284,
+                    "id": 8201,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7285,
+                    "id": 8202,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13203,28 +13203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6402,
+                    "id": 7236,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6403,
+                    "id": 7237,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6404,
+                    "id": 7238,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6405,
+                    "id": 7239,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13254,19 +13254,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7286,
+                    "id": 8203,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7287,
+                    "id": 8204,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7288,
+                    "id": 8205,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13283,28 +13283,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6406,
+                    "id": 7240,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6407,
+                    "id": 7241,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6408,
+                    "id": 7242,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6409,
+                    "id": 7243,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13334,19 +13334,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7289,
+                    "id": 8206,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7290,
+                    "id": 8207,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7291,
+                    "id": 8208,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13363,28 +13363,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6410,
+                    "id": 7244,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6411,
+                    "id": 7245,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6412,
+                    "id": 7246,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6413,
+                    "id": 7247,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13413,19 +13413,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7292,
+                    "id": 8209,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7293,
+                    "id": 8210,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7294,
+                    "id": 8211,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13442,28 +13442,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6414,
+                    "id": 7248,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6415,
+                    "id": 7249,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6416,
+                    "id": 7250,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6417,
+                    "id": 7251,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13493,19 +13493,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7295,
+                    "id": 8212,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7296,
+                    "id": 8213,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7297,
+                    "id": 8214,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13522,28 +13522,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6418,
+                    "id": 7252,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6419,
+                    "id": 7253,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6420,
+                    "id": 7254,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6421,
+                    "id": 7255,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13573,19 +13573,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7298,
+                    "id": 8215,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7299,
+                    "id": 8216,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7300,
+                    "id": 8217,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13602,28 +13602,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6422,
+                    "id": 7256,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6423,
+                    "id": 7257,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6424,
+                    "id": 7258,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6425,
+                    "id": 7259,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13652,19 +13652,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7301,
+                    "id": 8218,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7302,
+                    "id": 8219,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7303,
+                    "id": 8220,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13681,21 +13681,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6426,
+                    "id": 7260,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6427,
+                    "id": 7261,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6428,
+                    "id": 7262,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13728,19 +13728,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7304,
+                    "id": 8221,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7305,
+                    "id": 8222,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7306,
+                    "id": 8223,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13757,21 +13757,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6429,
+                    "id": 7263,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6430,
+                    "id": 7264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6431,
+                    "id": 7265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13803,19 +13803,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7307,
+                    "id": 8224,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7308,
+                    "id": 8225,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7309,
+                    "id": 8226,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13832,21 +13832,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6432,
+                    "id": 7266,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6433,
+                    "id": 7267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6434,
+                    "id": 7268,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13878,19 +13878,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7310,
+                    "id": 8227,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7311,
+                    "id": 8228,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7312,
+                    "id": 8229,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13907,21 +13907,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6435,
+                    "id": 7269,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6436,
+                    "id": 7270,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6437,
+                    "id": 7271,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13953,19 +13953,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7313,
+                    "id": 8230,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7314,
+                    "id": 8231,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7315,
+                    "id": 8232,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13982,28 +13982,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6438,
+                    "id": 7272,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6439,
+                    "id": 7273,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6440,
+                    "id": 7274,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6441,
+                    "id": 7275,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14038,25 +14038,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7316,
+                    "id": 8233,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7317,
+                    "id": 8234,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7318,
+                    "id": 8235,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7319,
+                    "id": 8236,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14073,28 +14073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6442,
+                    "id": 7276,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6443,
+                    "id": 7277,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6444,
+                    "id": 7278,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6445,
+                    "id": 7279,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14129,25 +14129,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7320,
+                    "id": 8237,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7321,
+                    "id": 8238,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7322,
+                    "id": 8239,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7323,
+                    "id": 8240,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14164,28 +14164,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6446,
+                    "id": 7280,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6447,
+                    "id": 7281,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6448,
+                    "id": 7282,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6449,
+                    "id": 7283,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14220,25 +14220,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7324,
+                    "id": 8241,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7325,
+                    "id": 8242,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7326,
+                    "id": 8243,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7327,
+                    "id": 8244,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14255,28 +14255,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6450,
+                    "id": 7284,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6451,
+                    "id": 7285,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6452,
+                    "id": 7286,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6453,
+                    "id": 7287,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14310,25 +14310,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7328,
+                    "id": 8245,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7329,
+                    "id": 8246,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7330,
+                    "id": 8247,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7331,
+                    "id": 8248,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14345,21 +14345,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6454,
+                    "id": 7288,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6455,
+                    "id": 7289,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6456,
+                    "id": 7290,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14390,25 +14390,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7332,
+                    "id": 8249,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7333,
+                    "id": 8250,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7334,
+                    "id": 8251,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7335,
+                    "id": 8252,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14425,21 +14425,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6457,
+                    "id": 7291,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6458,
+                    "id": 7292,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6459,
+                    "id": 7293,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14470,25 +14470,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7336,
+                    "id": 8253,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7337,
+                    "id": 8254,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7338,
+                    "id": 8255,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7339,
+                    "id": 8256,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14505,21 +14505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6460,
+                    "id": 7294,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6461,
+                    "id": 7295,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6462,
+                    "id": 7296,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14549,25 +14549,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7340,
+                    "id": 8257,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7341,
+                    "id": 8258,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7342,
+                    "id": 8259,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7343,
+                    "id": 8260,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14584,21 +14584,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6463,
+                    "id": 7297,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6464,
+                    "id": 7298,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6465,
+                    "id": 7299,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14629,25 +14629,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7344,
+                    "id": 8261,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7345,
+                    "id": 8262,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7346,
+                    "id": 8263,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7347,
+                    "id": 8264,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14664,21 +14664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6466,
+                    "id": 7300,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6467,
+                    "id": 7301,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6468,
+                    "id": 7302,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14708,25 +14708,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7348,
+                    "id": 8265,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7349,
+                    "id": 8266,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7350,
+                    "id": 8267,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7351,
+                    "id": 8268,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14743,35 +14743,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6469,
+                    "id": 7303,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6470,
+                    "id": 7304,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6471,
+                    "id": 7305,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6472,
+                    "id": 7306,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6473,
+                    "id": 7307,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14804,31 +14804,31 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7352,
+                    "id": 8269,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7353,
+                    "id": 8270,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7354,
+                    "id": 8271,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7355,
+                    "id": 8272,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7356,
+                    "id": 8273,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "3"
@@ -14845,35 +14845,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6474,
+                    "id": 7308,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6475,
+                    "id": 7309,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6476,
+                    "id": 7310,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6477,
+                    "id": 7311,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6478,
+                    "id": 7312,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14906,25 +14906,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7357,
+                    "id": 8274,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7358,
+                    "id": 8275,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7359,
+                    "id": 8276,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7360,
+                    "id": 8277,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14941,35 +14941,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6479,
+                    "id": 7313,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6480,
+                    "id": 7314,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6481,
+                    "id": 7315,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6482,
+                    "id": 7316,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6483,
+                    "id": 7317,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15001,25 +15001,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7361,
+                    "id": 8278,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7362,
+                    "id": 8279,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7363,
+                    "id": 8280,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7364,
+                    "id": 8281,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15036,35 +15036,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6484,
+                    "id": 7318,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6485,
+                    "id": 7319,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6486,
+                    "id": 7320,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6487,
+                    "id": 7321,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6488,
+                    "id": 7322,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15096,25 +15096,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7365,
+                    "id": 8282,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7366,
+                    "id": 8283,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7367,
+                    "id": 8284,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7368,
+                    "id": 8285,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15131,28 +15131,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6489,
+                    "id": 7323,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6490,
+                    "id": 7324,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6491,
+                    "id": 7325,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6492,
+                    "id": 7326,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 }
@@ -15184,25 +15184,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7369,
+                    "id": 8286,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7370,
+                    "id": 8287,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7371,
+                    "id": 8288,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7372,
+                    "id": 8289,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15219,28 +15219,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6493,
+                    "id": 7327,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6494,
+                    "id": 7328,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6495,
+                    "id": 7329,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6496,
+                    "id": 7330,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15272,25 +15272,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7373,
+                    "id": 8290,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7374,
+                    "id": 8291,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7375,
+                    "id": 8292,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7376,
+                    "id": 8293,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15307,28 +15307,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6497,
+                    "id": 7331,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6498,
+                    "id": 7332,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6499,
+                    "id": 7333,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6500,
+                    "id": 7334,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15360,25 +15360,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7377,
+                    "id": 8294,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7378,
+                    "id": 8295,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7379,
+                    "id": 8296,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7380,
+                    "id": 8297,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15395,28 +15395,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6501,
+                    "id": 7335,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6502,
+                    "id": 7336,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6503,
+                    "id": 7337,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6504,
+                    "id": 7338,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15448,25 +15448,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7381,
+                    "id": 8298,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7382,
+                    "id": 8299,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7383,
+                    "id": 8300,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7384,
+                    "id": 8301,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15483,28 +15483,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6505,
+                    "id": 7339,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6506,
+                    "id": 7340,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6507,
+                    "id": 7341,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6508,
+                    "id": 7342,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15535,25 +15535,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7385,
+                    "id": 8302,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7386,
+                    "id": 8303,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7387,
+                    "id": 8304,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7388,
+                    "id": 8305,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15570,28 +15570,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6509,
+                    "id": 7343,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6510,
+                    "id": 7344,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6511,
+                    "id": 7345,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6512,
+                    "id": 7346,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15621,25 +15621,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7389,
+                    "id": 8306,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7390,
+                    "id": 8307,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7391,
+                    "id": 8308,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7392,
+                    "id": 8309,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15656,28 +15656,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6513,
+                    "id": 7347,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6514,
+                    "id": 7348,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6515,
+                    "id": 7349,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6516,
+                    "id": 7350,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15707,25 +15707,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7393,
+                    "id": 8310,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7394,
+                    "id": 8311,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7395,
+                    "id": 8312,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7396,
+                    "id": 8313,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15742,28 +15742,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6517,
+                    "id": 7351,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6518,
+                    "id": 7352,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6519,
+                    "id": 7353,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6520,
+                    "id": 7354,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15793,25 +15793,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7397,
+                    "id": 8314,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7398,
+                    "id": 8315,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7399,
+                    "id": 8316,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7400,
+                    "id": 8317,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15828,28 +15828,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6521,
+                    "id": 7355,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6522,
+                    "id": 7356,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6523,
+                    "id": 7357,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6524,
+                    "id": 7358,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15879,25 +15879,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7401,
+                    "id": 8318,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7402,
+                    "id": 8319,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7403,
+                    "id": 8320,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7404,
+                    "id": 8321,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15914,28 +15914,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6525,
+                    "id": 7359,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6526,
+                    "id": 7360,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6527,
+                    "id": 7361,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6528,
+                    "id": 7362,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15964,25 +15964,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7405,
+                    "id": 8322,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7406,
+                    "id": 8323,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7407,
+                    "id": 8324,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7408,
+                    "id": 8325,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15999,28 +15999,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6529,
+                    "id": 7363,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6530,
+                    "id": 7364,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6531,
+                    "id": 7365,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6532,
+                    "id": 7366,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16049,25 +16049,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7409,
+                    "id": 8326,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7410,
+                    "id": 8327,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7411,
+                    "id": 8328,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7412,
+                    "id": 8329,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16084,28 +16084,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6533,
+                    "id": 7367,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6534,
+                    "id": 7368,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6535,
+                    "id": 7369,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6536,
+                    "id": 7370,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16135,25 +16135,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7413,
+                    "id": 8330,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7414,
+                    "id": 8331,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7415,
+                    "id": 8332,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7416,
+                    "id": 8333,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16170,28 +16170,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6537,
+                    "id": 7371,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6538,
+                    "id": 7372,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6539,
+                    "id": 7373,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6540,
+                    "id": 7374,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16220,25 +16220,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7417,
+                    "id": 8334,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7418,
+                    "id": 8335,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7419,
+                    "id": 8336,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7420,
+                    "id": 8337,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16255,21 +16255,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6541,
+                    "id": 7375,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6542,
+                    "id": 7376,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6543,
+                    "id": 7377,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16302,25 +16302,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7421,
+                    "id": 8338,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7422,
+                    "id": 8339,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7423,
+                    "id": 8340,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7424,
+                    "id": 8341,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16337,21 +16337,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6544,
+                    "id": 7378,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6545,
+                    "id": 7379,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6546,
+                    "id": 7380,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16384,25 +16384,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7425,
+                    "id": 8342,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7426,
+                    "id": 8343,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7427,
+                    "id": 8344,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7428,
+                    "id": 8345,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16419,21 +16419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6547,
+                    "id": 7381,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6548,
+                    "id": 7382,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6549,
+                    "id": 7383,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16466,25 +16466,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7429,
+                    "id": 8346,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7430,
+                    "id": 8347,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7431,
+                    "id": 8348,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7432,
+                    "id": 8349,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16501,21 +16501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6550,
+                    "id": 7384,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6551,
+                    "id": 7385,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6552,
+                    "id": 7386,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16547,25 +16547,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7433,
+                    "id": 8350,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7434,
+                    "id": 8351,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7435,
+                    "id": 8352,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7436,
+                    "id": 8353,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16582,21 +16582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6553,
+                    "id": 7387,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6554,
+                    "id": 7388,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6555,
+                    "id": 7389,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16629,25 +16629,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7437,
+                    "id": 8354,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7438,
+                    "id": 8355,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7439,
+                    "id": 8356,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7440,
+                    "id": 8357,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16664,21 +16664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6556,
+                    "id": 7390,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6557,
+                    "id": 7391,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6558,
+                    "id": 7392,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16710,25 +16710,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7441,
+                    "id": 8358,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7442,
+                    "id": 8359,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7443,
+                    "id": 8360,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7444,
+                    "id": 8361,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16745,28 +16745,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6559,
+                    "id": 7393,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6560,
+                    "id": 7394,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6561,
+                    "id": 7395,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6562,
+                    "id": 7396,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16801,25 +16801,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7445,
+                    "id": 8362,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7446,
+                    "id": 8363,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7447,
+                    "id": 8364,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7448,
+                    "id": 8365,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16836,28 +16836,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6563,
+                    "id": 7397,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6564,
+                    "id": 7398,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6565,
+                    "id": 7399,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6566,
+                    "id": 7400,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16892,25 +16892,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7449,
+                    "id": 8366,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7450,
+                    "id": 8367,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7451,
+                    "id": 8368,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7452,
+                    "id": 8369,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16927,28 +16927,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6567,
+                    "id": 7401,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6568,
+                    "id": 7402,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6569,
+                    "id": 7403,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6570,
+                    "id": 7404,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16983,25 +16983,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7453,
+                    "id": 8370,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7454,
+                    "id": 8371,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7455,
+                    "id": 8372,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7456,
+                    "id": 8373,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17018,28 +17018,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6571,
+                    "id": 7405,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6572,
+                    "id": 7406,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6573,
+                    "id": 7407,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6574,
+                    "id": 7408,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17074,25 +17074,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7457,
+                    "id": 8374,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7458,
+                    "id": 8375,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7459,
+                    "id": 8376,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7460,
+                    "id": 8377,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17109,21 +17109,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6575,
+                    "id": 7409,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6576,
+                    "id": 7410,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6577,
+                    "id": 7411,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17156,25 +17156,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7461,
+                    "id": 8378,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7462,
+                    "id": 8379,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7463,
+                    "id": 8380,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7464,
+                    "id": 8381,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17191,21 +17191,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6578,
+                    "id": 7412,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6579,
+                    "id": 7413,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6580,
+                    "id": 7414,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17238,25 +17238,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7465,
+                    "id": 8382,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7466,
+                    "id": 8383,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7467,
+                    "id": 8384,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7468,
+                    "id": 8385,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17273,21 +17273,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6581,
+                    "id": 7415,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6582,
+                    "id": 7416,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6583,
+                    "id": 7417,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17319,25 +17319,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7469,
+                    "id": 8386,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7470,
+                    "id": 8387,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7471,
+                    "id": 8388,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7472,
+                    "id": 8389,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17354,21 +17354,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6584,
+                    "id": 7418,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6585,
+                    "id": 7419,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6586,
+                    "id": 7420,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17402,31 +17402,31 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7473,
+                    "id": 8390,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7474,
+                    "id": 8391,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7475,
+                    "id": 8392,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7476,
+                    "id": 8393,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7477,
+                    "id": 8394,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -17443,21 +17443,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6587,
+                    "id": 7421,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6588,
+                    "id": 7422,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6589,
+                    "id": 7423,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17491,25 +17491,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7478,
+                    "id": 8395,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7479,
+                    "id": 8396,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7480,
+                    "id": 8397,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7481,
+                    "id": 8398,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17526,21 +17526,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6590,
+                    "id": 7424,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6591,
+                    "id": 7425,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6592,
+                    "id": 7426,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17573,25 +17573,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7482,
+                    "id": 8399,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7483,
+                    "id": 8400,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7484,
+                    "id": 8401,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7485,
+                    "id": 8402,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17608,28 +17608,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6593,
+                    "id": 7427,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6594,
+                    "id": 7428,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6595,
+                    "id": 7429,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6596,
+                    "id": 7430,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17662,25 +17662,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7486,
+                    "id": 8403,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7487,
+                    "id": 8404,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7488,
+                    "id": 8405,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7489,
+                    "id": 8406,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17697,28 +17697,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6597,
+                    "id": 7431,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6598,
+                    "id": 7432,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6599,
+                    "id": 7433,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6600,
+                    "id": 7434,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17751,31 +17751,31 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7490,
+                    "id": 8407,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7491,
+                    "id": 8408,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7492,
+                    "id": 8409,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7493,
+                    "id": 8410,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7494,
+                    "id": 8411,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -17792,28 +17792,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6601,
+                    "id": 7435,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6602,
+                    "id": 7436,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6603,
+                    "id": 7437,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6604,
+                    "id": 7438,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17846,25 +17846,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7495,
+                    "id": 8412,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7496,
+                    "id": 8413,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7497,
+                    "id": 8414,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7498,
+                    "id": 8415,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17881,21 +17881,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6605,
+                    "id": 7439,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6606,
+                    "id": 7440,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6607,
+                    "id": 7441,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17931,25 +17931,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7499,
+                    "id": 8416,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7500,
+                    "id": 8417,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7501,
+                    "id": 8418,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7502,
+                    "id": 8419,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17966,21 +17966,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6608,
+                    "id": 7442,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6609,
+                    "id": 7443,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6610,
+                    "id": 7444,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18016,31 +18016,31 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7503,
+                    "id": 8420,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7504,
+                    "id": 8421,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7505,
+                    "id": 8422,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7506,
+                    "id": 8423,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7507,
+                    "id": 8424,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -18057,21 +18057,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6611,
+                    "id": 7445,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6612,
+                    "id": 7446,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6613,
+                    "id": 7447,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18107,25 +18107,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7508,
+                    "id": 8425,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7509,
+                    "id": 8426,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7510,
+                    "id": 8427,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7511,
+                    "id": 8428,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18142,21 +18142,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6614,
+                    "id": 7448,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6615,
+                    "id": 7449,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6616,
+                    "id": 7450,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18191,25 +18191,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7512,
+                    "id": 8429,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7513,
+                    "id": 8430,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7514,
+                    "id": 8431,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7515,
+                    "id": 8432,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18226,21 +18226,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6617,
+                    "id": 7451,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6618,
+                    "id": 7452,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6619,
+                    "id": 7453,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18273,31 +18273,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7516,
+                    "id": 8433,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7517,
+                    "id": 8434,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7518,
+                    "id": 8435,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7519,
+                    "id": 8436,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7520,
+                    "id": 8437,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -18314,21 +18314,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6620,
+                    "id": 7454,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6621,
+                    "id": 7455,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6622,
+                    "id": 7456,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18346,7 +18346,7 @@
                 6
             ],
             "card_type_id": 1,
-            "cost": "54",
+            "cost": "56",
             "faction_id": 3,
             "ffg_id": "XW_P_215",
             "force_side": null,
@@ -18356,30 +18356,30 @@
             "is_unique": true,
             "name": "•Manaroo",
             "restrictions": [],
-            "ship_ability_text": null,
+            "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7521,
+                    "id": 8438,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7522,
+                    "id": 8439,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7523,
+                    "id": 8440,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7524,
+                    "id": 8441,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18396,21 +18396,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6623,
+                    "id": 7457,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6624,
+                    "id": 7458,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6625,
+                    "id": 7459,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18443,31 +18443,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7525,
+                    "id": 8442,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7526,
+                    "id": 8443,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7527,
+                    "id": 8444,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7528,
+                    "id": 8445,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7529,
+                    "id": 8446,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -18484,21 +18484,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6626,
+                    "id": 7460,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6627,
+                    "id": 7461,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6628,
+                    "id": 7462,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18530,25 +18530,25 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7530,
+                    "id": 8447,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7531,
+                    "id": 8448,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7532,
+                    "id": 8449,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7533,
+                    "id": 8450,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18565,28 +18565,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6629,
+                    "id": 7463,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6630,
+                    "id": 7464,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6631,
+                    "id": 7465,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6632,
+                    "id": 7466,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18619,31 +18619,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7534,
+                    "id": 8451,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7535,
+                    "id": 8452,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7536,
+                    "id": 8453,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7537,
+                    "id": 8454,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7538,
+                    "id": 8455,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18660,28 +18660,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6633,
+                    "id": 7467,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6634,
+                    "id": 7468,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6635,
+                    "id": 7469,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6636,
+                    "id": 7470,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18714,37 +18714,37 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7539,
+                    "id": 8456,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7540,
+                    "id": 8457,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7541,
+                    "id": 8458,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7542,
+                    "id": 8459,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7543,
+                    "id": 8460,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7544,
+                    "id": 8461,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -18761,28 +18761,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6637,
+                    "id": 7471,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6638,
+                    "id": 7472,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6639,
+                    "id": 7473,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6640,
+                    "id": 7474,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18815,31 +18815,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7545,
+                    "id": 8462,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7546,
+                    "id": 8463,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7547,
+                    "id": 8464,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7548,
+                    "id": 8465,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7549,
+                    "id": 8466,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18856,28 +18856,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6641,
+                    "id": 7475,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6642,
+                    "id": 7476,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6643,
+                    "id": 7477,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6644,
+                    "id": 7478,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18909,31 +18909,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7550,
+                    "id": 8467,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7551,
+                    "id": 8468,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7552,
+                    "id": 8469,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7553,
+                    "id": 8470,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7554,
+                    "id": 8471,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18950,28 +18950,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6645,
+                    "id": 7479,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6646,
+                    "id": 7480,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6647,
+                    "id": 7481,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6648,
+                    "id": 7482,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19006,25 +19006,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7555,
+                    "id": 8472,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7556,
+                    "id": 8473,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7557,
+                    "id": 8474,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7558,
+                    "id": 8475,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19041,28 +19041,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6649,
+                    "id": 7483,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6650,
+                    "id": 7484,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6651,
+                    "id": 7485,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6652,
+                    "id": 7486,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19097,25 +19097,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7559,
+                    "id": 8476,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7560,
+                    "id": 8477,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7561,
+                    "id": 8478,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7562,
+                    "id": 8479,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19132,28 +19132,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6653,
+                    "id": 7487,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6654,
+                    "id": 7488,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6655,
+                    "id": 7489,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6656,
+                    "id": 7490,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19187,25 +19187,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7563,
+                    "id": 8480,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7564,
+                    "id": 8481,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7565,
+                    "id": 8482,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7566,
+                    "id": 8483,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19222,28 +19222,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 7491,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 7492,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 7493,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 7494,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19277,25 +19277,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 8484,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 8485,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 8486,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 8487,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19312,21 +19312,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6661,
+                    "id": 7495,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6662,
+                    "id": 7496,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6663,
+                    "id": 7497,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19356,25 +19356,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7571,
+                    "id": 8488,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7572,
+                    "id": 8489,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7573,
+                    "id": 8490,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7574,
+                    "id": 8491,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19391,21 +19391,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6664,
+                    "id": 7498,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6665,
+                    "id": 7499,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6666,
+                    "id": 7500,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19435,25 +19435,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7575,
+                    "id": 8492,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7576,
+                    "id": 8493,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7577,
+                    "id": 8494,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7578,
+                    "id": 8495,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19470,21 +19470,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6667,
+                    "id": 7501,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6668,
+                    "id": 7502,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6669,
+                    "id": 7503,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19514,25 +19514,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 8496,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7580,
+                    "id": 8497,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7581,
+                    "id": 8498,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7582,
+                    "id": 8499,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19549,21 +19549,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6670,
+                    "id": 7504,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6671,
+                    "id": 7505,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6672,
+                    "id": 7506,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19589,31 +19589,31 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7583,
+                    "id": 8500,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7584,
+                    "id": 8501,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7585,
+                    "id": 8502,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7586,
+                    "id": 8503,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7587,
+                    "id": 8504,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "3"
@@ -20685,7 +20685,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât <hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
@@ -20724,7 +20724,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, tous les résultats <hit>/<crit> infligent des marqueurs de brouillage au lieu des dégâts.",
@@ -20763,7 +20763,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, tous les résultats <hit>/<crit> infligent des marqueurs de rayon tracteur au lieu des dégâts.",
@@ -20802,7 +20802,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque</smallcaps>",
@@ -20849,7 +20849,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attaque :</smallcaps> si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât<nonbreak><hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
@@ -20897,7 +20897,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Changez 1 résultat<nonbreak><hit> en un résultat <crit>.",
@@ -20989,7 +20989,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Changez 1 résultat<nonbreak><hit> en un résultat <crit>.",
@@ -21036,7 +21036,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque (<focus>) :</smallcaps> dépensez 1 <standardcharge>. Si le défenseur est dans votre <bullseye>, vous pouvez dépenser 1 ou plusieurs <standardcharge> pour relancer autant de dés d’attaque.",
@@ -21080,7 +21080,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Après cette attaque, vous pouvez effectuer cette attaque en tant qu’attaque bonus contre une cible différente à portée 0–1 du défenseur, en ignorant le prérequis <targetlock>.",
@@ -21126,7 +21126,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Après que cette attaque a touché, chaque vaisseau à portée 0–1 du défenseur expose 1 de ses cartes de dégât.",
@@ -21172,7 +21172,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :</smallcaps> dépensez 1 <standardcharge>. Après que vous avez déclaré le défenseur, il peut choisir de subir 1 dégât<nonbreak><hit>. Dans ce cas, sautez les étapes «<nonbreak>Dés d’attaque<nonbreak>» et «<nonbreak>Dés de défense<nonbreak>» et considérez que l’attaque a touché.",
@@ -21217,7 +21217,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque (<targetlock>) :<smallcaps> dépensez 1 <standardcharge>. Si cette attaque touche, dépensez 1 résultat<nonbreak><hit> ou <crit> pour faire subir 1 dégât<nonbreak><hit> au défenseur. Tous les résultats <hit>/<crit> restants infligent des marqueurs ioniques au lieu des dégâts.",
@@ -21262,7 +21262,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attaque (<focus>) :</smallcaps> dépensez 1<nonbreak><standardcharge>.",
@@ -21307,7 +21307,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "Tant que vous défendez et avant que les dés d’attaque ne soient lancés, vous pouvez dépenser un marqueur de verrouillage que vous avez sur l’attaquant pour lancer 1 dé d’attaque. Dans ce cas, l’attaquant gagne 1 marqueur de brouillage. Puis, sur un résultat <hit> ou <crit>, gagnez 1 marqueur de brouillage.",

--- a/translation_helper/api_export_it.json
+++ b/translation_helper/api_export_it.json
@@ -6,21 +6,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 6673,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 6674,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 6675,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -53,25 +53,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 7588,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 7589,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 7590,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 7591,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -88,21 +88,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5842,
+                    "id": 6676,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5843,
+                    "id": 6677,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5844,
+                    "id": 6678,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -134,31 +134,31 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6675,
+                    "id": 7592,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6676,
+                    "id": 7593,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6677,
+                    "id": 7594,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6678,
+                    "id": 7595,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 6679,
+                    "id": 7596,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -175,21 +175,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 6679,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 6680,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 6681,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -221,25 +221,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 7597,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 7598,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 7599,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 7600,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -256,21 +256,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5848,
+                    "id": 6682,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5849,
+                    "id": 6683,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5850,
+                    "id": 6684,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -303,25 +303,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6684,
+                    "id": 7601,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6685,
+                    "id": 7602,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6686,
+                    "id": 7603,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6687,
+                    "id": 7604,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -338,21 +338,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5851,
+                    "id": 6685,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5852,
+                    "id": 6686,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5853,
+                    "id": 6687,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -384,25 +384,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6688,
+                    "id": 7605,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6689,
+                    "id": 7606,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6690,
+                    "id": 7607,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6691,
+                    "id": 7608,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -419,21 +419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5854,
+                    "id": 6688,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5855,
+                    "id": 6689,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5856,
+                    "id": 6690,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -466,25 +466,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6692,
+                    "id": 7609,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6693,
+                    "id": 7610,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6694,
+                    "id": 7611,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6695,
+                    "id": 7612,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -501,21 +501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5857,
+                    "id": 6691,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5858,
+                    "id": 6692,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5859,
+                    "id": 6693,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -547,25 +547,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6696,
+                    "id": 7613,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6697,
+                    "id": 7614,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6698,
+                    "id": 7615,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6699,
+                    "id": 7616,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -582,21 +582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 6694,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 6695,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 6696,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -629,25 +629,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 7617,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6701,
+                    "id": 7618,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 7619,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6703,
+                    "id": 7620,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -664,21 +664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5863,
+                    "id": 6697,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5864,
+                    "id": 6698,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5865,
+                    "id": 6699,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -710,25 +710,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6704,
+                    "id": 7621,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6705,
+                    "id": 7622,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6706,
+                    "id": 7623,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6707,
+                    "id": 7624,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -745,21 +745,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5866,
+                    "id": 6700,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5867,
+                    "id": 6701,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5868,
+                    "id": 6702,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -793,25 +793,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6708,
+                    "id": 7625,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6709,
+                    "id": 7626,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6710,
+                    "id": 7627,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6711,
+                    "id": 7628,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -828,21 +828,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5869,
+                    "id": 6703,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5870,
+                    "id": 6704,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5871,
+                    "id": 6705,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -875,25 +875,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6712,
+                    "id": 7629,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6713,
+                    "id": 7630,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6714,
+                    "id": 7631,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6715,
+                    "id": 7632,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -910,21 +910,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5872,
+                    "id": 6706,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5873,
+                    "id": 6707,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5874,
+                    "id": 6708,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -956,25 +956,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6716,
+                    "id": 7633,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6717,
+                    "id": 7634,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6718,
+                    "id": 7635,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6719,
+                    "id": 7636,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -991,28 +991,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5875,
+                    "id": 6709,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5876,
+                    "id": 6710,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5877,
+                    "id": 6711,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5878,
+                    "id": 6712,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1046,25 +1046,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6720,
+                    "id": 7637,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6721,
+                    "id": 7638,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6722,
+                    "id": 7639,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6723,
+                    "id": 7640,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1081,28 +1081,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5879,
+                    "id": 6713,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5880,
+                    "id": 6714,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5881,
+                    "id": 6715,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5882,
+                    "id": 6716,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1137,25 +1137,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6724,
+                    "id": 7641,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6725,
+                    "id": 7642,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6726,
+                    "id": 7643,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6727,
+                    "id": 7644,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1172,28 +1172,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5883,
+                    "id": 6717,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5884,
+                    "id": 6718,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5885,
+                    "id": 6719,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5886,
+                    "id": 6720,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1228,25 +1228,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6728,
+                    "id": 7645,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6729,
+                    "id": 7646,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6730,
+                    "id": 7647,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6731,
+                    "id": 7648,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1263,28 +1263,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 6721,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 6722,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 6723,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 6724,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1318,25 +1318,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 7649,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 7650,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 7651,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 7652,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1353,28 +1353,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5891,
+                    "id": 6725,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5892,
+                    "id": 6726,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5893,
+                    "id": 6727,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5894,
+                    "id": 6728,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1409,25 +1409,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6736,
+                    "id": 7653,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6737,
+                    "id": 7654,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6738,
+                    "id": 7655,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6739,
+                    "id": 7656,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1444,28 +1444,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 6729,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 6730,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "id": 6731,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "id": 6732,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1499,25 +1499,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 7657,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 7658,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6742,
+                    "id": 7659,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6743,
+                    "id": 7660,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1534,35 +1534,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5899,
+                    "id": 6733,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5900,
+                    "id": 6734,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5901,
+                    "id": 6735,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5902,
+                    "id": 6736,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5903,
+                    "id": 6737,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1591,25 +1591,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6744,
+                    "id": 7661,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6745,
+                    "id": 7662,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6746,
+                    "id": 7663,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6747,
+                    "id": 7664,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1626,35 +1626,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
+                    "id": 6738,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5905,
+                    "id": 6739,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 6740,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
+                    "id": 6741,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 6742,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1683,25 +1683,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 7665,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 7666,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6750,
+                    "id": 7667,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 7668,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1718,35 +1718,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5909,
+                    "id": 6743,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5910,
+                    "id": 6744,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5911,
+                    "id": 6745,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5912,
+                    "id": 6746,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5913,
+                    "id": 6747,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1775,25 +1775,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6752,
+                    "id": 7669,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6753,
+                    "id": 7670,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6754,
+                    "id": 7671,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6755,
+                    "id": 7672,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1810,35 +1810,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5914,
+                    "id": 6748,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5915,
+                    "id": 6749,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5916,
+                    "id": 6750,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5917,
+                    "id": 6751,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5918,
+                    "id": 6752,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1866,25 +1866,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6756,
+                    "id": 7673,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6757,
+                    "id": 7674,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6758,
+                    "id": 7675,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6759,
+                    "id": 7676,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1901,21 +1901,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5919,
+                    "id": 6753,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5920,
+                    "id": 6754,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5921,
+                    "id": 6755,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1948,25 +1948,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6760,
+                    "id": 7677,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6761,
+                    "id": 7678,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6762,
+                    "id": 7679,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6763,
+                    "id": 7680,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -1983,21 +1983,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5922,
+                    "id": 6756,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5923,
+                    "id": 6757,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5924,
+                    "id": 6758,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2030,25 +2030,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6764,
+                    "id": 7681,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6765,
+                    "id": 7682,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6766,
+                    "id": 7683,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6767,
+                    "id": 7684,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2065,21 +2065,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5925,
+                    "id": 6759,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5926,
+                    "id": 6760,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5927,
+                    "id": 6761,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2112,25 +2112,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6768,
+                    "id": 7685,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6769,
+                    "id": 7686,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6770,
+                    "id": 7687,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6771,
+                    "id": 7688,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2147,21 +2147,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5928,
+                    "id": 6762,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5929,
+                    "id": 6763,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5930,
+                    "id": 6764,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2193,25 +2193,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6772,
+                    "id": 7689,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6773,
+                    "id": 7690,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6774,
+                    "id": 7691,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6775,
+                    "id": 7692,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2228,21 +2228,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5931,
+                    "id": 6765,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5932,
+                    "id": 6766,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5933,
+                    "id": 6767,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2272,25 +2272,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6776,
+                    "id": 7693,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6777,
+                    "id": 7694,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6778,
+                    "id": 7695,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6779,
+                    "id": 7696,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2307,21 +2307,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5934,
+                    "id": 6768,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5935,
+                    "id": 6769,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5936,
+                    "id": 6770,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2351,25 +2351,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6780,
+                    "id": 7697,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6781,
+                    "id": 7698,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6782,
+                    "id": 7699,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6783,
+                    "id": 7700,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2386,21 +2386,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5937,
+                    "id": 6771,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5938,
+                    "id": 6772,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5939,
+                    "id": 6773,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2430,25 +2430,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6784,
+                    "id": 7701,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6785,
+                    "id": 7702,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6786,
+                    "id": 7703,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6787,
+                    "id": 7704,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2465,21 +2465,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5940,
+                    "id": 6774,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5941,
+                    "id": 6775,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5942,
+                    "id": 6776,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2508,25 +2508,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6788,
+                    "id": 7705,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6789,
+                    "id": 7706,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6790,
+                    "id": 7707,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6791,
+                    "id": 7708,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2543,21 +2543,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5943,
+                    "id": 6777,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5944,
+                    "id": 6778,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5945,
+                    "id": 6779,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2588,25 +2588,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6792,
+                    "id": 7709,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6793,
+                    "id": 7710,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6794,
+                    "id": 7711,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6795,
+                    "id": 7712,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2623,21 +2623,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5946,
+                    "id": 6780,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5947,
+                    "id": 6781,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5948,
+                    "id": 6782,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2668,25 +2668,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6796,
+                    "id": 7713,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6797,
+                    "id": 7714,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6798,
+                    "id": 7715,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6799,
+                    "id": 7716,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2703,21 +2703,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5949,
+                    "id": 6783,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5950,
+                    "id": 6784,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5951,
+                    "id": 6785,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2747,25 +2747,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6800,
+                    "id": 7717,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6801,
+                    "id": 7718,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6802,
+                    "id": 7719,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6803,
+                    "id": 7720,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2782,21 +2782,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5952,
+                    "id": 6786,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5953,
+                    "id": 6787,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5954,
+                    "id": 6788,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2828,25 +2828,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6804,
+                    "id": 7721,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6805,
+                    "id": 7722,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6806,
+                    "id": 7723,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6807,
+                    "id": 7724,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2863,21 +2863,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5955,
+                    "id": 6789,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5956,
+                    "id": 6790,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5957,
+                    "id": 6791,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2909,25 +2909,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6808,
+                    "id": 7725,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6809,
+                    "id": 7726,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6810,
+                    "id": 7727,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6811,
+                    "id": 7728,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2944,21 +2944,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5958,
+                    "id": 6792,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5959,
+                    "id": 6793,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5960,
+                    "id": 6794,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2990,31 +2990,31 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6812,
+                    "id": 7729,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6813,
+                    "id": 7730,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6814,
+                    "id": 7731,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6815,
+                    "id": 7732,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6816,
+                    "id": 7733,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3031,21 +3031,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5961,
+                    "id": 6795,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5962,
+                    "id": 6796,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5963,
+                    "id": 6797,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -3076,25 +3076,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6817,
+                    "id": 7734,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6818,
+                    "id": 7735,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6819,
+                    "id": 7736,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6820,
+                    "id": 7737,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3111,14 +3111,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5964,
+                    "id": 6798,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5965,
+                    "id": 6799,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3150,31 +3150,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6821,
+                    "id": 7738,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6822,
+                    "id": 7739,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6823,
+                    "id": 7740,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6824,
+                    "id": 7741,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6825,
+                    "id": 7742,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3191,14 +3191,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5966,
+                    "id": 6800,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5967,
+                    "id": 6801,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3230,37 +3230,37 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6826,
+                    "id": 7743,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6827,
+                    "id": 7744,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6828,
+                    "id": 7745,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6829,
+                    "id": 7746,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6830,
+                    "id": 7747,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6831,
+                    "id": 7748,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3277,14 +3277,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5968,
+                    "id": 6802,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5969,
+                    "id": 6803,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3316,31 +3316,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6832,
+                    "id": 7749,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6833,
+                    "id": 7750,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6834,
+                    "id": 7751,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6835,
+                    "id": 7752,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6836,
+                    "id": 7753,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3357,14 +3357,14 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 5970,
+                    "id": 6804,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5971,
+                    "id": 6805,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3396,31 +3396,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6837,
+                    "id": 7754,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6838,
+                    "id": 7755,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6839,
+                    "id": 7756,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6840,
+                    "id": 7757,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6841,
+                    "id": 7758,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3437,35 +3437,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5972,
+                    "id": 6806,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5973,
+                    "id": 6807,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5974,
+                    "id": 6808,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5975,
+                    "id": 6809,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5976,
+                    "id": 6810,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3498,25 +3498,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6842,
+                    "id": 7759,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6843,
+                    "id": 7760,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6844,
+                    "id": 7761,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6845,
+                    "id": 7762,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3533,35 +3533,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5977,
+                    "id": 6811,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5978,
+                    "id": 6812,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5979,
+                    "id": 6813,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5980,
+                    "id": 6814,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5981,
+                    "id": 6815,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3594,25 +3594,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6846,
+                    "id": 7763,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6847,
+                    "id": 7764,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6848,
+                    "id": 7765,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6849,
+                    "id": 7766,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3629,35 +3629,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5982,
+                    "id": 6816,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5983,
+                    "id": 6817,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5984,
+                    "id": 6818,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5985,
+                    "id": 6819,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5986,
+                    "id": 6820,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3690,25 +3690,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6850,
+                    "id": 7767,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6851,
+                    "id": 7768,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6852,
+                    "id": 7769,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6853,
+                    "id": 7770,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3725,35 +3725,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5987,
+                    "id": 6821,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5988,
+                    "id": 6822,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5989,
+                    "id": 6823,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5990,
+                    "id": 6824,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5991,
+                    "id": 6825,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3785,25 +3785,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6854,
+                    "id": 7771,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6855,
+                    "id": 7772,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6856,
+                    "id": 7773,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6857,
+                    "id": 7774,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3820,21 +3820,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5992,
+                    "id": 6826,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5993,
+                    "id": 6827,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5994,
+                    "id": 6828,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3863,25 +3863,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6858,
+                    "id": 7775,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6859,
+                    "id": 7776,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6860,
+                    "id": 7777,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6861,
+                    "id": 7778,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3898,21 +3898,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5995,
+                    "id": 6829,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5996,
+                    "id": 6830,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5997,
+                    "id": 6831,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3941,19 +3941,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6862,
+                    "id": 7779,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6863,
+                    "id": 7780,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6864,
+                    "id": 7781,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -3970,21 +3970,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5998,
+                    "id": 6832,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5999,
+                    "id": 6833,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6000,
+                    "id": 6834,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4012,19 +4012,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6865,
+                    "id": 7782,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6866,
+                    "id": 7783,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6867,
+                    "id": 7784,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4041,21 +4041,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6001,
+                    "id": 6835,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6002,
+                    "id": 6836,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6003,
+                    "id": 6837,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4083,19 +4083,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6868,
+                    "id": 7785,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6869,
+                    "id": 7786,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6870,
+                    "id": 7787,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4112,35 +4112,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6004,
+                    "id": 6838,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6005,
+                    "id": 6839,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6006,
+                    "id": 6840,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6007,
+                    "id": 6841,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6008,
+                    "id": 6842,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4172,25 +4172,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6871,
+                    "id": 7788,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6872,
+                    "id": 7789,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6873,
+                    "id": 7790,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6874,
+                    "id": 7791,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4207,35 +4207,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6009,
+                    "id": 6843,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6010,
+                    "id": 6844,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6011,
+                    "id": 6845,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6012,
+                    "id": 6846,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6013,
+                    "id": 6847,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4267,25 +4267,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6875,
+                    "id": 7792,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6876,
+                    "id": 7793,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6877,
+                    "id": 7794,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6878,
+                    "id": 7795,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4302,35 +4302,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6014,
+                    "id": 6848,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6015,
+                    "id": 6849,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6016,
+                    "id": 6850,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6017,
+                    "id": 6851,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6018,
+                    "id": 6852,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4362,25 +4362,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6879,
+                    "id": 7796,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6880,
+                    "id": 7797,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6881,
+                    "id": 7798,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6882,
+                    "id": 7799,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4397,35 +4397,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6019,
+                    "id": 6853,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6020,
+                    "id": 6854,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6021,
+                    "id": 6855,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6022,
+                    "id": 6856,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6023,
+                    "id": 6857,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4456,25 +4456,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6883,
+                    "id": 7800,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6884,
+                    "id": 7801,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6885,
+                    "id": 7802,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6886,
+                    "id": 7803,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4491,21 +4491,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6024,
+                    "id": 6858,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6025,
+                    "id": 6859,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6026,
+                    "id": 6860,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4538,25 +4538,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6887,
+                    "id": 7804,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6888,
+                    "id": 7805,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6889,
+                    "id": 7806,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6890,
+                    "id": 7807,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4573,21 +4573,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6861,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6862,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "id": 6863,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4621,25 +4621,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6891,
+                    "id": 7808,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6892,
+                    "id": 7809,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6893,
+                    "id": 7810,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6894,
+                    "id": 7811,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4656,21 +4656,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6030,
+                    "id": 6864,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6031,
+                    "id": 6865,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6032,
+                    "id": 6866,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4703,25 +4703,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6895,
+                    "id": 7812,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6896,
+                    "id": 7813,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6897,
+                    "id": 7814,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6898,
+                    "id": 7815,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4738,21 +4738,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6033,
+                    "id": 6867,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6034,
+                    "id": 6868,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6035,
+                    "id": 6869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4786,25 +4786,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6899,
+                    "id": 7816,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6900,
+                    "id": 7817,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6901,
+                    "id": 7818,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6902,
+                    "id": 7819,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4821,21 +4821,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6036,
+                    "id": 6870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6037,
+                    "id": 6871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6038,
+                    "id": 6872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4868,25 +4868,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6903,
+                    "id": 7820,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6904,
+                    "id": 7821,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6905,
+                    "id": 7822,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6906,
+                    "id": 7823,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4903,21 +4903,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6039,
+                    "id": 6873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6040,
+                    "id": 6874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6041,
+                    "id": 6875,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4950,25 +4950,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6907,
+                    "id": 7824,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6908,
+                    "id": 7825,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6909,
+                    "id": 7826,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6910,
+                    "id": 7827,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4985,21 +4985,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6042,
+                    "id": 6876,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6043,
+                    "id": 6877,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6044,
+                    "id": 6878,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5031,25 +5031,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6911,
+                    "id": 7828,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6912,
+                    "id": 7829,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6913,
+                    "id": 7830,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6914,
+                    "id": 7831,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5066,21 +5066,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6045,
+                    "id": 6879,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6046,
+                    "id": 6880,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6047,
+                    "id": 6881,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5113,25 +5113,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6915,
+                    "id": 7832,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6916,
+                    "id": 7833,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6917,
+                    "id": 7834,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6918,
+                    "id": 7835,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5148,35 +5148,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6048,
+                    "id": 6882,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6049,
+                    "id": 6883,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6050,
+                    "id": 6884,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6051,
+                    "id": 6885,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6052,
+                    "id": 6886,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5211,25 +5211,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6919,
+                    "id": 7836,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6920,
+                    "id": 7837,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6921,
+                    "id": 7838,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6922,
+                    "id": 7839,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5246,35 +5246,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6053,
+                    "id": 6887,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6054,
+                    "id": 6888,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6055,
+                    "id": 6889,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6056,
+                    "id": 6890,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6057,
+                    "id": 6891,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5309,25 +5309,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6923,
+                    "id": 7840,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6924,
+                    "id": 7841,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6925,
+                    "id": 7842,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6926,
+                    "id": 7843,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5344,35 +5344,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6058,
+                    "id": 6892,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6059,
+                    "id": 6893,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6060,
+                    "id": 6894,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6061,
+                    "id": 6895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6062,
+                    "id": 6896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5407,25 +5407,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6927,
+                    "id": 7844,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6928,
+                    "id": 7845,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6929,
+                    "id": 7846,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6930,
+                    "id": 7847,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5442,21 +5442,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6063,
+                    "id": 6897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6064,
+                    "id": 6898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6065,
+                    "id": 6899,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5489,31 +5489,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6931,
+                    "id": 7848,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6932,
+                    "id": 7849,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6933,
+                    "id": 7850,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6934,
+                    "id": 7851,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6935,
+                    "id": 7852,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5530,21 +5530,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6066,
+                    "id": 6900,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6067,
+                    "id": 6901,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6068,
+                    "id": 6902,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5577,31 +5577,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6936,
+                    "id": 7853,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6937,
+                    "id": 7854,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6938,
+                    "id": 7855,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6939,
+                    "id": 7856,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6940,
+                    "id": 7857,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5618,21 +5618,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6069,
+                    "id": 6903,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6070,
+                    "id": 6904,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6071,
+                    "id": 6905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5665,31 +5665,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6941,
+                    "id": 7858,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6942,
+                    "id": 7859,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6943,
+                    "id": 7860,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6944,
+                    "id": 7861,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6945,
+                    "id": 7862,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5706,21 +5706,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6072,
+                    "id": 6906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6073,
+                    "id": 6907,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6074,
+                    "id": 6908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5753,31 +5753,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6946,
+                    "id": 7863,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6947,
+                    "id": 7864,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6948,
+                    "id": 7865,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6949,
+                    "id": 7866,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6950,
+                    "id": 7867,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5794,28 +5794,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6075,
+                    "id": 6909,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6076,
+                    "id": 6910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6077,
+                    "id": 6911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6078,
+                    "id": 6912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5850,25 +5850,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6951,
+                    "id": 7868,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6952,
+                    "id": 7869,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6953,
+                    "id": 7870,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6954,
+                    "id": 7871,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5885,28 +5885,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6079,
+                    "id": 6913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6080,
+                    "id": 6914,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6081,
+                    "id": 6915,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6082,
+                    "id": 6916,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5941,25 +5941,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6955,
+                    "id": 7872,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6956,
+                    "id": 7873,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6957,
+                    "id": 7874,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6958,
+                    "id": 7875,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5976,28 +5976,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6083,
+                    "id": 6917,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6084,
+                    "id": 6918,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6085,
+                    "id": 6919,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6086,
+                    "id": 6920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6032,31 +6032,31 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6959,
+                    "id": 7876,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6960,
+                    "id": 7877,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6961,
+                    "id": 7878,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6962,
+                    "id": 7879,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
                 },
                 {
-                    "id": 6963,
+                    "id": 7880,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -6073,28 +6073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6087,
+                    "id": 6921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6088,
+                    "id": 6922,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6089,
+                    "id": 6923,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6090,
+                    "id": 6924,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6128,25 +6128,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6964,
+                    "id": 7881,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6965,
+                    "id": 7882,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6966,
+                    "id": 7883,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6967,
+                    "id": 7884,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -6163,21 +6163,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6091,
+                    "id": 6925,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6092,
+                    "id": 6926,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6093,
+                    "id": 6927,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6212,25 +6212,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6968,
+                    "id": 7885,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6969,
+                    "id": 7886,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6970,
+                    "id": 7887,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6971,
+                    "id": 7888,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6247,21 +6247,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6094,
+                    "id": 6928,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6095,
+                    "id": 6929,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6096,
+                    "id": 6930,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6296,31 +6296,31 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6972,
+                    "id": 7889,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6973,
+                    "id": 7890,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6974,
+                    "id": 7891,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6975,
+                    "id": 7892,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 6976,
+                    "id": 7893,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -6337,21 +6337,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6097,
+                    "id": 6931,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6098,
+                    "id": 6932,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6099,
+                    "id": 6933,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6385,25 +6385,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6977,
+                    "id": 7894,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6978,
+                    "id": 7895,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6979,
+                    "id": 7896,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6980,
+                    "id": 7897,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6420,21 +6420,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6100,
+                    "id": 6934,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6101,
+                    "id": 6935,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6102,
+                    "id": 6936,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6468,25 +6468,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6981,
+                    "id": 7898,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6982,
+                    "id": 7899,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6983,
+                    "id": 7900,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6984,
+                    "id": 7901,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6503,28 +6503,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6103,
+                    "id": 6937,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6104,
+                    "id": 6938,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6105,
+                    "id": 6939,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6106,
+                    "id": 6940,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6558,25 +6558,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6985,
+                    "id": 7902,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6986,
+                    "id": 7903,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6987,
+                    "id": 7904,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6988,
+                    "id": 7905,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6593,28 +6593,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6107,
+                    "id": 6941,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6108,
+                    "id": 6942,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6109,
+                    "id": 6943,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6110,
+                    "id": 6944,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6647,25 +6647,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6989,
+                    "id": 7906,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6990,
+                    "id": 7907,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6991,
+                    "id": 7908,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6992,
+                    "id": 7909,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6682,28 +6682,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6111,
+                    "id": 6945,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6112,
+                    "id": 6946,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6113,
+                    "id": 6947,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6114,
+                    "id": 6948,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6736,25 +6736,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6993,
+                    "id": 7910,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6994,
+                    "id": 7911,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6995,
+                    "id": 7912,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6996,
+                    "id": 7913,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6771,21 +6771,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6115,
+                    "id": 6949,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6116,
+                    "id": 6950,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6117,
+                    "id": 6951,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6815,19 +6815,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6997,
+                    "id": 7914,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6998,
+                    "id": 7915,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6999,
+                    "id": 7916,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6844,21 +6844,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6118,
+                    "id": 6952,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6119,
+                    "id": 6953,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6120,
+                    "id": 6954,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6888,19 +6888,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7000,
+                    "id": 7917,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7001,
+                    "id": 7918,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7002,
+                    "id": 7919,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6917,21 +6917,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6121,
+                    "id": 6955,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6122,
+                    "id": 6956,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6123,
+                    "id": 6957,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6961,19 +6961,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7003,
+                    "id": 7920,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7004,
+                    "id": 7921,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7005,
+                    "id": 7922,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6990,21 +6990,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6124,
+                    "id": 6958,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6125,
+                    "id": 6959,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6126,
+                    "id": 6960,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7033,25 +7033,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7006,
+                    "id": 7923,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7007,
+                    "id": 7924,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7008,
+                    "id": 7925,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7009,
+                    "id": 7926,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -7068,21 +7068,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6127,
+                    "id": 6961,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6128,
+                    "id": 6962,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6129,
+                    "id": 6963,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7111,19 +7111,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7010,
+                    "id": 7927,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7011,
+                    "id": 7928,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7012,
+                    "id": 7929,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7140,21 +7140,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6130,
+                    "id": 6964,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6131,
+                    "id": 6965,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6132,
+                    "id": 6966,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7183,19 +7183,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7013,
+                    "id": 7930,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7014,
+                    "id": 7931,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7015,
+                    "id": 7932,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7212,21 +7212,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6133,
+                    "id": 6967,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6134,
+                    "id": 6968,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6135,
+                    "id": 6969,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7255,19 +7255,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7016,
+                    "id": 7933,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7017,
+                    "id": 7934,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7018,
+                    "id": 7935,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7284,21 +7284,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6136,
+                    "id": 6970,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6137,
+                    "id": 6971,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6138,
+                    "id": 6972,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7327,19 +7327,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7019,
+                    "id": 7936,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7020,
+                    "id": 7937,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7021,
+                    "id": 7938,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7356,21 +7356,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6139,
+                    "id": 6973,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6140,
+                    "id": 6974,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6141,
+                    "id": 6975,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7398,19 +7398,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7022,
+                    "id": 7939,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7023,
+                    "id": 7940,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7024,
+                    "id": 7941,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7427,21 +7427,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6142,
+                    "id": 6976,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6143,
+                    "id": 6977,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6144,
+                    "id": 6978,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7470,25 +7470,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7025,
+                    "id": 7942,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7026,
+                    "id": 7943,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7027,
+                    "id": 7944,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7028,
+                    "id": 7945,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -7505,21 +7505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6145,
+                    "id": 6979,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6146,
+                    "id": 6980,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6147,
+                    "id": 6981,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7550,19 +7550,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7029,
+                    "id": 7946,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7030,
+                    "id": 7947,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7031,
+                    "id": 7948,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7579,21 +7579,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6148,
+                    "id": 6982,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6149,
+                    "id": 6983,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6150,
+                    "id": 6984,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7623,19 +7623,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7032,
+                    "id": 7949,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7033,
+                    "id": 7950,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7034,
+                    "id": 7951,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7652,21 +7652,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6151,
+                    "id": 6985,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6152,
+                    "id": 6986,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6153,
+                    "id": 6987,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7696,19 +7696,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7035,
+                    "id": 7952,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7036,
+                    "id": 7953,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7037,
+                    "id": 7954,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7725,21 +7725,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6154,
+                    "id": 6988,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6155,
+                    "id": 6989,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6156,
+                    "id": 6990,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7771,31 +7771,31 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7038,
+                    "id": 7955,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7039,
+                    "id": 7956,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7040,
+                    "id": 7957,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7041,
+                    "id": 7958,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7042,
+                    "id": 7959,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "3"
@@ -7812,21 +7812,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6157,
+                    "id": 6991,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6158,
+                    "id": 6992,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6159,
+                    "id": 6993,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7858,25 +7858,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7043,
+                    "id": 7960,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7044,
+                    "id": 7961,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7045,
+                    "id": 7962,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7046,
+                    "id": 7963,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7893,21 +7893,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6160,
+                    "id": 6994,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6161,
+                    "id": 6995,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6162,
+                    "id": 6996,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7938,25 +7938,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7047,
+                    "id": 7964,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7048,
+                    "id": 7965,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7049,
+                    "id": 7966,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7050,
+                    "id": 7967,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7973,21 +7973,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6163,
+                    "id": 6997,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6164,
+                    "id": 6998,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6165,
+                    "id": 6999,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8018,25 +8018,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7051,
+                    "id": 7968,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7052,
+                    "id": 7969,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7053,
+                    "id": 7970,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7054,
+                    "id": 7971,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8053,21 +8053,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6166,
+                    "id": 7000,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6167,
+                    "id": 7001,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6168,
+                    "id": 7002,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8099,25 +8099,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7055,
+                    "id": 7972,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7056,
+                    "id": 7973,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7057,
+                    "id": 7974,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7058,
+                    "id": 7975,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8134,21 +8134,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6169,
+                    "id": 7003,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6170,
+                    "id": 7004,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6171,
+                    "id": 7005,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8179,25 +8179,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7059,
+                    "id": 7976,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7060,
+                    "id": 7977,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7061,
+                    "id": 7978,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7062,
+                    "id": 7979,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8214,35 +8214,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6172,
+                    "id": 7006,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6173,
+                    "id": 7007,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6174,
+                    "id": 7008,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6175,
+                    "id": 7009,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6176,
+                    "id": 7010,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8272,31 +8272,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7063,
+                    "id": 7980,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7064,
+                    "id": 7981,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7065,
+                    "id": 7982,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7066,
+                    "id": 7983,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7067,
+                    "id": 7984,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8313,35 +8313,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6177,
+                    "id": 7011,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6178,
+                    "id": 7012,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6179,
+                    "id": 7013,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6180,
+                    "id": 7014,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6181,
+                    "id": 7015,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8371,31 +8371,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7068,
+                    "id": 7985,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7069,
+                    "id": 7986,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7070,
+                    "id": 7987,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7071,
+                    "id": 7988,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7072,
+                    "id": 7989,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8412,35 +8412,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6182,
+                    "id": 7016,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6183,
+                    "id": 7017,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6184,
+                    "id": 7018,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6185,
+                    "id": 7019,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6186,
+                    "id": 7020,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8470,25 +8470,25 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7073,
+                    "id": 7990,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7074,
+                    "id": 7991,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7075,
+                    "id": 7992,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7076,
+                    "id": 7993,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8505,35 +8505,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6187,
+                    "id": 7021,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6188,
+                    "id": 7022,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6189,
+                    "id": 7023,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6190,
+                    "id": 7024,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6191,
+                    "id": 7025,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8563,31 +8563,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7994,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7078,
+                    "id": 7995,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7996,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7080,
+                    "id": 7997,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7081,
+                    "id": 7998,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -8604,28 +8604,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6192,
+                    "id": 7026,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6193,
+                    "id": 7027,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6194,
+                    "id": 7028,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6195,
+                    "id": 7029,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8655,19 +8655,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7082,
+                    "id": 7999,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7083,
+                    "id": 8000,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7084,
+                    "id": 8001,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8684,28 +8684,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6196,
+                    "id": 7030,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6197,
+                    "id": 7031,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6198,
+                    "id": 7032,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6199,
+                    "id": 7033,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8735,19 +8735,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7085,
+                    "id": 8002,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7086,
+                    "id": 8003,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7087,
+                    "id": 8004,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8764,28 +8764,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6200,
+                    "id": 7034,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6201,
+                    "id": 7035,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6202,
+                    "id": 7036,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6203,
+                    "id": 7037,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8815,19 +8815,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7088,
+                    "id": 8005,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7089,
+                    "id": 8006,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7090,
+                    "id": 8007,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8844,28 +8844,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6204,
+                    "id": 7038,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6205,
+                    "id": 7039,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6206,
+                    "id": 7040,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6207,
+                    "id": 7041,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8894,19 +8894,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7091,
+                    "id": 8008,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7092,
+                    "id": 8009,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7093,
+                    "id": 8010,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8923,28 +8923,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6208,
+                    "id": 7042,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6209,
+                    "id": 7043,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6210,
+                    "id": 7044,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6211,
+                    "id": 7045,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8979,19 +8979,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7094,
+                    "id": 8011,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7095,
+                    "id": 8012,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7096,
+                    "id": 8013,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9008,28 +9008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6212,
+                    "id": 7046,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6213,
+                    "id": 7047,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6214,
+                    "id": 7048,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6215,
+                    "id": 7049,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9064,19 +9064,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7097,
+                    "id": 8014,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7098,
+                    "id": 8015,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7099,
+                    "id": 8016,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9093,28 +9093,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6216,
+                    "id": 7050,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6217,
+                    "id": 7051,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6218,
+                    "id": 7052,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6219,
+                    "id": 7053,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9149,19 +9149,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7100,
+                    "id": 8017,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7101,
+                    "id": 8018,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7102,
+                    "id": 8019,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9178,28 +9178,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6220,
+                    "id": 7054,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6221,
+                    "id": 7055,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6222,
+                    "id": 7056,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6223,
+                    "id": 7057,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9233,19 +9233,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7103,
+                    "id": 8020,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7104,
+                    "id": 8021,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7105,
+                    "id": 8022,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9262,28 +9262,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6224,
+                    "id": 7058,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6225,
+                    "id": 7059,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6226,
+                    "id": 7060,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6227,
+                    "id": 7061,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9318,19 +9318,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7106,
+                    "id": 8023,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7107,
+                    "id": 8024,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7108,
+                    "id": 8025,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9347,28 +9347,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6228,
+                    "id": 7062,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6229,
+                    "id": 7063,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6230,
+                    "id": 7064,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6231,
+                    "id": 7065,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9402,19 +9402,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7109,
+                    "id": 8026,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7110,
+                    "id": 8027,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7111,
+                    "id": 8028,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9431,28 +9431,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6232,
+                    "id": 7066,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6233,
+                    "id": 7067,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6234,
+                    "id": 7068,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6235,
+                    "id": 7069,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9483,25 +9483,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7112,
+                    "id": 8029,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7113,
+                    "id": 8030,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7114,
+                    "id": 8031,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7115,
+                    "id": 8032,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9518,28 +9518,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6236,
+                    "id": 7070,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6237,
+                    "id": 7071,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6238,
+                    "id": 7072,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6239,
+                    "id": 7073,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9570,25 +9570,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7116,
+                    "id": 8033,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7117,
+                    "id": 8034,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7118,
+                    "id": 8035,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7119,
+                    "id": 8036,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9605,28 +9605,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6240,
+                    "id": 7074,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6241,
+                    "id": 7075,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6242,
+                    "id": 7076,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6243,
+                    "id": 7077,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9656,25 +9656,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7120,
+                    "id": 8037,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7121,
+                    "id": 8038,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7122,
+                    "id": 8039,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7123,
+                    "id": 8040,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9691,28 +9691,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6244,
+                    "id": 7078,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6245,
+                    "id": 7079,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6246,
+                    "id": 7080,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6247,
+                    "id": 7081,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9742,25 +9742,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7124,
+                    "id": 8041,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7125,
+                    "id": 8042,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7126,
+                    "id": 8043,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7127,
+                    "id": 8044,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9777,21 +9777,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6248,
+                    "id": 7082,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6249,
+                    "id": 7083,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6250,
+                    "id": 7084,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9822,19 +9822,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7128,
+                    "id": 8045,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7129,
+                    "id": 8046,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7130,
+                    "id": 8047,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9851,21 +9851,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6251,
+                    "id": 7085,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6252,
+                    "id": 7086,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6253,
+                    "id": 7087,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9896,19 +9896,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7131,
+                    "id": 8048,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7132,
+                    "id": 8049,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7133,
+                    "id": 8050,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9925,21 +9925,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6254,
+                    "id": 7088,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6255,
+                    "id": 7089,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6256,
+                    "id": 7090,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9970,19 +9970,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7134,
+                    "id": 8051,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7135,
+                    "id": 8052,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7136,
+                    "id": 8053,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9999,21 +9999,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6257,
+                    "id": 7091,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6258,
+                    "id": 7092,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6259,
+                    "id": 7093,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10044,19 +10044,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7137,
+                    "id": 8054,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7138,
+                    "id": 8055,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7139,
+                    "id": 8056,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10073,21 +10073,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6260,
+                    "id": 7094,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6261,
+                    "id": 7095,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6262,
+                    "id": 7096,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10117,19 +10117,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7140,
+                    "id": 8057,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7141,
+                    "id": 8058,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7142,
+                    "id": 8059,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10146,35 +10146,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6263,
+                    "id": 7097,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6264,
+                    "id": 7098,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6265,
+                    "id": 7099,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6266,
+                    "id": 7100,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6267,
+                    "id": 7101,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10205,25 +10205,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7143,
+                    "id": 8060,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7144,
+                    "id": 8061,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7145,
+                    "id": 8062,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7146,
+                    "id": 8063,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10240,35 +10240,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6268,
+                    "id": 7102,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6269,
+                    "id": 7103,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6270,
+                    "id": 7104,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6271,
+                    "id": 7105,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6272,
+                    "id": 7106,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10299,25 +10299,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7147,
+                    "id": 8064,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7148,
+                    "id": 8065,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7149,
+                    "id": 8066,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7150,
+                    "id": 8067,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10334,35 +10334,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6273,
+                    "id": 7107,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6274,
+                    "id": 7108,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6275,
+                    "id": 7109,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6276,
+                    "id": 7110,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6277,
+                    "id": 7111,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10393,25 +10393,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7151,
+                    "id": 8068,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7152,
+                    "id": 8069,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7153,
+                    "id": 8070,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7154,
+                    "id": 8071,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10428,35 +10428,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6278,
+                    "id": 7112,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6279,
+                    "id": 7113,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6280,
+                    "id": 7114,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6281,
+                    "id": 7115,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6282,
+                    "id": 7116,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10487,25 +10487,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7155,
+                    "id": 8072,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7156,
+                    "id": 8073,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7157,
+                    "id": 8074,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7158,
+                    "id": 8075,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10522,35 +10522,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6283,
+                    "id": 7117,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6284,
+                    "id": 7118,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6285,
+                    "id": 7119,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6286,
+                    "id": 7120,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6287,
+                    "id": 7121,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10580,25 +10580,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7159,
+                    "id": 8076,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7160,
+                    "id": 8077,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7161,
+                    "id": 8078,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7162,
+                    "id": 8079,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10615,21 +10615,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6288,
+                    "id": 7122,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6289,
+                    "id": 7123,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6290,
+                    "id": 7124,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10662,25 +10662,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7163,
+                    "id": 8080,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7164,
+                    "id": 8081,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7165,
+                    "id": 8082,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7166,
+                    "id": 8083,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10697,21 +10697,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6291,
+                    "id": 7125,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6292,
+                    "id": 7126,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6293,
+                    "id": 7127,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10744,25 +10744,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7167,
+                    "id": 8084,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7168,
+                    "id": 8085,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7169,
+                    "id": 8086,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7170,
+                    "id": 8087,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10779,21 +10779,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6294,
+                    "id": 7128,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6295,
+                    "id": 7129,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6296,
+                    "id": 7130,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10826,25 +10826,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7171,
+                    "id": 8088,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7172,
+                    "id": 8089,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7173,
+                    "id": 8090,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7174,
+                    "id": 8091,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10861,21 +10861,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6297,
+                    "id": 7131,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6298,
+                    "id": 7132,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6299,
+                    "id": 7133,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10907,25 +10907,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7175,
+                    "id": 8092,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7176,
+                    "id": 8093,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7177,
+                    "id": 8094,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7178,
+                    "id": 8095,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10942,28 +10942,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6300,
+                    "id": 7134,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6301,
+                    "id": 7135,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6302,
+                    "id": 7136,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6303,
+                    "id": 7137,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10994,25 +10994,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7179,
+                    "id": 8096,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7180,
+                    "id": 8097,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7181,
+                    "id": 8098,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7182,
+                    "id": 8099,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11029,28 +11029,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6304,
+                    "id": 7138,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6305,
+                    "id": 7139,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6306,
+                    "id": 7140,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6307,
+                    "id": 7141,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11081,25 +11081,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7183,
+                    "id": 8100,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7184,
+                    "id": 8101,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7185,
+                    "id": 8102,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7186,
+                    "id": 8103,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11116,28 +11116,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6308,
+                    "id": 7142,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6309,
+                    "id": 7143,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6310,
+                    "id": 7144,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6311,
+                    "id": 7145,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11168,25 +11168,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7187,
+                    "id": 8104,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7188,
+                    "id": 8105,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7189,
+                    "id": 8106,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7190,
+                    "id": 8107,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11203,28 +11203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6312,
+                    "id": 7146,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6313,
+                    "id": 7147,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6314,
+                    "id": 7148,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6315,
+                    "id": 7149,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11254,25 +11254,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7191,
+                    "id": 8108,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7192,
+                    "id": 8109,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7193,
+                    "id": 8110,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7194,
+                    "id": 8111,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11289,28 +11289,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6316,
+                    "id": 7150,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6317,
+                    "id": 7151,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6318,
+                    "id": 7152,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6319,
+                    "id": 7153,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11343,25 +11343,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7195,
+                    "id": 8112,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7196,
+                    "id": 8113,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7197,
+                    "id": 8114,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7198,
+                    "id": 8115,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11378,28 +11378,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6320,
+                    "id": 7154,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6321,
+                    "id": 7155,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6322,
+                    "id": 7156,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6323,
+                    "id": 7157,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11432,25 +11432,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7199,
+                    "id": 8116,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7200,
+                    "id": 8117,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7201,
+                    "id": 8118,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7202,
+                    "id": 8119,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11467,28 +11467,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6324,
+                    "id": 7158,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6325,
+                    "id": 7159,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6326,
+                    "id": 7160,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6327,
+                    "id": 7161,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11521,25 +11521,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7203,
+                    "id": 8120,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7204,
+                    "id": 8121,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7205,
+                    "id": 8122,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7206,
+                    "id": 8123,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11556,28 +11556,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6328,
+                    "id": 7162,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6329,
+                    "id": 7163,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6330,
+                    "id": 7164,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6331,
+                    "id": 7165,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11609,25 +11609,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7207,
+                    "id": 8124,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7208,
+                    "id": 8125,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7209,
+                    "id": 8126,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7210,
+                    "id": 8127,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11644,35 +11644,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6332,
+                    "id": 7166,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6333,
+                    "id": 7167,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6334,
+                    "id": 7168,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6335,
+                    "id": 7169,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6336,
+                    "id": 7170,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11707,25 +11707,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7211,
+                    "id": 8128,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7212,
+                    "id": 8129,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7213,
+                    "id": 8130,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7214,
+                    "id": 8131,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11742,35 +11742,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6337,
+                    "id": 7171,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6338,
+                    "id": 7172,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6339,
+                    "id": 7173,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6340,
+                    "id": 7174,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6341,
+                    "id": 7175,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11805,25 +11805,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7215,
+                    "id": 8132,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7216,
+                    "id": 8133,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7217,
+                    "id": 8134,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7218,
+                    "id": 8135,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11840,35 +11840,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6342,
+                    "id": 7176,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6343,
+                    "id": 7177,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6344,
+                    "id": 7178,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6345,
+                    "id": 7179,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6346,
+                    "id": 7180,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11903,25 +11903,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7219,
+                    "id": 8136,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7220,
+                    "id": 8137,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7221,
+                    "id": 8138,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7222,
+                    "id": 8139,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11938,28 +11938,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6347,
+                    "id": 7181,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6348,
+                    "id": 7182,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6349,
+                    "id": 7183,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6350,
+                    "id": 7184,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11992,31 +11992,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7223,
+                    "id": 8140,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7224,
+                    "id": 8141,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7225,
+                    "id": 8142,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7226,
+                    "id": 8143,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7227,
+                    "id": 8144,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12033,28 +12033,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6351,
+                    "id": 7185,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6352,
+                    "id": 7186,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6353,
+                    "id": 7187,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6354,
+                    "id": 7188,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12087,37 +12087,37 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7228,
+                    "id": 8145,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7229,
+                    "id": 8146,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7230,
+                    "id": 8147,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7231,
+                    "id": 8148,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7232,
+                    "id": 8149,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7233,
+                    "id": 8150,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -12134,28 +12134,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6355,
+                    "id": 7189,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6356,
+                    "id": 7190,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6357,
+                    "id": 7191,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6358,
+                    "id": 7192,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12188,31 +12188,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7234,
+                    "id": 8151,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7235,
+                    "id": 8152,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7236,
+                    "id": 8153,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7237,
+                    "id": 8154,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7238,
+                    "id": 8155,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12229,28 +12229,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6359,
+                    "id": 7193,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6360,
+                    "id": 7194,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6361,
+                    "id": 7195,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6362,
+                    "id": 7196,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12283,31 +12283,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7239,
+                    "id": 8156,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7240,
+                    "id": 8157,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7241,
+                    "id": 8158,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7242,
+                    "id": 8159,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7243,
+                    "id": 8160,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12324,35 +12324,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6363,
+                    "id": 7197,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6364,
+                    "id": 7198,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6365,
+                    "id": 7199,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6366,
+                    "id": 7200,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6367,
+                    "id": 7201,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12387,25 +12387,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7244,
+                    "id": 8161,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7245,
+                    "id": 8162,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7246,
+                    "id": 8163,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7247,
+                    "id": 8164,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12422,35 +12422,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6368,
+                    "id": 7202,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6369,
+                    "id": 7203,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6370,
+                    "id": 7204,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6371,
+                    "id": 7205,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6372,
+                    "id": 7206,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12485,25 +12485,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7248,
+                    "id": 8165,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7249,
+                    "id": 8166,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7250,
+                    "id": 8167,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7251,
+                    "id": 8168,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12520,35 +12520,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6373,
+                    "id": 7207,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6374,
+                    "id": 7208,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6375,
+                    "id": 7209,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6376,
+                    "id": 7210,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6377,
+                    "id": 7211,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12582,25 +12582,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7252,
+                    "id": 8169,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7253,
+                    "id": 8170,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7254,
+                    "id": 8171,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7255,
+                    "id": 8172,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12617,28 +12617,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6378,
+                    "id": 7212,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6379,
+                    "id": 7213,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6380,
+                    "id": 7214,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6381,
+                    "id": 7215,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12674,31 +12674,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7256,
+                    "id": 8173,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7257,
+                    "id": 8174,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7258,
+                    "id": 8175,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7259,
+                    "id": 8176,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7260,
+                    "id": 8177,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12715,28 +12715,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6382,
+                    "id": 7216,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6383,
+                    "id": 7217,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6384,
+                    "id": 7218,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6385,
+                    "id": 7219,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12772,31 +12772,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7261,
+                    "id": 8178,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7262,
+                    "id": 8179,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7263,
+                    "id": 8180,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7264,
+                    "id": 8181,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7265,
+                    "id": 8182,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12813,28 +12813,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6386,
+                    "id": 7220,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6387,
+                    "id": 7221,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6388,
+                    "id": 7222,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6389,
+                    "id": 7223,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12870,31 +12870,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7266,
+                    "id": 8183,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7267,
+                    "id": 8184,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7268,
+                    "id": 8185,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7269,
+                    "id": 8186,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7270,
+                    "id": 8187,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12911,28 +12911,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6390,
+                    "id": 7224,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6391,
+                    "id": 7225,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6392,
+                    "id": 7226,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6393,
+                    "id": 7227,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12967,31 +12967,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7271,
+                    "id": 8188,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7272,
+                    "id": 8189,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7273,
+                    "id": 8190,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7274,
+                    "id": 8191,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7275,
+                    "id": 8192,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13008,28 +13008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6394,
+                    "id": 7228,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6395,
+                    "id": 7229,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6396,
+                    "id": 7230,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6397,
+                    "id": 7231,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13065,31 +13065,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7276,
+                    "id": 8193,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7277,
+                    "id": 8194,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7278,
+                    "id": 8195,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7279,
+                    "id": 8196,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7280,
+                    "id": 8197,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13106,28 +13106,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6398,
+                    "id": 7232,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6399,
+                    "id": 7233,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6400,
+                    "id": 7234,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6401,
+                    "id": 7235,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13162,31 +13162,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7281,
+                    "id": 8198,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7282,
+                    "id": 8199,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7283,
+                    "id": 8200,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7284,
+                    "id": 8201,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7285,
+                    "id": 8202,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13203,28 +13203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6402,
+                    "id": 7236,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6403,
+                    "id": 7237,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6404,
+                    "id": 7238,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6405,
+                    "id": 7239,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13254,19 +13254,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7286,
+                    "id": 8203,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7287,
+                    "id": 8204,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7288,
+                    "id": 8205,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13283,28 +13283,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6406,
+                    "id": 7240,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6407,
+                    "id": 7241,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6408,
+                    "id": 7242,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6409,
+                    "id": 7243,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13334,19 +13334,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7289,
+                    "id": 8206,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7290,
+                    "id": 8207,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7291,
+                    "id": 8208,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13363,28 +13363,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6410,
+                    "id": 7244,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6411,
+                    "id": 7245,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6412,
+                    "id": 7246,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6413,
+                    "id": 7247,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13413,19 +13413,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7292,
+                    "id": 8209,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7293,
+                    "id": 8210,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7294,
+                    "id": 8211,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13442,28 +13442,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6414,
+                    "id": 7248,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6415,
+                    "id": 7249,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6416,
+                    "id": 7250,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6417,
+                    "id": 7251,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13493,19 +13493,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7295,
+                    "id": 8212,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7296,
+                    "id": 8213,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7297,
+                    "id": 8214,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13522,28 +13522,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6418,
+                    "id": 7252,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6419,
+                    "id": 7253,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6420,
+                    "id": 7254,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6421,
+                    "id": 7255,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13573,19 +13573,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7298,
+                    "id": 8215,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7299,
+                    "id": 8216,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7300,
+                    "id": 8217,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13602,28 +13602,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6422,
+                    "id": 7256,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6423,
+                    "id": 7257,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6424,
+                    "id": 7258,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6425,
+                    "id": 7259,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13652,19 +13652,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7301,
+                    "id": 8218,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7302,
+                    "id": 8219,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7303,
+                    "id": 8220,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13681,21 +13681,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6426,
+                    "id": 7260,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6427,
+                    "id": 7261,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6428,
+                    "id": 7262,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13728,19 +13728,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7304,
+                    "id": 8221,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7305,
+                    "id": 8222,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7306,
+                    "id": 8223,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13757,21 +13757,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6429,
+                    "id": 7263,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6430,
+                    "id": 7264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6431,
+                    "id": 7265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13803,19 +13803,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7307,
+                    "id": 8224,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7308,
+                    "id": 8225,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7309,
+                    "id": 8226,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13832,21 +13832,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6432,
+                    "id": 7266,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6433,
+                    "id": 7267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6434,
+                    "id": 7268,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13878,19 +13878,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7310,
+                    "id": 8227,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7311,
+                    "id": 8228,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7312,
+                    "id": 8229,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13907,21 +13907,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6435,
+                    "id": 7269,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6436,
+                    "id": 7270,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6437,
+                    "id": 7271,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13953,19 +13953,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7313,
+                    "id": 8230,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7314,
+                    "id": 8231,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7315,
+                    "id": 8232,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13982,28 +13982,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6438,
+                    "id": 7272,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6439,
+                    "id": 7273,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6440,
+                    "id": 7274,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6441,
+                    "id": 7275,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14038,25 +14038,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7316,
+                    "id": 8233,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7317,
+                    "id": 8234,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7318,
+                    "id": 8235,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7319,
+                    "id": 8236,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14073,28 +14073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6442,
+                    "id": 7276,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6443,
+                    "id": 7277,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6444,
+                    "id": 7278,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6445,
+                    "id": 7279,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14129,25 +14129,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7320,
+                    "id": 8237,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7321,
+                    "id": 8238,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7322,
+                    "id": 8239,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7323,
+                    "id": 8240,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14164,28 +14164,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6446,
+                    "id": 7280,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6447,
+                    "id": 7281,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6448,
+                    "id": 7282,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6449,
+                    "id": 7283,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14220,25 +14220,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7324,
+                    "id": 8241,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7325,
+                    "id": 8242,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7326,
+                    "id": 8243,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7327,
+                    "id": 8244,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14255,28 +14255,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6450,
+                    "id": 7284,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6451,
+                    "id": 7285,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6452,
+                    "id": 7286,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6453,
+                    "id": 7287,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14310,25 +14310,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7328,
+                    "id": 8245,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7329,
+                    "id": 8246,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7330,
+                    "id": 8247,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7331,
+                    "id": 8248,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14345,21 +14345,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6454,
+                    "id": 7288,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6455,
+                    "id": 7289,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6456,
+                    "id": 7290,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14390,25 +14390,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7332,
+                    "id": 8249,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7333,
+                    "id": 8250,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7334,
+                    "id": 8251,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7335,
+                    "id": 8252,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14425,21 +14425,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6457,
+                    "id": 7291,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6458,
+                    "id": 7292,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6459,
+                    "id": 7293,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14470,25 +14470,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7336,
+                    "id": 8253,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7337,
+                    "id": 8254,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7338,
+                    "id": 8255,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7339,
+                    "id": 8256,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14505,21 +14505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6460,
+                    "id": 7294,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6461,
+                    "id": 7295,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6462,
+                    "id": 7296,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14549,25 +14549,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7340,
+                    "id": 8257,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7341,
+                    "id": 8258,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7342,
+                    "id": 8259,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7343,
+                    "id": 8260,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14584,21 +14584,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6463,
+                    "id": 7297,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6464,
+                    "id": 7298,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6465,
+                    "id": 7299,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14629,25 +14629,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7344,
+                    "id": 8261,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7345,
+                    "id": 8262,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7346,
+                    "id": 8263,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7347,
+                    "id": 8264,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14664,21 +14664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6466,
+                    "id": 7300,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6467,
+                    "id": 7301,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6468,
+                    "id": 7302,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14708,25 +14708,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7348,
+                    "id": 8265,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7349,
+                    "id": 8266,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7350,
+                    "id": 8267,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7351,
+                    "id": 8268,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14743,35 +14743,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6469,
+                    "id": 7303,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6470,
+                    "id": 7304,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6471,
+                    "id": 7305,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6472,
+                    "id": 7306,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6473,
+                    "id": 7307,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14804,31 +14804,31 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7352,
+                    "id": 8269,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7353,
+                    "id": 8270,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7354,
+                    "id": 8271,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7355,
+                    "id": 8272,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7356,
+                    "id": 8273,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "3"
@@ -14845,35 +14845,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6474,
+                    "id": 7308,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6475,
+                    "id": 7309,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6476,
+                    "id": 7310,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6477,
+                    "id": 7311,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6478,
+                    "id": 7312,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14906,25 +14906,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7357,
+                    "id": 8274,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7358,
+                    "id": 8275,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7359,
+                    "id": 8276,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7360,
+                    "id": 8277,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14941,35 +14941,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6479,
+                    "id": 7313,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6480,
+                    "id": 7314,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6481,
+                    "id": 7315,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6482,
+                    "id": 7316,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6483,
+                    "id": 7317,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15001,25 +15001,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7361,
+                    "id": 8278,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7362,
+                    "id": 8279,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7363,
+                    "id": 8280,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7364,
+                    "id": 8281,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15036,35 +15036,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6484,
+                    "id": 7318,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6485,
+                    "id": 7319,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6486,
+                    "id": 7320,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6487,
+                    "id": 7321,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6488,
+                    "id": 7322,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15096,25 +15096,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7365,
+                    "id": 8282,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7366,
+                    "id": 8283,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7367,
+                    "id": 8284,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7368,
+                    "id": 8285,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15131,28 +15131,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6489,
+                    "id": 7323,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6490,
+                    "id": 7324,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6491,
+                    "id": 7325,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6492,
+                    "id": 7326,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 }
@@ -15184,25 +15184,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7369,
+                    "id": 8286,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7370,
+                    "id": 8287,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7371,
+                    "id": 8288,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7372,
+                    "id": 8289,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15219,28 +15219,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6493,
+                    "id": 7327,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6494,
+                    "id": 7328,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6495,
+                    "id": 7329,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6496,
+                    "id": 7330,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15272,25 +15272,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7373,
+                    "id": 8290,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7374,
+                    "id": 8291,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7375,
+                    "id": 8292,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7376,
+                    "id": 8293,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15307,28 +15307,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6497,
+                    "id": 7331,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6498,
+                    "id": 7332,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6499,
+                    "id": 7333,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6500,
+                    "id": 7334,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15360,25 +15360,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7377,
+                    "id": 8294,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7378,
+                    "id": 8295,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7379,
+                    "id": 8296,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7380,
+                    "id": 8297,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15395,28 +15395,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6501,
+                    "id": 7335,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6502,
+                    "id": 7336,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6503,
+                    "id": 7337,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6504,
+                    "id": 7338,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15448,25 +15448,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7381,
+                    "id": 8298,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7382,
+                    "id": 8299,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7383,
+                    "id": 8300,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7384,
+                    "id": 8301,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15483,28 +15483,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6505,
+                    "id": 7339,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6506,
+                    "id": 7340,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6507,
+                    "id": 7341,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6508,
+                    "id": 7342,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15535,25 +15535,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7385,
+                    "id": 8302,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7386,
+                    "id": 8303,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7387,
+                    "id": 8304,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7388,
+                    "id": 8305,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15570,28 +15570,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6509,
+                    "id": 7343,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6510,
+                    "id": 7344,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6511,
+                    "id": 7345,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6512,
+                    "id": 7346,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15621,25 +15621,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7389,
+                    "id": 8306,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7390,
+                    "id": 8307,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7391,
+                    "id": 8308,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7392,
+                    "id": 8309,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15656,28 +15656,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6513,
+                    "id": 7347,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6514,
+                    "id": 7348,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6515,
+                    "id": 7349,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6516,
+                    "id": 7350,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15707,25 +15707,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7393,
+                    "id": 8310,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7394,
+                    "id": 8311,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7395,
+                    "id": 8312,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7396,
+                    "id": 8313,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15742,28 +15742,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6517,
+                    "id": 7351,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6518,
+                    "id": 7352,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6519,
+                    "id": 7353,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6520,
+                    "id": 7354,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15793,25 +15793,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7397,
+                    "id": 8314,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7398,
+                    "id": 8315,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7399,
+                    "id": 8316,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7400,
+                    "id": 8317,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15828,28 +15828,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6521,
+                    "id": 7355,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6522,
+                    "id": 7356,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6523,
+                    "id": 7357,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6524,
+                    "id": 7358,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15879,25 +15879,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7401,
+                    "id": 8318,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7402,
+                    "id": 8319,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7403,
+                    "id": 8320,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7404,
+                    "id": 8321,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15914,28 +15914,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6525,
+                    "id": 7359,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6526,
+                    "id": 7360,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6527,
+                    "id": 7361,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6528,
+                    "id": 7362,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15964,25 +15964,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7405,
+                    "id": 8322,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7406,
+                    "id": 8323,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7407,
+                    "id": 8324,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7408,
+                    "id": 8325,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15999,28 +15999,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6529,
+                    "id": 7363,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6530,
+                    "id": 7364,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6531,
+                    "id": 7365,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6532,
+                    "id": 7366,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16049,25 +16049,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7409,
+                    "id": 8326,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7410,
+                    "id": 8327,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7411,
+                    "id": 8328,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7412,
+                    "id": 8329,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16084,28 +16084,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6533,
+                    "id": 7367,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6534,
+                    "id": 7368,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6535,
+                    "id": 7369,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6536,
+                    "id": 7370,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16135,25 +16135,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7413,
+                    "id": 8330,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7414,
+                    "id": 8331,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7415,
+                    "id": 8332,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7416,
+                    "id": 8333,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16170,28 +16170,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6537,
+                    "id": 7371,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6538,
+                    "id": 7372,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6539,
+                    "id": 7373,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6540,
+                    "id": 7374,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16220,25 +16220,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7417,
+                    "id": 8334,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7418,
+                    "id": 8335,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7419,
+                    "id": 8336,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7420,
+                    "id": 8337,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16255,21 +16255,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6541,
+                    "id": 7375,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6542,
+                    "id": 7376,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6543,
+                    "id": 7377,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16302,25 +16302,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7421,
+                    "id": 8338,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7422,
+                    "id": 8339,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7423,
+                    "id": 8340,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7424,
+                    "id": 8341,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16337,21 +16337,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6544,
+                    "id": 7378,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6545,
+                    "id": 7379,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6546,
+                    "id": 7380,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16384,25 +16384,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7425,
+                    "id": 8342,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7426,
+                    "id": 8343,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7427,
+                    "id": 8344,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7428,
+                    "id": 8345,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16419,21 +16419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6547,
+                    "id": 7381,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6548,
+                    "id": 7382,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6549,
+                    "id": 7383,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16466,25 +16466,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7429,
+                    "id": 8346,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7430,
+                    "id": 8347,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7431,
+                    "id": 8348,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7432,
+                    "id": 8349,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16501,21 +16501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6550,
+                    "id": 7384,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6551,
+                    "id": 7385,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6552,
+                    "id": 7386,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16547,25 +16547,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7433,
+                    "id": 8350,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7434,
+                    "id": 8351,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7435,
+                    "id": 8352,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7436,
+                    "id": 8353,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16582,21 +16582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6553,
+                    "id": 7387,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6554,
+                    "id": 7388,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6555,
+                    "id": 7389,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16629,25 +16629,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7437,
+                    "id": 8354,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7438,
+                    "id": 8355,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7439,
+                    "id": 8356,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7440,
+                    "id": 8357,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16664,21 +16664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6556,
+                    "id": 7390,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6557,
+                    "id": 7391,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6558,
+                    "id": 7392,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16710,25 +16710,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7441,
+                    "id": 8358,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7442,
+                    "id": 8359,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7443,
+                    "id": 8360,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7444,
+                    "id": 8361,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16745,28 +16745,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6559,
+                    "id": 7393,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6560,
+                    "id": 7394,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6561,
+                    "id": 7395,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6562,
+                    "id": 7396,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16801,25 +16801,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7445,
+                    "id": 8362,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7446,
+                    "id": 8363,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7447,
+                    "id": 8364,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7448,
+                    "id": 8365,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16836,28 +16836,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6563,
+                    "id": 7397,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6564,
+                    "id": 7398,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6565,
+                    "id": 7399,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6566,
+                    "id": 7400,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16892,25 +16892,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7449,
+                    "id": 8366,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7450,
+                    "id": 8367,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7451,
+                    "id": 8368,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7452,
+                    "id": 8369,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16927,28 +16927,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6567,
+                    "id": 7401,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6568,
+                    "id": 7402,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6569,
+                    "id": 7403,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6570,
+                    "id": 7404,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16983,25 +16983,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7453,
+                    "id": 8370,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7454,
+                    "id": 8371,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7455,
+                    "id": 8372,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7456,
+                    "id": 8373,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17018,28 +17018,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6571,
+                    "id": 7405,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6572,
+                    "id": 7406,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6573,
+                    "id": 7407,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6574,
+                    "id": 7408,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17074,25 +17074,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7457,
+                    "id": 8374,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7458,
+                    "id": 8375,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7459,
+                    "id": 8376,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7460,
+                    "id": 8377,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17109,21 +17109,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6575,
+                    "id": 7409,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6576,
+                    "id": 7410,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6577,
+                    "id": 7411,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17156,25 +17156,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7461,
+                    "id": 8378,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7462,
+                    "id": 8379,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7463,
+                    "id": 8380,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7464,
+                    "id": 8381,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17191,21 +17191,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6578,
+                    "id": 7412,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6579,
+                    "id": 7413,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6580,
+                    "id": 7414,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17238,25 +17238,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7465,
+                    "id": 8382,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7466,
+                    "id": 8383,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7467,
+                    "id": 8384,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7468,
+                    "id": 8385,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17273,21 +17273,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6581,
+                    "id": 7415,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6582,
+                    "id": 7416,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6583,
+                    "id": 7417,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17319,25 +17319,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7469,
+                    "id": 8386,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7470,
+                    "id": 8387,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7471,
+                    "id": 8388,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7472,
+                    "id": 8389,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17354,21 +17354,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6584,
+                    "id": 7418,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6585,
+                    "id": 7419,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6586,
+                    "id": 7420,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17402,31 +17402,31 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7473,
+                    "id": 8390,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7474,
+                    "id": 8391,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7475,
+                    "id": 8392,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7476,
+                    "id": 8393,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7477,
+                    "id": 8394,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -17443,21 +17443,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6587,
+                    "id": 7421,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6588,
+                    "id": 7422,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6589,
+                    "id": 7423,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17491,25 +17491,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7478,
+                    "id": 8395,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7479,
+                    "id": 8396,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7480,
+                    "id": 8397,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7481,
+                    "id": 8398,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17526,21 +17526,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6590,
+                    "id": 7424,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6591,
+                    "id": 7425,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6592,
+                    "id": 7426,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17573,25 +17573,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7482,
+                    "id": 8399,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7483,
+                    "id": 8400,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7484,
+                    "id": 8401,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7485,
+                    "id": 8402,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17608,28 +17608,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6593,
+                    "id": 7427,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6594,
+                    "id": 7428,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6595,
+                    "id": 7429,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6596,
+                    "id": 7430,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17662,25 +17662,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7486,
+                    "id": 8403,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7487,
+                    "id": 8404,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7488,
+                    "id": 8405,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7489,
+                    "id": 8406,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17697,28 +17697,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6597,
+                    "id": 7431,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6598,
+                    "id": 7432,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6599,
+                    "id": 7433,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6600,
+                    "id": 7434,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17751,31 +17751,31 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7490,
+                    "id": 8407,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7491,
+                    "id": 8408,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7492,
+                    "id": 8409,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7493,
+                    "id": 8410,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7494,
+                    "id": 8411,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -17792,28 +17792,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6601,
+                    "id": 7435,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6602,
+                    "id": 7436,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6603,
+                    "id": 7437,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6604,
+                    "id": 7438,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17846,25 +17846,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7495,
+                    "id": 8412,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7496,
+                    "id": 8413,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7497,
+                    "id": 8414,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7498,
+                    "id": 8415,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17881,21 +17881,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6605,
+                    "id": 7439,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6606,
+                    "id": 7440,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6607,
+                    "id": 7441,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17931,25 +17931,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7499,
+                    "id": 8416,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7500,
+                    "id": 8417,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7501,
+                    "id": 8418,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7502,
+                    "id": 8419,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17966,21 +17966,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6608,
+                    "id": 7442,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6609,
+                    "id": 7443,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6610,
+                    "id": 7444,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18016,31 +18016,31 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7503,
+                    "id": 8420,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7504,
+                    "id": 8421,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7505,
+                    "id": 8422,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7506,
+                    "id": 8423,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7507,
+                    "id": 8424,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -18057,21 +18057,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6611,
+                    "id": 7445,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6612,
+                    "id": 7446,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6613,
+                    "id": 7447,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18107,25 +18107,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7508,
+                    "id": 8425,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7509,
+                    "id": 8426,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7510,
+                    "id": 8427,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7511,
+                    "id": 8428,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18142,21 +18142,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6614,
+                    "id": 7448,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6615,
+                    "id": 7449,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6616,
+                    "id": 7450,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18191,25 +18191,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7512,
+                    "id": 8429,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7513,
+                    "id": 8430,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7514,
+                    "id": 8431,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7515,
+                    "id": 8432,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18226,21 +18226,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6617,
+                    "id": 7451,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6618,
+                    "id": 7452,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6619,
+                    "id": 7453,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18273,31 +18273,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7516,
+                    "id": 8433,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7517,
+                    "id": 8434,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7518,
+                    "id": 8435,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7519,
+                    "id": 8436,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7520,
+                    "id": 8437,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -18314,21 +18314,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6620,
+                    "id": 7454,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6621,
+                    "id": 7455,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6622,
+                    "id": 7456,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18346,7 +18346,7 @@
                 6
             ],
             "card_type_id": 1,
-            "cost": "54",
+            "cost": "56",
             "faction_id": 3,
             "ffg_id": "XW_P_215",
             "force_side": null,
@@ -18356,30 +18356,30 @@
             "is_unique": true,
             "name": "•Manaroo",
             "restrictions": [],
-            "ship_ability_text": null,
+            "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7521,
+                    "id": 8438,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7522,
+                    "id": 8439,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7523,
+                    "id": 8440,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7524,
+                    "id": 8441,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18396,21 +18396,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6623,
+                    "id": 7457,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6624,
+                    "id": 7458,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6625,
+                    "id": 7459,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18443,31 +18443,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7525,
+                    "id": 8442,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7526,
+                    "id": 8443,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7527,
+                    "id": 8444,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7528,
+                    "id": 8445,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7529,
+                    "id": 8446,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -18484,21 +18484,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6626,
+                    "id": 7460,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6627,
+                    "id": 7461,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6628,
+                    "id": 7462,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18530,25 +18530,25 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7530,
+                    "id": 8447,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7531,
+                    "id": 8448,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7532,
+                    "id": 8449,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7533,
+                    "id": 8450,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18565,28 +18565,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6629,
+                    "id": 7463,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6630,
+                    "id": 7464,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6631,
+                    "id": 7465,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6632,
+                    "id": 7466,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18619,31 +18619,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7534,
+                    "id": 8451,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7535,
+                    "id": 8452,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7536,
+                    "id": 8453,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7537,
+                    "id": 8454,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7538,
+                    "id": 8455,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18660,28 +18660,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6633,
+                    "id": 7467,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6634,
+                    "id": 7468,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6635,
+                    "id": 7469,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6636,
+                    "id": 7470,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18714,37 +18714,37 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7539,
+                    "id": 8456,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7540,
+                    "id": 8457,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7541,
+                    "id": 8458,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7542,
+                    "id": 8459,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7543,
+                    "id": 8460,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7544,
+                    "id": 8461,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -18761,28 +18761,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6637,
+                    "id": 7471,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6638,
+                    "id": 7472,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6639,
+                    "id": 7473,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6640,
+                    "id": 7474,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18815,31 +18815,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7545,
+                    "id": 8462,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7546,
+                    "id": 8463,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7547,
+                    "id": 8464,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7548,
+                    "id": 8465,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7549,
+                    "id": 8466,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18856,28 +18856,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6641,
+                    "id": 7475,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6642,
+                    "id": 7476,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6643,
+                    "id": 7477,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6644,
+                    "id": 7478,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18909,31 +18909,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7550,
+                    "id": 8467,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7551,
+                    "id": 8468,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7552,
+                    "id": 8469,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7553,
+                    "id": 8470,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7554,
+                    "id": 8471,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18950,28 +18950,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6645,
+                    "id": 7479,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6646,
+                    "id": 7480,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6647,
+                    "id": 7481,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6648,
+                    "id": 7482,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19006,25 +19006,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7555,
+                    "id": 8472,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7556,
+                    "id": 8473,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7557,
+                    "id": 8474,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7558,
+                    "id": 8475,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19041,28 +19041,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6649,
+                    "id": 7483,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6650,
+                    "id": 7484,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6651,
+                    "id": 7485,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6652,
+                    "id": 7486,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19097,25 +19097,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7559,
+                    "id": 8476,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7560,
+                    "id": 8477,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7561,
+                    "id": 8478,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7562,
+                    "id": 8479,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19132,28 +19132,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6653,
+                    "id": 7487,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6654,
+                    "id": 7488,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6655,
+                    "id": 7489,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6656,
+                    "id": 7490,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19187,25 +19187,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7563,
+                    "id": 8480,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7564,
+                    "id": 8481,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7565,
+                    "id": 8482,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7566,
+                    "id": 8483,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19222,28 +19222,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 7491,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 7492,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 7493,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 7494,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19277,25 +19277,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 8484,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 8485,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 8486,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 8487,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19312,21 +19312,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6661,
+                    "id": 7495,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6662,
+                    "id": 7496,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6663,
+                    "id": 7497,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19356,25 +19356,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7571,
+                    "id": 8488,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7572,
+                    "id": 8489,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7573,
+                    "id": 8490,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7574,
+                    "id": 8491,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19391,21 +19391,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6664,
+                    "id": 7498,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6665,
+                    "id": 7499,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6666,
+                    "id": 7500,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19435,25 +19435,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7575,
+                    "id": 8492,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7576,
+                    "id": 8493,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7577,
+                    "id": 8494,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7578,
+                    "id": 8495,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19470,21 +19470,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6667,
+                    "id": 7501,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6668,
+                    "id": 7502,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6669,
+                    "id": 7503,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19514,25 +19514,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 8496,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7580,
+                    "id": 8497,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7581,
+                    "id": 8498,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7582,
+                    "id": 8499,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19549,21 +19549,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6670,
+                    "id": 7504,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6671,
+                    "id": 7505,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6672,
+                    "id": 7506,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19589,31 +19589,31 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7583,
+                    "id": 8500,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7584,
+                    "id": 8501,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7585,
+                    "id": 8502,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7586,
+                    "id": 8503,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7587,
+                    "id": 8504,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "3"
@@ -20685,7 +20685,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
@@ -20724,7 +20724,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, tutti i risultati <hit>/<crit> infliggono segnalini disturbo invece di danni.",
@@ -20763,7 +20763,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, tutti i risultati <hit>/<crit> infliggono segnalini raggio traente invece di danni.",
@@ -20802,7 +20802,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco</smallcaps>",
@@ -20849,7 +20849,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
@@ -20897,7 +20897,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Cambia 1 risultato <hit> in 1 risultato <crit>.",
@@ -20989,7 +20989,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1 <standardcharge>. Cambia 1 risultato <hit> in 1 risultato <crit>.",
@@ -21036,7 +21036,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><focus><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Se il difensore è nel tuo <bullseye>, puoi spendere 1 o più <standardcharge> per ripetere il tiro di un pari ammontare di dadi di attacco.",
@@ -21080,7 +21080,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Dopo questo attacco, puoi effettuare questo attacco come attacco bonus contro un bersaglio diverso a gittata 0-1 dal difensore, ignorando il requisito <targetlock>.",
@@ -21126,7 +21126,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Dopo che questo attacco ha colpito, ogni nave a gittata 0-1 dal difensore espone 1 sua carta danno.",
@@ -21172,7 +21172,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Dopo che hai dichiarato il difensore, questi può scegliere di subire 1 danno <hit>. Se lo fa, salta i passi “Dadi di Attacco” e “Dadi di Difesa” e considera l’attacco come se avesse colpito.",
@@ -21217,7 +21217,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>.Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
@@ -21262,7 +21262,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><focus><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>.",
@@ -21307,7 +21307,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "Mentre difendi, prima che i dadi di attacco siano tirati, puoi spendere 1 bersaglio acquisito che possiedi sull’attaccante per tirare 1 dado di attacco. Se lo fai, l’attaccante ottiene 1 segnalino disturbo. Poi, con un risultato <hit> o <crit>, ottieni 1 segnalino disturbo.",

--- a/translation_helper/api_export_it.json
+++ b/translation_helper/api_export_it.json
@@ -1,6 +1,745 @@
 {
     "cards": [
         {
+            "ability_text": "Mentre effettui un attacco, il difensore tira 1 dado di difesa in meno.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5839,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5840,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5841,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_1",
+            "force_side": null,
+            "id": 1,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Wedge Antilles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6671,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6672,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6673,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6674,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rosso Due",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che sei diventato il difensore (prima che i dadi siano tirati), puoi recuperare 1<nonbreak><forcecharge>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5842,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5843,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5844,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                17,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "62",
+            "faction_id": 1,
+            "ffg_id": "XW_P_2",
+            "force_side": 2,
+            "id": 2,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Luke Skywalker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6675,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6676,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6677,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6678,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 6679,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rosso Cinque",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco, puoi spendere 1 risultato <focus>, <hit> o <crit> per guardare le carte danno a faccia in giù del difensore, sceglierne 1 ed esporla.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5845,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5846,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5847,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_set_ids": [
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_3",
+            "force_side": null,
+            "id": 3,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Thane Kyrell",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6680,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6681,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6682,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6683,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Corona Quattro",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai speso un segnalino concentrazione, puoi scegliere 1 nave amica a gittata 1-3. Quella nave ottiene 1 segnalino concentrazione.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5848,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5849,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5850,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_4",
+            "force_side": null,
+            "id": 4,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6684,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6685,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6686,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6687,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Capo Rosso",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai ricevuto un segnalino tensione, puoi tirare 1 dado di attacco per rimuoverlo. Con un risultato <hit>, subisci 1 danno<nonbreak><hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5851,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5852,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5853,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_5",
+            "force_side": null,
+            "id": 5,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Jek Porkins",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6688,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6689,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6690,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6691,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rosso Sei",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un’azione <barrelroll> o <boost>, puoi girare la carta miglioria <config> di cui sei dotato.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5854,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5855,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5856,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_6",
+            "force_side": null,
+            "id": 6,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kullbee Sperado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6692,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6693,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6694,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6695,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Pistolero Enigmatico",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre un’altra nave amica a gittata 0-1 difende, prima del passo “Neutralizzare i Risultati”, se sei nell’arco di attacco, puoi subire 1 danno <hit> o <crit> per annullare 1 risultato corrispondente.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5857,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5858,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5859,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_7",
+            "force_side": null,
+            "id": 7,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Biggs Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6696,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6697,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6698,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6699,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rosso Tre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un’azione <barrelroll> o <boost>, puoi effettuare 1 azione <evade> rossa.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5860,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5861,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5862,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_8",
+            "force_side": null,
+            "id": 8,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Leevan Tenza",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6700,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6701,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6702,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6703,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Disertore per l’Alleanza Ribelle",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Prima di attivarti, se sei concentrato,puoi effettuare 1 azione.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5863,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5864,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5865,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_9",
+            "force_side": null,
+            "id": 9,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Edrio Due Tubi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6704,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6705,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6706,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6707,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Veterano degli Angeli della Caverna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>La Squadriglia Rossa, concepita come squadriglia di astrocaccia d’elite, includeva alcuni dei migliori piloti dell’Alleanza Ribelle.</flavor>",
             "available_actions": [
                 {
@@ -84,164 +823,164 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mentre effettui un attacco, il difensore tira 1 dado di difesa in meno.",
+            "ability_text": "<flavor>L’Ala-X T-65, progettato dalla Incom Corporation, si rivelò rapidamente uno dei più efficaci e versatili veicoli militari della galassia e una vera e propria benedizione per la Ribellione.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 5869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 5870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 5871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
             "card_set_ids": [
+                1,
                 4,
                 7
             ],
             "card_type_id": 1,
-            "cost": "52",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_1",
+            "ffg_id": "XW_P_11",
             "force_side": null,
-            "id": 1,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Wedge Antilles",
+            "id": 11,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Scorta della Squadriglia Blu",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 6712,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 6713,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 6714,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 6715,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Rosso Due",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "Mentre effettui un attacco, puoi spendere 1 risultato <focus>, <hit> o <crit> per guardare le carte danno a faccia in giù del difensore, sceglierne 1 ed esporla.",
+            "ability_text": "<flavor>A differenza di molte cellule Ribelli, i partigiani di Saw Gerrera sono disposti a ricorrere a mezzi estremi per ostacolare gli obiettivi dell’Impero Galattico in numerose e accanite battaglie da Geonosis a Jedha.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 5872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 5873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 5874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
+                13,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
             "card_set_ids": [
-                7
+                2
             ],
             "card_type_id": 1,
-            "cost": "48",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_3",
+            "ffg_id": "XW_P_12",
             "force_side": null,
-            "id": 3,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Thane Kyrell",
+            "id": 12,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Zelota degli Angelidella Caverna",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 6716,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 6717,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 6718,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 6719,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Corona Quattro",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -332,343 +1071,6 @@
                 }
             ],
             "subtitle": "Oro Nove",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai speso un segnalino concentrazione, puoi scegliere 1 nave amica a gittata 1-3. Quella nave ottiene 1 segnalino concentrazione.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5848,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5849,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5850,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_4",
-            "force_side": null,
-            "id": 4,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6684,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6685,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6686,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6687,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Capo Rosso",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>L’Ala-X T-65, progettato dalla Incom Corporation, si rivelò rapidamente uno dei più efficaci e versatili veicoli militari della galassia e una vera e propria benedizione per la Ribellione.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5869,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5870,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5871,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_11",
-            "force_side": null,
-            "id": 11,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Scorta della Squadriglia Blu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6712,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6713,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6714,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6715,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco, puoi ripetere il tiro di 1 dado di attacco per ogni altra nave amica a gittata 0-1 dal difensore.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5883,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5884,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5885,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5886,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
-            "card_set_ids": [
-                4,
-                8
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_15",
-            "force_side": null,
-            "id": 15,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Horton Salm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 6728,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6729,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6730,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6731,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Capo Grigio",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un’azione <barrelroll> o <boost>, puoi girare la carta miglioria <config> di cui sei dotato.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5854,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5855,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5856,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_6",
-            "force_side": null,
-            "id": 6,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kullbee Sperado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6692,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6693,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6694,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6695,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Pistolero Enigmatico",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -765,42 +1167,183 @@
             "weapon_range": null
         },
         {
-            "ability_text": "All’inizio della Fase Finale, puoi spendere 1 segnalino concentrazione per riparare 1 tua carta danno a faccia in su.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+            "ability_text": "Mentre effettui un attacco, puoi ripetere il tiro di 1 dado di attacco per ogni altra nave amica a gittata 0-1 dal difensore.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5883,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5884,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5885,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5886,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
             "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_157",
-            "force_side": null,
-            "id": 382,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
+                4,
                 8
             ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_15",
+            "force_side": null,
+            "id": 15,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Horton Salm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6728,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6729,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6730,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6731,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Capo Grigio",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi spendere 1 segnalino concentrazione per scegliere 1 nave amica a gittata 0-1. Se lo fai, quella nave tira 1 dado di difesa aggiuntivo mentre difende fino alla fine del round.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5887,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5888,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5889,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5890,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_set_ids": [
+                8
+            ],
+            "card_type_id": 1,
+            "cost": "36",
+            "faction_id": 1,
+            "ffg_id": "XW_P_16",
+            "force_side": null,
+            "id": 16,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Evaan Verlaine",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6732,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6733,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6734,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6735,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Oro Tre",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -896,39 +1439,38 @@
             "weapon_range": null
         },
         {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi spendere 1 segnalino concentrazione per scegliere 1 nave amica a gittata 0-1. Se lo fai, quella nave tira 1 dado di difesa aggiuntivo mentre difende fino alla fine del round.",
+            "ability_text": "<flavor>Anche molto tempo dopo essere stato scartato dall’Impero Galattico, l’Ala-Y rimase una colonna portante della flotta Ribelle graziealla sua resistenza, alla sua affidabilità e ai suoi armamenti pesanti.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 5895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 5896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 5897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 5898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 4,
                 5,
                 10,
@@ -936,51 +1478,52 @@
                 14,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
             "card_set_ids": [
+                4,
                 8
             ],
             "card_type_id": 1,
-            "cost": "36",
+            "cost": "32",
             "faction_id": 1,
-            "ffg_id": "XW_P_16",
+            "ffg_id": "XW_P_18",
             "force_side": null,
-            "id": 16,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Evaan Verlaine",
+            "id": 18,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Bombardiere della Squadriglia Grigia",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 6740,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 6741,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 6742,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 6743,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Oro Tre",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1078,167 +1621,179 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Dopo che hai effettuato un’azione <barrelroll> o <boost>, puoi effettuare 1 azione <evade> rossa.",
+            "ability_text": "Puoi effettuare attacchi primari a gittata 0. <return>Se stai per fallire un’azione <boost> a causa della sovrapposizione a un’altra nave, risolvila invece come se stessi effettuando parzialmente una manovra.<return><sabold>Propulsori Vettoriali:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <boost> rossa.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 5904,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 5906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 5907,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                5,
-                10,
-                13,
-                14,
-                18
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
             "card_set_ids": [
-                2
+                4
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_8",
+            "ffg_id": "XW_P_20",
             "force_side": null,
-            "id": 8,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "id": 20,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "•Leevan Tenza",
+            "name": "•Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 33,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 6748,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6701,
-                    "recurring": false,
-                    "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 6749,
                     "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
+                    "statistic_id": 1,
+                    "value": "3"
                 },
                 {
-                    "id": 6703,
+                    "id": 6750,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6751,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Disertore per l’Alleanza Ribelle",
+            "subtitle": "Capo Verde",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Anche molto tempo dopo essere stato scartato dall’Impero Galattico, l’Ala-Y rimase una colonna portante della flotta Ribelle graziealla sua resistenza, alla sua affidabilità e ai suoi armamenti pesanti.</flavor>",
+            "ability_text": "<flavor>Grazie ai suoi comandi sensibili e alla sua alta manovrabilità, l’abitacolo di un Ala-A era un luogo riservato soltanto ai piloti più dotati.</flavor><return><sabold>Propulsori Vettoriali:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <boost> rossa.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 5909,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 5911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "base_action_side_effect": null,
+                    "id": 5912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
+                1,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
             "card_set_ids": [
-                4,
-                8
+                4
             ],
             "card_type_id": 1,
-            "cost": "32",
+            "cost": "34",
             "faction_id": 1,
-            "ffg_id": "XW_P_18",
+            "ffg_id": "XW_P_21",
             "force_side": null,
-            "id": 18,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-            "initiative": 2,
+            "id": 21,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
+            "initiative": 3,
             "is_unique": false,
-            "name": "Bombardiere della Squadriglia Grigia",
+            "name": "Pilota della Squadriglia Verde",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 12,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 6752,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 6753,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "1"
+                    "value": "3"
                 },
                 {
-                    "id": 6742,
+                    "id": 6754,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "6"
+                    "value": "2"
                 },
                 {
-                    "id": 6743,
+                    "id": 6755,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1246,46 +1801,6 @@
             ],
             "subtitle": "",
             "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre possiedi esattamente 1 segnalino disarmo, puoi comunque effettuare attacchi <torpedo> e <missile> contro i bersagli che hai acquisito come bersaglio. Se lo fai, non puoi spendere il tuo bersaglio acquisito durante l’attacco.<return>Aggiungi 1 slot <torpedo> e 1 slot <missile>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_125",
-            "force_side": null,
-            "id": 350,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Arsenale Armamenti Os-1",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 14,
-                            "raw_name": "Alpha-class Star Wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -1381,93 +1896,3985 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Puoi effettuare attacchi primari a gittata 0. <return>Se stai per fallire un’azione <boost> a causa della sovrapposizione a un’altra nave, risolvila invece come se stessi effettuando parzialmente una manovra.<return><sabold>Propulsori Vettoriali:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <boost> rossa.",
+            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi ripetere il tiro di 2 tuoi dadi.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5905,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
+                    "id": 5919,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 5920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 5921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                6
+                2,
+                3,
+                3,
+                5,
+                14
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_23",
+            "force_side": null,
+            "id": 23,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Braylen Stramm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6760,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6761,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6762,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6763,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Capo Blade",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi o effettui un attacco, puoi spendere 1 segnalino tensione per cambiare tutti i tuoi risultati <focus> in risultati <evade> o <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5922,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5923,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5924,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_24",
+            "force_side": null,
+            "id": 24,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Ten Numb",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6764,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6765,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6766,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6767,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Blu Cinque",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Uno speciale sistema giroscopico stabilizzante circonda l’abitacolo dell’Ala-B, assicurandosi che il pilota rimanga sempre stazionario durante i combattimenti.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5925,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5926,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5927,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 1,
+            "ffg_id": "XW_P_25",
+            "force_side": null,
+            "id": 25,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Veterano della Squadriglia Blade",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6768,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6769,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6770,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6771,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Grazie al suo arsenale di armi pesanti e alla sua resistente schermatura, l’Ala-B si è consolidato come il caccia d’assalto più innovativo dell’Alleanza Ribelle.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5928,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5929,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5930,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_26",
+            "force_side": null,
+            "id": 26,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilota della Squadriglia Blu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6772,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6773,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6774,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6775,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un attacco, puoi scegliere 1 nave amica a gittata 1. Quella nave può effettuare 1 azione, considerandola come se fosse rossa.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5931,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5932,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5933,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 1,
             "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_20",
+            "ffg_id": "XW_P_27",
             "force_side": null,
-            "id": 20,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-            "initiative": 3,
+            "id": 27,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
+            "initiative": 5,
             "is_unique": true,
-            "name": "•Arvel Crynyd",
+            "name": "•Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 35,
+            "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 6776,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 6777,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "3"
+                    "value": "2"
                 },
                 {
-                    "id": 6750,
+                    "id": 6778,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 6779,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Capo Verde",
+            "subtitle": "Capo dei Servizi Segreti",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco primario, se ci sono altre navi amiche a gittata 0-1 dal difensore, puoi tirare 1 dado di attacco aggiuntivo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5934,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5935,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5936,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_28",
+            "force_side": null,
+            "id": 28,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Tenente Blount",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6780,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6781,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6782,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6783,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Anima della Squadra",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>La serie AF4 è l’ultima di una lunga linea di modelli Headhunter. Questo caccia economico e relativamente resistente è uno dei veicoli preferiti dalle organizzazioni indipendenti come la Ribellione.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5937,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5938,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5939,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "25",
+            "faction_id": 1,
+            "ffg_id": "XW_P_29",
+            "force_side": null,
+            "id": 29,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilota dellaSquadriglia Tala",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6784,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6785,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6786,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6787,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>L’Headhunter Z-95 funse da principale ispiratore per l’astrocaccia Ala-X T-65 della Incom Corporation. Anche se considerato datato per i parametri moderni, rimane un caccia monoposto versatile e potente.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5940,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5941,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5942,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "23",
+            "faction_id": 1,
+            "ffg_id": "XW_P_30",
+            "force_side": null,
+            "id": 30,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Pilota della Squadriglia Bandit",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6788,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6789,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6790,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6791,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco primario, se sei danneggiato, puoi tirare 1 dado di attacco aggiuntivo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5943,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5944,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5945,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "56",
+            "faction_id": 1,
+            "ffg_id": "XW_P_31",
+            "force_side": null,
+            "id": 31,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Wullffwarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6792,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6793,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6794,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6795,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Capotribù Wookiee",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che una nave amica a gittata 0-1 è diventata il difensore, puoi spendere 1 segnalino rinforzo. Se lo fai, quella nave ottiene 1 segnalino schivata.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5946,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5947,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5948,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_32",
+            "force_side": null,
+            "id": 32,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Lowhhrick",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6796,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6797,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6798,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6799,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gladiatore in Fuga",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Dotata di tre cannoni laser binati Sureggi ad ampio raggio, la cannoniera Auzituck costituiva un potente deterrente per le operazioni degli schiavisti nel sistema Kashyyyk.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5949,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5950,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5951,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_33",
+            "force_side": null,
+            "id": 33,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Difensore di Kashyyyk",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6800,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6801,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6802,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6803,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai rivelato una manovra rossa o blu, puoi selezionare un’altra manovra della stessa difficoltà sul tuo indicatore.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5952,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5953,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5954,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "39",
+            "faction_id": 1,
+            "ffg_id": "XW_P_34",
+            "force_side": null,
+            "id": 34,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6804,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6805,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6806,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6807,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Prima di attivarti, puoi effettuare 1 azione <barrelroll> o <boost>.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5955,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5956,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5957,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_35",
+            "force_side": null,
+            "id": 35,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6808,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6809,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6810,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6811,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi spendere 1 <forcecharge> per cambiare fino a 2 tuoi risultati <focus> in risultati <evade> o <hit>.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5958,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5959,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5960,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "41",
+            "faction_id": 1,
+            "ffg_id": "XW_P_36",
+            "force_side": 2,
+            "id": 36,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6812,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6813,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6814,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6815,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6816,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi, i risultati <crit> sono neutralizzati prima dei risultati <hit>.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5961,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5962,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5963,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 1,
+            "ffg_id": "XW_P_37",
+            "force_side": null,
+            "id": 37,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6817,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6818,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6819,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6820,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che una nave nemica nel tuo arco di fuoco ha ingaggiato, se non sei in tensione, puoi ottenere 1 segnalino tensione. Se lo fai, quella nave non può spendere segnalini per modificare dadi mentre effettua un attacco durante questa fase.<return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5964,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5965,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_38",
+            "force_side": null,
+            "id": 38,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6821,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6822,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6823,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6824,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6825,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Ribelle Riluttante",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi spendere 1 <forcecharge> per cambiare fino a 2 tuoi risultati <focus> in risultati <evade> /<hit>. <return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5966,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5967,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                10,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_39",
+            "force_side": 2,
+            "id": 39,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6826,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6827,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6828,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6829,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6830,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6831,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi, i risultati <crit> sono neutralizzati prima dei risultati <hit>.<return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5968,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5969,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_40",
+            "force_side": null,
+            "id": 40,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6832,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6833,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6834,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6835,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6836,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre coordini, se scegli una nave con esattamente 1 segnalino tensione, quella nave può effettuare azioni.<return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5970,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5971,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_41",
+            "force_side": null,
+            "id": 41,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
+            "initiative": 1,
+            "is_unique": true,
+            "name": "•AP-5",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6837,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6838,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6839,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6840,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6841,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Droide Analista in Fuga",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre una nave amica nel tuo arco di fuoco effettua un attacco primario, se non sei in tensione, puoi ottenere 1 segnalino tensione. Se lo fai, quella nave può tirare 1 dado di attacco aggiuntivo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5972,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5973,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5974,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5975,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5976,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_42",
+            "force_side": null,
+            "id": 42,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Jan Ors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6842,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6843,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6844,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6845,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Esperta di Spionaggio",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi trasferire 1 tuo segnalino concentrazione su una nave amica nel tuo arco di fuoco.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5977,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5978,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5979,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5980,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5981,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_43",
+            "force_side": null,
+            "id": 43,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kyle Katarn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6846,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6847,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6848,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6849,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Agente Implacabile",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave nel tuo arco di fuoco. Se lo fai, quella nave ingaggia a iniziativa 7 invece che al suo valore di iniziativa standard in questa fase.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5982,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5983,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5984,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5985,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5986,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_44",
+            "force_side": null,
+            "id": 44,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Roark Garnet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6850,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6851,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6852,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6853,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Contrabbandiere di Buon Cuore",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Progettate dalla Corellian Engineering Corporation per assomigliare a un uccello in volo, le navi della serie Hawk sono vascelli da trasporto esemplari. L’HWK-290, rapido e resistente, è spesso usato dagli agenti Ribelli come base operativa mobile.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5987,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5988,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5989,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5990,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5991,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_45",
+            "force_side": null,
+            "id": 45,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Esploratore Ribelle",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6854,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6855,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6856,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6857,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi spendere 1 <forcecharge> per cambiare fino a 2 tuoi risultati <focus> in risultati <evade> o <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5992,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5993,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5994,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_46",
+            "force_side": 2,
+            "id": 46,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6858,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6859,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6860,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6861,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Spectre-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Prima di attivarti, puoi effettuare 1 azione <barrelroll> o <boost>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5995,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5996,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5997,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 1,
+            "ffg_id": "XW_P_47",
+            "force_side": null,
+            "id": 47,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6862,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6863,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6864,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un attacco, assegna la condizione <smallcaps>Fuoco di Soppressione</smallcaps> al difensore.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5998,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5999,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6000,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_48",
+            "force_side": null,
+            "id": 48,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Capitano Rex",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6865,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6866,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6867,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Veterano delle Guerre dei Cloni",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi, i risultati <crit> sono neutralizzati prima dei risultati <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6001,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6002,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6003,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "26",
+            "faction_id": 1,
+            "ffg_id": "XW_P_49",
+            "force_side": null,
+            "id": 49,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6868,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6869,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6870,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Spectre-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la Fase di Ingaggio, a iniziativa 0, puoi effettuare un attacco primario bonus contro una nave nemica nel tuo <bullseye>. Se lo fai, all’inizio della Fase di Pianificazione successiva ottieni 1 segnalino disarmo.<return><sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6004,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6005,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6006,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6007,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6008,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 1,
+            "ffg_id": "XW_P_50",
+            "force_side": null,
+            "id": 50,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Corran Horn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6871,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6872,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6873,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6874,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Investigatore Tenace",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre una nave amica effettua un attacco, se il difensore è nel tuo <frontarc>, l’attaccante può cambiare 1 risultato <hit> in 1 risultato <crit>.<return><sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6009,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6010,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6011,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6012,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6013,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 1,
+            "ffg_id": "XW_P_51",
+            "force_side": null,
+            "id": 51,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Gavin Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6875,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6876,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6877,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6878,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Gregario Temerario",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>I piloti scelti della Squadriglia Rogue sono alcuni tra i migliori piloti di tutta la Ribellione.</flavor><return> <sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6014,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6015,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6016,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6017,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6018,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "63",
+            "faction_id": 1,
+            "ffg_id": "XW_P_52",
+            "force_side": null,
+            "id": 52,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Scorta della Squadriglia Rogue",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6879,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6880,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6881,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6882,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>L’Ala-E, progettato per unire i tratti migliori della serie Ala-X e quelli della serie Ala-A, vanta una potenza di fuoco, una velocità e una manovrabilità superiori.</flavor><return> <sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6019,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6020,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6021,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6022,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6023,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "61",
+            "faction_id": 1,
+            "ffg_id": "XW_P_53",
+            "force_side": null,
+            "id": 53,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Scorta dellaSquadriglia Knave",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6883,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6884,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6885,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6886,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Le navi amiche possono acquisire come bersaglio gli oggetti a gittata 0-3 da qualsiasi nave amica.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6024,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6025,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6026,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 1,
+            "ffg_id": "XW_P_54",
+            "force_side": null,
+            "id": 54,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Bodhi Rook",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6887,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6888,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6889,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6890,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Disertore Imperiale",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre una nave amica danneggiata a gittata 0-3 effettua un attacco, può ripetere il tiro di 1 dado di attacco.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6027,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6028,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6029,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_55",
+            "force_side": null,
+            "id": 55,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Saw Gerrera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6891,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6892,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6893,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6894,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Fuorilegge Ossessionato",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Attivazione, puoi scegliere 1 nave amica a gittata 1-3. Se lo fai, quella nave rimuove 1 segnalino tensione.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6030,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6031,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6032,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_56",
+            "force_side": null,
+            "id": 56,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Cassian Andor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6895,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6896,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6897,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6898,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Allevato dalla Ribellione",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando una nave amica a gittata 0-2 difende, l’attaccante non può ripetere il tiro di più di 1 dado di attacco.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6033,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6034,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6035,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_57",
+            "force_side": null,
+            "id": 57,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6899,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6900,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6901,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6902,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Vedetta degli Angeli della Caverna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un’azione <focus>, puoi trasferire 1 tuo segnalino concentrazione a una nave amica a gittata 1-2.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6036,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6037,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6038,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_58",
+            "force_side": null,
+            "id": 58,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Benthic Due Tubi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6903,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6904,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6905,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6906,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Cecchino degli Angeli della Caverna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che una nave nemica ha eseguito una manovra, se è a gittata 0, puoi effettuare 1 azione.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6039,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6040,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6041,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_59",
+            "force_side": null,
+            "id": 59,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Heff Tobber",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6907,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6908,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6909,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6910,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Blu Otto",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>L’Ala-U UT-60D, usato per schierare truppe con il favore dell’oscurità o nella foga della battaglia, soddisfa il bisogno della Ribellione di un trasporto truppe che sia rapido e allo stesso tempo solido.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6042,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6043,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6044,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_60",
+            "force_side": null,
+            "id": 60,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Esploratore della Squadriglia Blu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6911,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6912,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6913,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6914,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>In origine i partigiani di Saw Gerrera furono fondati per opporsi alle forze dei Separatisti su Onderon durante le Guerre dei Cloni, ma continuarono a combattere contro la tirannia galattica quando l’Impero ascese al potere.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6045,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6046,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6047,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_61",
+            "force_side": null,
+            "id": 61,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Rinnegato dei Partigiani",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6915,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6916,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6917,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6918,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco primario, puoi spendere 1 scudo per ripetere il tiro di 1 dado di attacco oppure, se non possiedi scudi attivi, puoi tirare 1 dado di attacco in meno per recuperare 1 scudo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6048,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6049,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6050,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6051,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6052,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_62",
+            "force_side": null,
+            "id": 62,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Miranda Doni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6919,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6920,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6921,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6922,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Pesantemente Armata",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre una nave amica a gittata 0-2 difende o effettua un attacco, può spendere i tuoi segnalini concentrazione come se fossero i suoi.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6053,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6054,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6055,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6056,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6057,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_63",
+            "force_side": null,
+            "id": 63,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Esege Tuketu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6923,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6924,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6925,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6926,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Eroe Altruista",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>L’Ala-K della Koensayr Manufacturing vantava un evoluto Motore ad Accelerazione Subluce (SLAM) e montava ben 18 innesti armati, un’attrezzatura che gli forniva velocità e potenza di fuoco ineguagliate.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6058,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6059,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6060,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6061,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6062,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 1,
+            "ffg_id": "XW_P_64",
+            "force_side": null,
+            "id": 64,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilota della Squadriglia Warden",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6927,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6928,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6929,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6930,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi, se ci sono navi nemiche a gittata 0-1, puoi aggiungere 1 risultato <evade> ai risultati dei tuoi dadi.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6063,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6064,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6065,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "55",
+            "faction_id": 1,
+            "ffg_id": "XW_P_65",
+            "force_side": null,
+            "id": 65,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Norra Wexley",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6931,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6932,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6933,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6934,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6935,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Oro Nove",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai speso un segnalino concentrazione, puoi scegliere 1 nave amica a gittata 1-3. Quella nave ottiene 1 segnalino concentrazione.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6066,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6067,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6068,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "51",
+            "faction_id": 1,
+            "ffg_id": "XW_P_66",
+            "force_side": null,
+            "id": 66,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6936,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6937,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6938,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6939,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6940,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Capo Rosso",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi o effettui un attacco primario, puoi spendere 1 bersaglio acquisito che possiedi sulla nave nemica per aggiungere 1 risultato <focus> ai risultati dei tuoi dadi.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6069,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6070,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6071,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "53",
+            "faction_id": 1,
+            "ffg_id": "XW_P_67",
+            "force_side": null,
+            "id": 67,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Shara Bey",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6941,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6942,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6943,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6944,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6945,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Verde Quattro",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai eseguito completamente una manovra, se sei in tensione, puoi tirare 1 dado di attacco. Con un risultato <hit> o <crit>, rimuovi 1 segnalino tensione.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6072,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6073,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6074,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_68",
+            "force_side": null,
+            "id": 68,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ibtisam",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6946,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6947,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6948,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6949,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6950,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Sopravvissuta di Endor",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai tirato i dadi, se sei a gittata 0-1 da un ostacolo, puoi ripetere il tiro di tutti i tuoi dadi. Questo non è considerato un tiro ripetuto al fine degli altri effetti.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6075,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6076,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6077,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6078,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "92",
+            "faction_id": 1,
+            "ffg_id": "XW_P_69",
+            "force_side": null,
+            "id": 69,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6951,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6952,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6953,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6954,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Canaglia a Pagamento",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1559,6 +5966,533 @@
                 }
             ],
             "subtitle": "Generale dell’Alleanza",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Prima che ti stia per essere inflitta 1 carta danno a faccia in su, puoi spendere 1 <standardcharge> per farti invece infliggere quella carta a faccia in giù.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6083,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6084,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6085,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6086,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 1,
+            "ffg_id": "XW_P_71",
+            "force_side": null,
+            "id": 71,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Chewbacca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6959,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6960,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6961,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6962,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                },
+                {
+                    "id": 6963,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Il Possente",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>L’YT-1300, noto per la sua longevità e la sua struttura modulare, è uno dei mercantili più popolari e diffusi in tutta la galassia ed è spesso sottoposto a estese modifiche personali. </flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6087,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6088,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6089,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6090,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "78",
+            "faction_id": 1,
+            "ffg_id": "XW_P_72",
+            "force_side": null,
+            "id": 72,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Contrabbandiere della Fascia Esterna",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6964,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6965,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6966,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6967,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai rivelato una manovra rossa o blu, puoi regolare il tuo indicatore su un’altra manovra della stessa difficoltà.<return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6091,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6092,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6093,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "76",
+            "faction_id": 1,
+            "ffg_id": "XW_P_73",
+            "force_side": null,
+            "id": 73,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6968,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6969,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6970,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6971,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre una nave amica nel tuo arco di fuoco difende, puoi spendere 1 <forcecharge>. Se lo fai, l’attaccante tira 1 dado di attacco in meno.<return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6094,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6095,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6096,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "90",
+            "faction_id": 1,
+            "ffg_id": "XW_P_74",
+            "force_side": 2,
+            "id": 74,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kanan Jarrus",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6972,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6973,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6974,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6975,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                },
+                {
+                    "id": 6976,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Spectre-1",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, ogni nave nemica a gittata 0 ottiene 2 segnalini disturbo.<return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6097,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6098,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6099,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 1,
+            "ffg_id": "XW_P_75",
+            "force_side": null,
+            "id": 75,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6977,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6978,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6979,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6980,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Spectre-3",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Il VCX-100, un altro modello di grande successo della Corellian Engineering Corporation, è più grande della diffusissima serie YT e offre spazi interni più ampi e maggiori opzioni di personalizzazione.</flavor><return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6100,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6101,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6102,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 1,
+            "ffg_id": "XW_P_76",
+            "force_side": null,
+            "id": 76,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Ribelle di Lothal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6981,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6982,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6983,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6984,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1973,87 +6907,6 @@
                 }
             ],
             "subtitle": "Capo Obsidian",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A differenza di molte cellule Ribelli, i partigiani di Saw Gerrera sono disposti a ricorrere a mezzi estremi per ostacolare gli obiettivi dell’Impero Galattico in numerose e accanite battaglie da Geonosis a Jedha.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5872,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5873,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5874,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_12",
-            "force_side": null,
-            "id": 12,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Zelota degli Angelidella Caverna",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6716,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6717,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6718,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6719,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -2647,9455 +7500,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Dopo che hai effettuato un’azione, puoi spendere 1<nonbreak><forcecharge> per effettuare 1 azione.<return><sabold>Computer d’Attacco Avanzato:</sabold> Mentre effettui un attacco primario contro un difensore che hai acquisito come bersaglio, tira 1 dado di attacco aggiuntivo e cambia 1 risultato <hit> in 1 risultato <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6154,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6155,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6156,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 2,
-            "ffg_id": "XW_P_93",
-            "force_side": 1,
-            "id": 93,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Darth Vader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7038,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7039,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7040,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7041,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7042,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Capo Nero",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Il TIE Advanced x1 fu prodotto in quantità limitate, ma in seguito gli ingegneri della Sienar incorporarono molte delle sue qualità migliori nel modello successivo: l’Intercettore TIE.</flavor><return><sabold>Computer d’Attacco Avanzato:</sabold> Mentre effettui un attacco primario contro un difensore che hai acquisito come bersaglio, tira 1 dado di attacco aggiuntivo e cambia 1 risultato <hit> in 1 risultato <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6166,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6167,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6168,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 2,
-            "ffg_id": "XW_P_97",
-            "force_side": null,
-            "id": 97,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Asso dellaSquadriglia Storm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7055,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7056,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7057,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7058,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Il TIE Advanced v1 della Sienar Fleet System è un modello di astrocaccia rivoluzionario, dotato di motori potenziati, un lancia missili e alettoni-S ripiegabili. </flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6182,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6183,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6184,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6185,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6186,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_101",
-            "force_side": null,
-            "id": 101,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Barone dell’Impero",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 25,
-            "statistics": [
-                {
-                    "id": 7073,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7074,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7075,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7076,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un’azione <reload>, puoi recuperare 1 <standardcharge> su 1 carta miglioria <talent> di cui sei dotato.<return><shipability><sabold>Bombardiere Agile:</sabold> Se stai per sganciare un congegno usando un modello <straight>, puoi invece usare un modello <leftbank> o <rightbank> con la stessa velocità.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6208,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6209,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6210,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6211,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_107",
-            "force_side": null,
-            "id": 107,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Tomax Bren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7094,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7095,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7096,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Irruento Cane Sciolto ",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che sei stato distrutto, puoi effettuare un attacco e sganciare o lanciare 1 congegno.<return><shipability><sabold>Bombardiere Agile:</sabold> Se stai per sganciare un congegno usando un modello <straight>, puoi invece usare un modello <leftbank> o <rightbank> con la stessa velocità.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6220,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6221,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6222,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6223,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_110",
-            "force_side": null,
-            "id": 110,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Deathfire”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7103,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7104,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7105,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Impassibile e Incrollabile",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi, se l’attaccante non possiede segnalini verdi, puoi cambiare 1 tuo risultato <focus>/vuoto in 1 risultato <evade>.<return><sabold>Alettoni ad Assetto Variabile:</sabold> Prima di rivelare il tuo indicatore, se non sei in tensione, devi eseguire una manovra bianca [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>].",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6236,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6237,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6238,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6239,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 2,
-            "ffg_id": "XW_P_114",
-            "force_side": null,
-            "id": 114,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitano Feroph",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 43,
-            "statistics": [
-                {
-                    "id": 7116,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7117,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7118,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7119,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Corriere Imperiale",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi, dopo il passo “Neutralizzare i Risultati”, se non sei in tensione, puoi subire 1 danno <hit> e ottenere 1 segnalino tensione. Se lo fai, annulla tutti i risultati dei dadi.<return><sabold>Alettoni ad Assetto Variabile:</sabold> Prima di rivelare il tuo indicatore, se non sei in tensione, devi eseguire una manovra bianca [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>].",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6251,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6252,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6253,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_118",
-            "force_side": null,
-            "id": 118,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•“Countdown”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 16,
-            "statistics": [
-                {
-                    "id": 7131,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7132,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7133,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Pronto a Sfidare la Morte",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un attacco che ha colpito, se stai schivando, esponi 1 carta danno del difensore.<return><shipability><sabold>A Tutta Velocità:</sabold> Dopo aver eseguito completamente una manovra a velocità 3-5, puoi effettuare 1 azione <evade>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6263,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6264,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6265,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6266,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6267,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_122",
-            "force_side": null,
-            "id": 122,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Rexler Brath",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 18,
-            "statistics": [
-                {
-                    "id": 7143,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7144,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7145,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7146,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Capo Onyx",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Durante lo sviluppo del TIE Aggressor, la Sienar Fleet Systems diede la precedenza alle sue prestazioni e alla sua versatilità, anziché alla cruda efficienza in costo.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6297,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6298,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6299,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 2,
-            "ffg_id": "XW_P_130",
-            "force_side": null,
-            "id": 130,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Specialista della Sienar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7175,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7176,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7177,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7178,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Il TIE Phantom, il risultato primario della struttura di ricerca segreta chiamata Imdaar Alfa, è ciò che molti consideravano impossibile: un piccolo astrocaccia dotato di un evoluto dispositivo di occultamento.</flavor><return><shipability><sabold>Apparato di Stygium:</sabold> Dopo che ti sei deoccultato, puoi effettuare 1 azione <evade>. All’inizio della Fase Finale, puoi spendere 1 segnalino schivata per ottenere 1 segnalino occultamento.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6312,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6313,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6314,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 7,
-                    "base_action_side_effect": null,
-                    "id": 6315,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_134",
-            "force_side": null,
-            "id": 134,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Pilota Collaudatoredi Imdaar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 27,
-            "statistics": [
-                {
-                    "id": 7191,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7192,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7193,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7194,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Lo Star Wing Classe <untalic>Alfa</untalic>, la cui estetica si ispirava agli altri vascelli della Cygnus Spaceworks, era una nave versatile, assegnata alle unità specialistiche della Flotta Imperiale bisognose di un astrocaccia che potesse svolgere molte mansioni diverse.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6328,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6329,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6330,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6331,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                6,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "35",
-            "faction_id": 2,
-            "ffg_id": "XW_P_138",
-            "force_side": null,
-            "id": 138,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilota dellaSquadriglia Nu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 14,
-            "statistics": [
-                {
-                    "id": 7207,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7208,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7209,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7210,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 o più navi amiche a gittata 0-3. Se lo fai, trasferisci tutti i segnalini bersaglio acquisito nemici dalle navi scelte a te.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6347,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6348,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 6349,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6350,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                8,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 2,
-            "ffg_id": "XW_P_142",
-            "force_side": null,
-            "id": 142,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Capitano Kagi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 26,
-            "statistics": [
-                {
-                    "id": 7223,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7224,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 7225,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7226,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7227,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Pilota della Navetta dell’Imperatore",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco, se sei rinforzato e il difensore è nel <fullfront> o <fullrear> corrispondente al tuo segnalino rinforzo, puoi cambiare 1 tuo risultato <focus> in 1 risultato <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6368,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6369,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6370,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6371,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6372,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "88",
-            "faction_id": 2,
-            "ffg_id": "XW_P_147",
-            "force_side": null,
-            "id": 147,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Contrammiraglio Chiraneau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7248,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7249,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7250,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7251,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Consigliere dell’Ammiraglio Piett",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco primario, se ci sono navi amiche non limitate a gittata 0 dal difensore, tira 1 dadodi attacco aggiuntivo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6386,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6387,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": "stress",
-                    "id": 6388,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6389,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
-            "card_set_ids": [
-                6,
-                11
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 3,
-            "ffg_id": "XW_P_151",
-            "force_side": null,
-            "id": 151,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kath Scarlet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 10,
-            "statistics": [
-                {
-                    "id": 7266,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7267,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "3"
-                },
-                {
-                    "id": 7268,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7269,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7270,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Capitano dei Pirati di Binayre",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, se la gittata di attacco è 1, puoi tirare 1 dado aggiuntivo.<return><sabold>Carica Frontale di Concordia:</sabold> Mentre difendi, se la gittata di attacco è 1 e sei nel <frontarc> dell’attaccante, cambia 1 risultato in 1 risultato <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6402,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6403,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6404,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6405,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 3,
-            "ffg_id": "XW_P_155",
-            "force_side": null,
-            "id": 155,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7286,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7287,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7288,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Capo Skull",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Grazie ai suoi comandi sensibili e alla sua alta manovrabilità, l’abitacolo di un Ala-A era un luogo riservato soltanto ai piloti più dotati.</flavor><return><sabold>Propulsori Vettoriali:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <boost> rossa.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5909,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5910,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5911,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5912,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5913,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_21",
-            "force_side": null,
-            "id": 21,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Pilota della Squadriglia Verde",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 35,
-            "statistics": [
-                {
-                    "id": 6752,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6753,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6754,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6755,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Gli assi della Squadriglia Skull prediligono un approccio aggressivo e usano la tecnologia ad ali ruotanti del loro vascello per acquisire un’agilità ineguagliata all’inseguimento delle loro prede.</flavor><return><sabold>Carica Frontale di Concordia:</sabold> Mentre difendi, se la gittata di attacco è 1 e sei nel <frontarc> dell’attaccante, cambia 1 risultato in 1 risultato <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6418,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6419,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6420,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6421,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_159",
-            "force_side": null,
-            "id": 159,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Pilota dellaSquadriglia Skull",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7298,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7299,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7300,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, se ci sono altre navi a gittata 0, tu e ogni altra nave a gittata 0 ottenete 1 segnalino raggio traente.<return><shipability><sabold>Apparato Traente da Rimorchiatore:</sabold> <smallcaps>Azione:</smallcaps> Scegli 1 nave nel tuo <frontarc> a gittata 1. Quella nave ottiene 1 segnalino raggio traente, oppure 2 segnalini raggio traente se è nel tuo <bullseye> a gittata 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6432,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6433,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6434,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 3,
-            "ffg_id": "XW_P_163",
-            "force_side": null,
-            "id": 163,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Unkar Plutt",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7310,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7311,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7312,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Avaro Dispensatore di Porzioni",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre una nave amica non limitata effettua un attacco, se il difensore è nel tuo arco di fuoco, l’attaccante può ripetere il tiro di 1 dado di attacco.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6442,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6443,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6444,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6445,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 3,
-            "ffg_id": "XW_P_166",
-            "force_side": null,
-            "id": 166,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Drea Renthal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7320,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7321,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7322,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7323,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Signore dei Pirati",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>È sufficiente parlare di crediti Imperiali per vedere una schiera di individui poco affidabili accorrere al proprio fianco.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6446,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6447,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6448,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6449,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 3,
-            "ffg_id": "XW_P_167",
-            "force_side": null,
-            "id": 167,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Sicario Prezzolato",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7324,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7325,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7326,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7327,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puoi schierarti solo tramite uno schieramento di emergenza e possiedi il nome, l’iniziativa, le <standardcharge> della nave e la capacità del pilota dell’<smallcaps>Hound’s Tooth</smallcaps> amico distrutto.<return><shipability><sabold>Navetta di Fuga:</sabold> <smallcaps>Preparazione:</smallcaps>Richiede l’<smallcaps>Hound’s Tooth</smallcaps>. Devi iniziare la partita attraccato all’<smallcaps>Hound’s Tooth</smallcaps>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6460,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6461,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6462,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "6",
-            "faction_id": 3,
-            "ffg_id": "XW_P_171",
-            "force_side": null,
-            "id": 171,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Nashtah Pup</italic>",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 7340,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7341,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7342,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7343,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Piano di Riserva",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave nemica nel tuo arco di fuoco a gittata 0-2.Se lo fai, trasferisci 1 segnalino concentrazione o schivata da quella nave a te stesso.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6474,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6475,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6476,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6477,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6478,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 3,
-            "ffg_id": "XW_P_175",
-            "force_side": null,
-            "id": 175,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Palob Godalhi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 7357,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7358,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7359,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7360,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Membro della Resistenza Tethana",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai eseguito completamente una manovra, puoi ottenere 1 segnalino tensione per ruotare la tua nave di 90°.<return><sabold>Micropropulsori:</sabold> Mentre effettui un avvitamento, devi usare il modello <leftbank> o <rightbank> invece del modello <straight>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6493,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6494,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6495,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6496,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_179",
-            "force_side": null,
-            "id": 179,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Dalan Oberos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 3,
-            "statistics": [
-                {
-                    "id": 7373,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7374,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7375,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7376,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Cacciatore di Taglie d’Elite",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre una nave amica a gittata 0-1 difende, può ripetere il tiro di 1 suo dado.<return><shipability><sabold>Innesto Armato:</sabold> Puoi dotarti di 1 miglioria <cannon>, <torpedo> o <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6509,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6510,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6511,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6512,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_183",
-            "force_side": null,
-            "id": 183,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Serissu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7389,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7390,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7391,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7392,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Istruttore di Volo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, puoi subire 1 danno <hit> per ripetere il tiro di un qualsiasi numero di tuoi dadi.<return><shipability><sabold>Innesto Armato:</sabold> Puoi dotarti di 1 miglioria <cannon>, <torpedo> o <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6525,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6526,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6527,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6528,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 3,
-            "ffg_id": "XW_P_187",
-            "force_side": null,
-            "id": 187,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Inaldra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7405,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7406,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7407,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7408,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Boss di Punta Tansarii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi a gittata di attacco 3 o effettui un attacco a gittata di attacco 1, tira 1 dado aggiuntivo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6541,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6542,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6543,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_191",
-            "force_side": null,
-            "id": 191,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Talonbane Cobra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7421,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7422,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7423,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7424,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Flagello di Punta Tansarii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Il caccia d’assalto Kihraxz fu sviluppato specificamente per il consorzio criminale del Sole Nero, i cui assi del volo, pagati profumatamente, esigevano una nave agile e potente, all’altezza delle loro abilità.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6553,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6554,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6555,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 3,
-            "ffg_id": "XW_P_195",
-            "force_side": null,
-            "id": 195,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Asso del Sole Nero",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7437,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7438,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7439,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7440,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un’azione <boost>, puoi effettuare 1 azione <evade>.<return><shipability><sabold>Cervello Droide Evoluto:</sabold> Dopo che hai effettuato un’azione <calculate>, ottieni 1 segnalino calcolo.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6567,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6568,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6569,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6570,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 3,
-            "ffg_id": "XW_P_199",
-            "force_side": null,
-            "id": 199,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•IG-88C",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 21,
-            "statistics": [
-                {
-                    "id": 7453,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7454,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7455,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7456,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Costrutto Calcolatore",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>I leggendari Cercatori di Gand venerano le nebbie che avviluppano il loro pianeta natio e fanno uso di presagi, premonizioni e rituali mistici per rintracciare le loro prede.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6581,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6582,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6583,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_203",
-            "force_side": null,
-            "id": 203,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Cercatore di Gand",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 22,
-            "statistics": [
-                {
-                    "id": 7469,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7470,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7471,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7472,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un attacco, ogni nave nemica nel tuo <bullseye> subisce 1 danno <hit> a meno che non rimuova 1 segnalino verde.<return><sabold>Nessuna Via di Fuga:</sabold> Mentre effettui un attacco, se il difensore è nel tuo <bullseye>, i dadi di difesa non possono essere modificati usando segnalini verdi.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6593,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6594,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6595,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6596,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                10,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_207",
-            "force_side": null,
-            "id": 207,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Torani Kulda",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 39,
-            "statistics": [
-                {
-                    "id": 7486,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7487,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7488,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "7"
-                },
-                {
-                    "id": 7489,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Agente Indipendente Rodiano",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi ripetere il tiro di 2 tuoi dadi.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5919,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5920,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5921,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_23",
-            "force_side": null,
-            "id": 23,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Braylen Stramm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6760,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6761,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6762,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6763,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Capo Blade",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Se stai per fuggire, puoi spendere 1 <standardcharge>. Se lo fai, collocati invece in riserva. All’inizio della Fase di Pianificazione successiva, collocati entro gittata 1 dal margine dell’area di gioco da cui stavi per fuggire.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6608,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6609,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6610,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                8,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 3,
-            "ffg_id": "XW_P_211",
-            "force_side": null,
-            "id": 211,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Moralo Eval",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 24,
-            "statistics": [
-                {
-                    "id": 7503,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 7504,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7505,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "9"
-                },
-                {
-                    "id": 7506,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                },
-                {
-                    "id": 7507,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Genio del Crimine",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave amica a gittata 0-1. Se lo fai, trasferisci tutti i tuoi segnalini verdi a quella nave.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6620,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6621,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6622,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_215",
-            "force_side": null,
-            "id": 215,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Manaroo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 45,
-            "statistics": [
-                {
-                    "id": 7521,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7522,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7523,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7524,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Affascinante Aruzan",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Grazie al suo arsenale di armi pesanti e alla sua resistente schermatura, l’Ala-B si è consolidato come il caccia d’assalto più innovativo dell’Alleanza Ribelle.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5928,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5929,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5930,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_26",
-            "force_side": null,
-            "id": 26,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilota della Squadriglia Blu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6772,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6773,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6774,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6775,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, puoi spendere 1 segnalino tensione per cambiare tutti i tuoi risultati <focus> in risultati <evade> o <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5922,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5923,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5924,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_24",
-            "force_side": null,
-            "id": 24,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Ten Numb",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6764,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6765,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6766,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6767,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Blu Cinque",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Uno speciale sistema giroscopico stabilizzante circonda l’abitacolo dell’Ala-B, assicurandosi che il pilota rimanga sempre stazionario durante i combattimenti.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5925,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5926,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5927,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 1,
-            "ffg_id": "XW_P_25",
-            "force_side": null,
-            "id": 25,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Veterano della Squadriglia Blade",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6768,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6769,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6770,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6771,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco primario, se l’attacco è ostruito da un ostacolo, puoi ripetere il tiro di 1 dado aggiuntivo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6645,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6646,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6647,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6648,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_222",
-            "force_side": null,
-            "id": 222,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7555,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7556,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7557,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7558,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Ragazzino Corelliano",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco primario, se ci sono altre navi amiche a gittata 0-1 dal difensore, puoi tirare 1 dado di attacco aggiuntivo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5934,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5935,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5936,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_28",
-            "force_side": null,
-            "id": 28,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Tenente Blount",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6780,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6781,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6782,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6783,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Anima della Squadra",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Il TIE/ag, concepito per ingaggi prolungati, è comandato soprattutto da quei piloti scelti e addestrati per sfruttare al meglio sia i suoi armamenti unici che la sua manovrabilità.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6294,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6295,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6296,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_129",
-            "force_side": null,
-            "id": 129,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Esploratore della Squadriglia Onyx",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7171,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7172,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7173,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7174,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Le navi amiche a gittata 0-1 possono effettuare attacchi a gittata 0 dagli ostacoli.<return><shipability><sabold>Copilota:</sabold> Mentre sei attraccato, la tua nave madre possiede la tua capacità del pilota in aggiunta alla sua.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6664,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6665,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6666,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "24",
-            "faction_id": 3,
-            "ffg_id": "XW_P_227",
-            "force_side": null,
-            "id": 227,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Pioniere della Fascia Esterna",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
-            "statistics": [
-                {
-                    "id": 7575,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7576,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7577,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7578,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Abile Fuorilegge",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>L’Headhunter Z-95 funse da principale ispiratore per l’astrocaccia Ala-X T-65 della Incom Corporation. Anche se considerato datato per i parametri moderni, rimane un caccia monoposto versatile e potente.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5940,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5941,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5942,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "23",
-            "faction_id": 1,
-            "ffg_id": "XW_P_30",
-            "force_side": null,
-            "id": 30,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Pilota della Squadriglia Bandit",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6788,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6789,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6790,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6791,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai tirato i dadi, se non sei in tensione, puoi ottenere 1 segnalino tensione per ripetere il tiro di tutti i tuoi risultati vuoto.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6649,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6650,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6651,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6652,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 3,
-            "ffg_id": "XW_P_223",
-            "force_side": null,
-            "id": 223,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7559,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7560,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7561,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7562,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Giocatore d’Azzardo Persuasivo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre un’altra nave amica a gittata 0-1 difende, prima del passo “Neutralizzare i Risultati”, se sei nell’arco di attacco, puoi subire 1 danno <hit> o <crit> per annullare 1 risultato corrispondente.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5857,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5858,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5859,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_7",
-            "force_side": null,
-            "id": 7,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Biggs Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6696,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6697,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6698,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6699,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rosso Tre",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Prima di attivarti, se sei concentrato,puoi effettuare 1 azione.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5863,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5864,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5865,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_9",
-            "force_side": null,
-            "id": 9,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Edrio Due Tubi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6704,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6705,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6706,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6707,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Veterano degli Angeli della Caverna",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che una nave amica a gittata 0-1 è diventata il difensore, puoi spendere 1 segnalino rinforzo. Se lo fai, quella nave ottiene 1 segnalino schivata.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5946,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5947,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5948,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_32",
-            "force_side": null,
-            "id": 32,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Lowhhrick",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6796,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6797,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6798,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6799,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gladiatore in Fuga",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>La serie AF4 è l’ultima di una lunga linea di modelli Headhunter. Questo caccia economico e relativamente resistente è uno dei veicoli preferiti dalle organizzazioni indipendenti come la Ribellione.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5937,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5938,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5939,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "25",
-            "faction_id": 1,
-            "ffg_id": "XW_P_29",
-            "force_side": null,
-            "id": 29,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilota dellaSquadriglia Tala",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6784,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6785,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6786,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6787,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco primario, se sei danneggiato, puoi tirare 1 dado di attacco aggiuntivo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5943,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5944,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5945,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "56",
-            "faction_id": 1,
-            "ffg_id": "XW_P_31",
-            "force_side": null,
-            "id": 31,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Wullffwarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6792,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6793,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6794,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6795,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Capotribù Wookiee",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un attacco, puoi scegliere 1 nave amica a gittata 1. Quella nave può effettuare 1 azione, considerandola come se fosse rossa.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5931,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5932,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5933,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "36",
-            "faction_id": 1,
-            "ffg_id": "XW_P_27",
-            "force_side": null,
-            "id": 27,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Airen Cracken",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6776,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6777,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6778,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6779,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Capo dei Servizi Segreti",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Prima di attivarti, puoi effettuare 1 azione <barrelroll> o <boost>.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5955,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5956,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5957,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_35",
-            "force_side": null,
-            "id": 35,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6808,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6809,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6810,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6811,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Il Rimorchiatore Spaziale Quadrijet, comunemente chiamato “Quadjumper”, è un vascello agile sia nello spazio che in atmosfera, qualità che lo rende popolare sia presso i contrabbandieri che gli esploratori.</flavor><return><shipability><sabold>Apparato Traente da Rimorchiatore:</sabold> <smallcaps>Azione:</smallcaps> Scegli 1 nave nel tuo <frontarc> a gittata 1. Quella nave ottiene 1 segnalino raggio traente, oppure 2 segnalini raggio traente se è nel tuo <bullseye> a gittata 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6435,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6436,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6437,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 3,
-            "ffg_id": "XW_P_164",
-            "force_side": null,
-            "id": 164,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Mercante d’Armidi Jakku",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7313,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7314,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7315,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Dotata di tre cannoni laser binati Sureggi ad ampio raggio, la cannoniera Auzituck costituiva un potente deterrente per le operazioni degli schiavisti nel sistema Kashyyyk.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5949,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5950,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5951,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_33",
-            "force_side": null,
-            "id": 33,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Difensore di Kashyyyk",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6800,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6801,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6802,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6803,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi spendere 1 <forcecharge> per cambiare fino a 2 tuoi risultati <focus> in risultati <evade> o <hit>.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5958,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5959,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5960,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_36",
-            "force_side": 2,
-            "id": 36,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6812,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6813,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6814,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6815,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6816,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco primario, puoi spendere 1 scudo per ripetere il tiro di 1 dado di attacco oppure, se non possiedi scudi attivi, puoi tirare 1 dado di attacco in meno per recuperare 1 scudo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6048,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6049,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6050,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6051,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6052,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_62",
-            "force_side": null,
-            "id": 62,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Miranda Doni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6919,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6920,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6921,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6922,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Pesantemente Armata",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante il passo “Effettuare l’Azione”, puoi effettuare 1 azione anche mentre sei in tensione. Dopo che hai effettuato un’azione mentre sei in tensione, subisci 1 danno <hit> a meno che tu non esponga 1 tua carta danno.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_83",
-            "force_side": null,
-            "id": 307,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Azione:</smallcaps> Spendi 1 <standardcharge> non ricorsivada un’altra miglioria di cui sei dotato per recuperare 1 scudo.<return><smallcaps>Azione:</smallcaps> Spendi 2 scudi per recuperare 1 <standardcharge> non ricorsiva su una miglioria di cui sei dotato.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_99",
-            "force_side": null,
-            "id": 323,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai eseguito completamente una manovra, se non hai sganciato o lanciato un congegno in questo round, puoi sganciare 1 bomba.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_143",
-            "force_side": null,
-            "id": 368,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Genius”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puoi far attraccare 1 Navetta di Attacco o 1 Navetta Classe Sheathipede.<return>Le tue navi attraccate possono essere schierate soltanto dalle tue guide posteriori.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_102",
-            "force_side": null,
-            "id": 326,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Ghost</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 23,
-                            "raw_name": "VCX-100 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puoi far attraccare 1 Headhunter Z-95-AF4.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_148",
-            "force_side": null,
-            "id": 373,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Hound’s Tooth</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 24,
-                            "raw_name": "YV-666 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puoi attraccare a gittata 0-1.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_106",
-            "force_side": null,
-            "id": 330,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Phantom</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 32,
-                            "raw_name": "Attack Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    },
-                    {
-                        "kwargs": {
-                            "pk": 8,
-                            "raw_name": "Sheathipede-class Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco primario, se il difensore è nel tuo <frontarc>, tira 1 dado di attacco aggiuntivo.<return>Rimuovi 1 slot <crew>. Aggiungi 1 slot <astro>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_152",
-            "force_side": null,
-            "id": 377,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Punishing One</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 45,
-                            "raw_name": "JumpMaster 5000"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave nemica a gittata 0-1. Se lo fai, ottieni 1 segnalino calcolo a meno che quella nave non scelga di ottenere 1 segnalino tensione.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_127",
-            "force_side": null,
-            "id": 352,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•0-0-0",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 338
-                        },
-                        "type": "CARD_INCLUDED"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 93
-                        },
-                        "type": "CARD_INCLUDED"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che un’altra nave amica a gittata 0-3 ha difeso, se è distrutta, l’attaccante ottiene 2 segnalini tensione.<return>Mentre una nave amica a gittata 0-3 effettua un attacco contro una nave in tensione, può ripetere il tiro di 1 dado di attacco.<return>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_109",
-            "force_side": null,
-            "id": 335,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Ammiraglio Sloane",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un attacco primario, se sei concentrato, puoi effettuare un attacco <turretarc> bonus contro una nave che non hai già attaccato in questo round.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "14",
-            "faction_id": null,
-            "ffg_id": "XW_U_95",
-            "force_side": null,
-            "id": 319,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bistan",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un attacco primario che ha mancato, se non sei in tensione, devi ricevere 1 segnalino tensione per effettuare 1 attacco primario bonus contro lo stesso bersaglio.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_139",
-            "force_side": null,
-            "id": 364,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bossk",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un’azione <focus>, puoi considerarla come se fosse rossa. Se lo fai, ottieni 1 segnalino concentrazione aggiuntivo per ogni nave nemica a gittata 0-1, fino a un massimo di 2.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_79",
-            "force_side": null,
-            "id": 303,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Baze Malbus",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante la Fase Finale, puoi scegliere 2 migliorie <illicit> di cui siano dotate navi amiche a gittata 0-1. Se lo fai, puoi scambiare quelle migliorie.<return><smallcaps>Fine della Partita:</smallcaps> Rimetti tutte le migliorie <illicit> sulle loro navi originali.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_131",
-            "force_side": null,
-            "id": 356,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Cikatro Vizago",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Azione:</smallcaps> Spendi 1<nonbreak><standardcharge> per effettuare 1 azione <cloak>. <return>All’inizio della Fase di Pianificazione, tira 1 dado di attacco. Con un risultato <focus>, deoccultati o scarta il tuo segnalino occultamento.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_57",
-            "force_side": null,
-            "id": 286,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Dispositivo Occultante",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6594,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante la Fase di Attivazione, le navi nemiche a gittata 0-1 non possono rimuovere i segnalini tensione.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_113",
-            "force_side": null,
-            "id": 339,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Assaltatori della Morte",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8,
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante la Fase di Sistema, puoi spendere 2 <standardcharge>. Se lo fai, ogni nave amica può acquisire come bersaglio una nave che hai acquisito come bersaglio.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_117",
-            "force_side": null,
-            "id": 343,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Gran Moff Tarkin",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "STRESS"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6601,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Preparazione:</smallcaps> Dopo il passo “Collocare le Forze”, scegli 1 nave nemica e assegnale la condizione <smallcaps>Dispositivo di Spionaggio</smallcaps>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_44",
-            "force_side": null,
-            "id": 273,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Informatore",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Se una nave amica a gittata 0-3 sta per ottenere un segnalino concentrazione, può invece ottenere 1 segnalino schivata.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_85",
-            "force_side": null,
-            "id": 309,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Jyn Erso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi, se l’attaccante è in tensione, puoi rimuovere 1 segnalino tensione dall’attaccante per cambiare 1 tuo risultato vuoto/<focus> in 1 risultato <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_135",
-            "force_side": null,
-            "id": 360,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Latts Razzi",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, se non ci sono altre navi amiche a gittata 0-2, puoi spendere 1<nonbreak><standardcharge> per ripetere il tiro di 1 tuo dado.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_9",
-            "force_side": null,
-            "id": 238,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lupo Solitario",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6606,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai difeso, se l’attacco ha colpito, puoi acquisire l’attaccante come bersaglio.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_89",
-            "force_side": null,
-            "id": 313,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre coordini, la nave che scegli può effettuare un’azione solo se quell’azione si trova anche nella tua barra delle azioni.",
-            "available_actions": [
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 5830,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_16",
-            "force_side": null,
-            "id": 245,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Caposquadra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Prima che tu stia per subire danni da un ostacolo o da una bomba amica che detona, puoi spendere 1<nonbreak><standardcharge>. Se lo fai, previeni 1 danno.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_68",
-            "force_side": null,
-            "id": 292,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Blindatura Ablativa",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "LARGE"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6614,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Cambia 1 risultato <hit> in 1 risultato <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_33",
-            "force_side": null,
-            "id": 262,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Siluri Protonici Avanzati",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6615,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "5"
-                },
-                {
-                    "id": 6617,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                5
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1"
-        },
-        {
-            "ability_text": "Dopo che hai rivelato il tuo indicatore, puoi effettuare 1 azione.<return>Se lo fai, non puoi effettuare altre azioni durante la tua attivazione.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_23",
-            "force_side": null,
-            "id": 252,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Sensori Avanzati",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un’azione <slam>, se hai eseguito completamente la manovra, puoi effettuare 1 azione bianca nella tua barra delle azioni considerandola come se fosse rossa.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_69",
-            "force_side": null,
-            "id": 293,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "SLAM Avanzato",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Slam",
-                            "pk": 13,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 bomba a frammentazione usando il modello [1<nonbreak><straight>].<return>All’inizio della Fase di Attivazione, puoi spendere 1 scudo per recuperare 2 <standardcharge>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_63",
-            "force_side": null,
-            "id": 392,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Generatore di Bombe a Frammentazione",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6622,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12,
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Dopo questo attacco, puoi effettuare questo attacco come attacco bonus contro un bersaglio diverso a gittata 0-1 dal difensore, ignorando il requisito <targetlock>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_37",
-            "force_side": null,
-            "id": 266,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Missili a Grappolo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6623,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6625,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "4"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                6
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<flavor>L’Ala-U UT-60D, usato per schierare truppe con il favore dell’oscurità o nella foga della battaglia, soddisfa il bisogno della Ribellione di un trasporto truppe che sia rapido e allo stesso tempo solido.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6042,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6043,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6044,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_60",
-            "force_side": null,
-            "id": 60,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Esploratore della Squadriglia Blu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6911,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6912,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6913,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6914,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un’accelerazione o un avvitamento, puoi muoverti attraverso gli ostacoli e sovrapporti ad essi.<return>Dopo che ti sei mosso attraverso un ostacolo o ti sei sovrapposto ad esso, puoi spendere 1<nonbreak><standardcharge> per ignorarne gli effetti fino alla fine del round.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_24",
-            "force_side": null,
-            "id": 253,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Rilevatore di Collisione",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6626,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Prima di attivarti, puoi spendere 1 <standardcharge>. Se lo fai, fino alla fine del round puoi effettuare azioni ed eseguire manovre rosse anche mentre sei in tensione.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_58",
-            "force_side": null,
-            "id": 287,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Cibernetica di Contrabbando",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6631,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un’azione <boost> bianca, puoi considerarla come se fosse rossa per usare invece il modello [1<nonbreak><leftturn>] o [1<nonbreak><rightturn>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                12
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_2",
-            "force_side": null,
-            "id": 231,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Temerario",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Boost",
-                            "pk": 1,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Preparazione:</smallcaps> Perdi 1<nonbreak><standardcharge>.<return><smallcaps>Azione:</smallcaps> Recupera 1<nonbreak><standardcharge>.<return><smallcaps>Azione:</smallcaps> Spendi 1<nonbreak><standardcharge> per recuperare 1 scudo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_43",
-            "force_side": null,
-            "id": 272,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Droide GNK “Gonk” ",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6636,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco <turretarc>, dopo il passo “Modificare i Dadi di Difesa”, il difensore rimuove 1 segnalino concentrazione o calcolo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_49",
-            "force_side": null,
-            "id": 278,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Artigliere Spericolato",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Per chi non può permettersi un generatore di scudo potenziato, saldare ulteriori strati di piastre sullo scafo di una nave può fungere da alternativa adeguata.</flavor>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "*",
-            "faction_id": null,
-            "ffg_id": "XW_U_73",
-            "force_side": null,
-            "id": 297,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Miglioria allo Scafo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6642,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_28",
-            "force_side": null,
-            "id": 257,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Cannone a Ioni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6643,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                3
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
-        },
-        {
-            "ability_text": "Mentre effettui un attacco <frontarc>, se non sei nell’arco di fuoco del difensore, il difensore tira 1 dado di difesa in meno.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_11",
-            "force_side": null,
-            "id": 240,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Manovrabilità Superiore",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai rivelato il tuo indicatore, puoi spendere 1 <standardcharge> e ottenere 1 segnalino disarmo per recuperare 1 scudo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-            "card_set_ids": [
-                1,
-                4,
-                6,
-                7
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_53",
-            "force_side": null,
-            "id": 282,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Droide Astromeccanico R2",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6663,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi, i risultati <crit> sono neutralizzati prima dei risultati <hit>.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5961,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5962,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5963,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_37",
-            "force_side": null,
-            "id": 37,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6817,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6818,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6819,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6820,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che una nave nemica nel tuo arco di fuoco ha ingaggiato, se non sei in tensione, puoi ottenere 1 segnalino tensione. Se lo fai, quella nave non può spendere segnalini per modificare dadi mentre effettua un attacco durante questa fase.<return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5964,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5965,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_38",
-            "force_side": null,
-            "id": 38,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6821,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6822,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6823,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6824,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6825,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Ribelle Riluttante",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Progettate dalla Corellian Engineering Corporation per assomigliare a un uccello in volo, le navi della serie Hawk sono vascelli da trasporto esemplari. L’HWK-290, rapido e resistente, è spesso usato dagli agenti Ribelli come base operativa mobile.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5987,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5988,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5989,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5990,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5991,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_45",
-            "force_side": null,
-            "id": 45,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Esploratore Ribelle",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6854,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6855,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6856,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6857,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi spendere 1 <forcecharge> per cambiare fino a 2 tuoi risultati <focus> in risultati <evade> /<hit>. <return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5966,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5967,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                10,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_39",
-            "force_side": 2,
-            "id": 39,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6826,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6827,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6828,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6829,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6830,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6831,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi, i risultati <crit> sono neutralizzati prima dei risultati <hit>.<return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5968,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5969,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_40",
-            "force_side": null,
-            "id": 40,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6832,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6833,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6834,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6835,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6836,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre coordini, se scegli una nave con esattamente 1 segnalino tensione, quella nave può effettuare azioni.<return><sabold>Navetta di Comunicazione:</sabold> Mentre sei attraccato, la tua nave madre ottiene <coordinate>. Prima che la tua nave madre si attivi, può effettuare 1 azione <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5970,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5971,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_41",
-            "force_side": null,
-            "id": 41,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-            "initiative": 1,
-            "is_unique": true,
-            "name": "•AP-5",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6837,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6838,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6839,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6840,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6841,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Droide Analista in Fuga",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre una nave amica nel tuo arco di fuoco effettua un attacco primario, se non sei in tensione, puoi ottenere 1 segnalino tensione. Se lo fai, quella nave può tirare 1 dado di attacco aggiuntivo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5972,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5973,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5974,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5975,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5976,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_42",
-            "force_side": null,
-            "id": 42,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Jan Ors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6842,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6843,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6844,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6845,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Esperta di Spionaggio",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi trasferire 1 tuo segnalino concentrazione su una nave amica nel tuo arco di fuoco.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5977,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5978,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5979,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5980,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5981,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_43",
-            "force_side": null,
-            "id": 43,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kyle Katarn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6846,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6847,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6848,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6849,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Agente Implacabile",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave nel tuo arco di fuoco. Se lo fai, quella nave ingaggia a iniziativa 7 invece che al suo valore di iniziativa standard in questa fase.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5982,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5983,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5984,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5985,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5986,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_44",
-            "force_side": null,
-            "id": 44,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Roark Garnet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6850,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6851,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6852,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6853,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Contrabbandiere di Buon Cuore",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Prima di attivarti, puoi effettuare 1 azione <barrelroll> o <boost>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5995,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5996,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5997,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 1,
-            "ffg_id": "XW_P_47",
-            "force_side": null,
-            "id": 47,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6862,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6863,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6864,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che sei diventato il difensore (prima che i dadi siano tirati), puoi recuperare 1<nonbreak><forcecharge>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5842,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5843,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5844,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                17,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "62",
-            "faction_id": 1,
-            "ffg_id": "XW_P_2",
-            "force_side": 2,
-            "id": 2,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Luke Skywalker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6675,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6676,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6677,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6678,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 6679,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rosso Cinque",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre una nave amica effettua un attacco, se il difensore è nel tuo <frontarc>, l’attaccante può cambiare 1 risultato <hit> in 1 risultato <crit>.<return><sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6009,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6010,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6011,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6012,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6013,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 1,
-            "ffg_id": "XW_P_51",
-            "force_side": null,
-            "id": 51,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Gavin Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6875,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6876,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6877,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6878,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Gregario Temerario",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>I piloti scelti della Squadriglia Rogue sono alcuni tra i migliori piloti di tutta la Ribellione.</flavor><return> <sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6014,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6015,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6016,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6017,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6018,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "63",
-            "faction_id": 1,
-            "ffg_id": "XW_P_52",
-            "force_side": null,
-            "id": 52,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Scorta della Squadriglia Rogue",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6879,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6880,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6881,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6882,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>L’Ala-E, progettato per unire i tratti migliori della serie Ala-X e quelli della serie Ala-A, vanta una potenza di fuoco, una velocità e una manovrabilità superiori.</flavor><return> <sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6019,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6020,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6021,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6022,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6023,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "61",
-            "faction_id": 1,
-            "ffg_id": "XW_P_53",
-            "force_side": null,
-            "id": 53,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Scorta dellaSquadriglia Knave",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6883,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6884,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6885,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6886,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai rivelato una manovra rossa o blu, puoi selezionare un’altra manovra della stessa difficoltà sul tuo indicatore.<return><sabold>Carico e Pronto:</sabold> Mentre sei attraccato, dopo che la tua nave madre ha effettuato un attacco primario <frontarc> o un attacco <turret>, può effettuare un attacco primario <reararc> bonus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5952,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5953,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5954,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "39",
-            "faction_id": 1,
-            "ffg_id": "XW_P_34",
-            "force_side": null,
-            "id": 34,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6804,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6805,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6806,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6807,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che una nave nemica ha eseguito una manovra, se è a gittata 0, puoi effettuare 1 azione.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6039,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6040,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6041,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_59",
-            "force_side": null,
-            "id": 59,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Heff Tobber",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6907,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6908,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6909,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6910,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Blu Otto",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>In origine i partigiani di Saw Gerrera furono fondati per opporsi alle forze dei Separatisti su Onderon durante le Guerre dei Cloni, ma continuarono a combattere contro la tirannia galattica quando l’Impero ascese al potere.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6045,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6046,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6047,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_61",
-            "force_side": null,
-            "id": 61,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Rinnegato dei Partigiani",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6915,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6916,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6917,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6918,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>L’Ala-K della Koensayr Manufacturing vantava un evoluto Motore ad Accelerazione Subluce (SLAM) e montava ben 18 innesti armati, un’attrezzatura che gli forniva velocità e potenza di fuoco ineguagliate.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6058,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6059,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6060,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6061,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6062,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 1,
-            "ffg_id": "XW_P_64",
-            "force_side": null,
-            "id": 64,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilota della Squadriglia Warden",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6927,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6928,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6929,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6930,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco, se sei in tensione, puoi spendere 1 <forcecharge> per cambiare fino a 2 tuoi risultati <focus> in risultati <evade> o <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5992,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5993,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5994,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_46",
-            "force_side": 2,
-            "id": 46,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6858,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6859,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6860,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6861,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Spectre-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un attacco, assegna la condizione <smallcaps>Fuoco di Soppressione</smallcaps> al difensore.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5998,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5999,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6000,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_48",
-            "force_side": null,
-            "id": 48,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Capitano Rex",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6865,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6866,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6867,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Veterano delle Guerre dei Cloni",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi, i risultati <crit> sono neutralizzati prima dei risultati <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6001,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6002,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6003,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "26",
-            "faction_id": 1,
-            "ffg_id": "XW_P_49",
-            "force_side": null,
-            "id": 49,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6868,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6869,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6870,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Spectre-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante la Fase di Ingaggio, a iniziativa 0, puoi effettuare un attacco primario bonus contro una nave nemica nel tuo <bullseye>. Se lo fai, all’inizio della Fase di Pianificazione successiva ottieni 1 segnalino disarmo.<return><sabold>Scanner Sperimentali:</sabold> Puoi acquisire bersagli oltre gittata 3. Non puoi acquisire bersagli a gittata 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6004,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6005,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6006,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6007,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6008,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 1,
-            "ffg_id": "XW_P_50",
-            "force_side": null,
-            "id": 50,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Corran Horn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6871,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6872,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6873,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6874,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Investigatore Tenace",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi, se ci sono navi nemiche a gittata 0-1, puoi aggiungere 1 risultato <evade> ai risultati dei tuoi dadi.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6063,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6064,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6065,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "55",
-            "faction_id": 1,
-            "ffg_id": "XW_P_65",
-            "force_side": null,
-            "id": 65,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Norra Wexley",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6931,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6932,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6933,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6934,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6935,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Oro Nove",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Le navi amiche possono acquisire come bersaglio gli oggetti a gittata 0-3 da qualsiasi nave amica.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6024,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6025,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6026,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 1,
-            "ffg_id": "XW_P_54",
-            "force_side": null,
-            "id": 54,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Bodhi Rook",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6887,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6888,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6889,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6890,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Disertore Imperiale",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Attivazione, puoi scegliere 1 nave amica a gittata 1-3. Se lo fai, quella nave rimuove 1 segnalino tensione.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6030,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6031,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6032,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_56",
-            "force_side": null,
-            "id": 56,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Cassian Andor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6895,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6896,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6897,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6898,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Allevato dalla Ribellione",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando una nave amica a gittata 0-2 difende, l’attaccante non può ripetere il tiro di più di 1 dado di attacco.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6033,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6034,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6035,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_57",
-            "force_side": null,
-            "id": 57,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6899,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6900,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6901,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6902,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Vedetta degli Angeli della Caverna",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un’azione <focus>, puoi trasferire 1 tuo segnalino concentrazione a una nave amica a gittata 1-2.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6036,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6037,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6038,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_58",
-            "force_side": null,
-            "id": 58,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Benthic Due Tubi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6903,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6904,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6905,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6906,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Cecchino degli Angeli della Caverna",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre una nave amica a gittata 0-2 difende o effettua un attacco, può spendere i tuoi segnalini concentrazione come se fossero i suoi.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6053,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6054,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6055,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6056,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6057,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_63",
-            "force_side": null,
-            "id": 63,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Esege Tuketu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6923,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6924,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6925,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6926,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Eroe Altruista",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai speso un segnalino concentrazione, puoi scegliere 1 nave amica a gittata 1-3. Quella nave ottiene 1 segnalino concentrazione.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6066,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6067,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6068,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "51",
-            "faction_id": 1,
-            "ffg_id": "XW_P_66",
-            "force_side": null,
-            "id": 66,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6936,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6937,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6938,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6939,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6940,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Capo Rosso",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre difendi o effettui un attacco primario, puoi spendere 1 bersaglio acquisito che possiedi sulla nave nemica per aggiungere 1 risultato <focus> ai risultati dei tuoi dadi.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6069,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6070,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6071,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "53",
-            "faction_id": 1,
-            "ffg_id": "XW_P_67",
-            "force_side": null,
-            "id": 67,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Shara Bey",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6941,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6942,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6943,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6944,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6945,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Verde Quattro",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai eseguito completamente una manovra, se sei in tensione, puoi tirare 1 dado di attacco. Con un risultato <hit> o <crit>, rimuovi 1 segnalino tensione.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6072,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6073,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6074,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_68",
-            "force_side": null,
-            "id": 68,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ibtisam",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6946,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6947,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6948,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6949,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6950,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Sopravvissuta di Endor",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai tirato i dadi, se sei a gittata 0-1 da un ostacolo, puoi ripetere il tiro di tutti i tuoi dadi. Questo non è considerato un tiro ripetuto al fine degli altri effetti.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6075,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6076,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6077,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6078,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "92",
-            "faction_id": 1,
-            "ffg_id": "XW_P_69",
-            "force_side": null,
-            "id": 69,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6951,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6952,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6953,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6954,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Canaglia a Pagamento",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Prima che ti stia per essere inflitta 1 carta danno a faccia in su, puoi spendere 1 <standardcharge> per farti invece infliggere quella carta a faccia in giù.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6083,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6084,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6085,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6086,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 1,
-            "ffg_id": "XW_P_71",
-            "force_side": null,
-            "id": 71,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6959,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6960,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6961,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6962,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                },
-                {
-                    "id": 6963,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Il Possente",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>L’YT-1300, noto per la sua longevità e la sua struttura modulare, è uno dei mercantili più popolari e diffusi in tutta la galassia ed è spesso sottoposto a estese modifiche personali. </flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6087,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6088,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6089,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6090,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "78",
-            "faction_id": 1,
-            "ffg_id": "XW_P_72",
-            "force_side": null,
-            "id": 72,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Contrabbandiere della Fascia Esterna",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6964,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6965,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6966,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6967,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai rivelato una manovra rossa o blu, puoi regolare il tuo indicatore su un’altra manovra della stessa difficoltà.<return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6091,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6092,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6093,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "76",
-            "faction_id": 1,
-            "ffg_id": "XW_P_73",
-            "force_side": null,
-            "id": 73,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6968,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6969,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6970,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6971,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre una nave amica nel tuo arco di fuoco difende, puoi spendere 1 <forcecharge>. Se lo fai, l’attaccante tira 1 dado di attacco in meno.<return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6094,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6095,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6096,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "90",
-            "faction_id": 1,
-            "ffg_id": "XW_P_74",
-            "force_side": 2,
-            "id": 74,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kanan Jarrus",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6972,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6973,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6974,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6975,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                },
-                {
-                    "id": 6976,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Spectre-1",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "All’inizio della Fase di Ingaggio, ogni nave nemica a gittata 0 ottiene 2 segnalini disturbo.<return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6097,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6098,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6099,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 1,
-            "ffg_id": "XW_P_75",
-            "force_side": null,
-            "id": 75,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6977,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6978,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6979,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6980,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Spectre-3",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Il VCX-100, un altro modello di grande successo della Corellian Engineering Corporation, è più grande della diffusissima serie YT e offre spazi interni più ampi e maggiori opzioni di personalizzazione.</flavor><return><shipability><sabold>Cannone Caudale:</sabold> Mentre possiedi una nave attraccata, possiedi un’arma primaria <reararc> con un valore di attacco pari al valore di attacco dell’arma primaria <frontarc> della tua nave attraccata.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6100,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6101,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6102,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 1,
-            "ffg_id": "XW_P_76",
-            "force_side": null,
-            "id": 76,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Ribelle di Lothal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6981,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6982,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6983,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6984,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>I piloti scelti dei Caccia TIE/In della Squadriglia Nera seguirono Darth Vader in un assalto devastante alle forze Ribelli durante la Battaglia di Yavin.</flavor>",
             "available_actions": [
                 {
@@ -12311,6 +7715,93 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un’azione, puoi spendere 1<nonbreak><forcecharge> per effettuare 1 azione.<return><sabold>Computer d’Attacco Avanzato:</sabold> Mentre effettui un attacco primario contro un difensore che hai acquisito come bersaglio, tira 1 dado di attacco aggiuntivo e cambia 1 risultato <hit> in 1 risultato <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6154,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6155,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6156,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 2,
+            "ffg_id": "XW_P_93",
+            "force_side": 1,
+            "id": 93,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Darth Vader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7038,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7039,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7040,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7041,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7042,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Capo Nero",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12552,6 +8043,87 @@
                 }
             ],
             "subtitle": "Amministratore Spietato",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Il TIE Advanced x1 fu prodotto in quantità limitate, ma in seguito gli ingegneri della Sienar incorporarono molte delle sue qualità migliori nel modello successivo: l’Intercettore TIE.</flavor><return><sabold>Computer d’Attacco Avanzato:</sabold> Mentre effettui un attacco primario contro un difensore che hai acquisito come bersaglio, tira 1 dado di attacco aggiuntivo e cambia 1 risultato <hit> in 1 risultato <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6166,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6167,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6168,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 2,
+            "ffg_id": "XW_P_97",
+            "force_side": null,
+            "id": 97,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Asso dellaSquadriglia Storm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7055,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7056,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7057,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7058,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12835,6 +8407,278 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Il TIE Advanced v1 della Sienar Fleet System è un modello di astrocaccia rivoluzionario, dotato di motori potenziati, un lancia missili e alettoni-S ripiegabili. </flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6182,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6183,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6184,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6185,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6186,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_101",
+            "force_side": null,
+            "id": 101,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Barone dell’Impero",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7073,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7074,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7075,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7076,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>I temibili Inquisitori dispongono di un alto grado di autonomia e possono accedere alle tecnologie più evolute dell’Impero, come i prototipi del TIE Advanced v1.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6187,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6188,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6189,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6190,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6191,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 2,
+            "ffg_id": "XW_P_102",
+            "force_side": 1,
+            "id": 102,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Inquisitore",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7077,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7078,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7079,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7080,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7081,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, se ci sono navi nemiche nel tuo <bullseye>, ottieni 1 segnalino concentrazione.<return><shipability><sabold>Propulsori Automatici:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <barrelroll> o <boost> rossa. </shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6192,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6193,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6194,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6195,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 2,
+            "ffg_id": "XW_P_103",
+            "force_side": null,
+            "id": 103,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Soontir Fel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 41,
+            "statistics": [
+                {
+                    "id": 7082,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7083,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7084,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Asso Leggendario",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Dopo aver effettuato un attacco, puoi effettuare 1 azione <barrelroll> o <boost> anche se sei in tensione.<return><shipability><sabold>Propulsori Automatici:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <barrelroll> o <boost> rossa. </shipability>",
             "available_actions": [
                 {
@@ -12995,86 +8839,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "All’inizio della Fase di Ingaggio, se ci sono navi nemiche nel tuo <bullseye>, ottieni 1 segnalino concentrazione.<return><shipability><sabold>Propulsori Automatici:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <barrelroll> o <boost> rossa. </shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6192,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6193,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6194,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6195,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 2,
-            "ffg_id": "XW_P_103",
-            "force_side": null,
-            "id": 103,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Soontir Fel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 41,
-            "statistics": [
-                {
-                    "id": 7082,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7083,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7084,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Asso Leggendario",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>L’Intercettore TIE, progettato dalla Sienar Fleet Systems, era dotato di quattro cannoni laser montati sulle ali che gli conferivano una potenza di fuoco superiore a quella di tutti i suoi predecessori.</flavor><return><shipability><sabold>Propulsori Automatici:</sabold> Dopo che hai effettuato un’azione, puoi effettuare 1 azione <barrelroll> o <boost> rossa. </shipability>",
             "available_actions": [
                 {
@@ -13149,6 +8913,91 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un’azione <reload>, puoi recuperare 1 <standardcharge> su 1 carta miglioria <talent> di cui sei dotato.<return><shipability><sabold>Bombardiere Agile:</sabold> Se stai per sganciare un congegno usando un modello <straight>, puoi invece usare un modello <leftbank> o <rightbank> con la stessa velocità.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6208,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6209,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6210,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6211,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_107",
+            "force_side": null,
+            "id": 107,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Tomax Bren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7094,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7095,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7096,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Irruento Cane Sciolto ",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13319,6 +9168,90 @@
                 }
             ],
             "subtitle": "Capo Scimitar",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che sei stato distrutto, puoi effettuare un attacco e sganciare o lanciare 1 congegno.<return><shipability><sabold>Bombardiere Agile:</sabold> Se stai per sganciare un congegno usando un modello <straight>, puoi invece usare un modello <leftbank> o <rightbank> con la stessa velocità.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6220,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6221,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6222,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6223,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_110",
+            "force_side": null,
+            "id": 110,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Deathfire”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7103,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7104,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7105,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Impassibile e Incrollabile",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13580,6 +9513,93 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre difendi, se l’attaccante non possiede segnalini verdi, puoi cambiare 1 tuo risultato <focus>/vuoto in 1 risultato <evade>.<return><sabold>Alettoni ad Assetto Variabile:</sabold> Prima di rivelare il tuo indicatore, se non sei in tensione, devi eseguire una manovra bianca [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>].",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6236,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6237,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6238,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6239,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 2,
+            "ffg_id": "XW_P_114",
+            "force_side": null,
+            "id": 114,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitano Feroph",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 43,
+            "statistics": [
+                {
+                    "id": 7116,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7117,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7118,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7119,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Corriere Imperiale",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Dopo che hai eseguito completamente una manovra a velocità 1 usando la tua capacità di nave <smallcaps>Alettoni ad Assetto Variabile</smallcaps>, puoi effettuare 1 azione <coordinate>. Se lo fai, salta il tuo passo “Effettuare l'Azione”.<return><sabold>Alettoni ad Assetto Variabile:</sabold> Prima di rivelare il tuo indicatore, se non sei in tensione, devi eseguire una manovra bianca [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>].",
             "available_actions": [
                 {
@@ -13826,6 +9846,80 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre difendi, dopo il passo “Neutralizzare i Risultati”, se non sei in tensione, puoi subire 1 danno <hit> e ottenere 1 segnalino tensione. Se lo fai, annulla tutti i risultati dei dadi.<return><sabold>Alettoni ad Assetto Variabile:</sabold> Prima di rivelare il tuo indicatore, se non sei in tensione, devi eseguire una manovra bianca [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>].",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6251,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6252,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6253,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_118",
+            "force_side": null,
+            "id": 118,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•“Countdown”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 16,
+            "statistics": [
+                {
+                    "id": 7131,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7132,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7133,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Pronto a Sfidare la Morte",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre effettui un attacco, se possiedi 1 o meno carte danno, puoi tirare 1 dado di attacco aggiuntivo.<return><sabold>Alettoni ad Assetto Variabile:</sabold> Prima di rivelare il tuo indicatore, se non sei in tensione, devi eseguire una manovra bianca [1<nonbreak><leftbank>], [1<nonbreak><straight>] o [1<nonbreak><rightbank>].",
             "available_actions": [
                 {
@@ -14047,26 +10141,40 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mentre una nave amica danneggiata a gittata 0-3 effettua un attacco, può ripetere il tiro di 1 dado di attacco.",
+            "ability_text": "Dopo che hai effettuato un attacco che ha colpito, se stai schivando, esponi 1 carta danno del difensore.<return><shipability><sabold>A Tutta Velocità:</sabold> Dopo aver eseguito completamente una manovra a velocità 3-5, puoi effettuare 1 azione <evade>.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6263,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6266,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14074,156 +10182,54 @@
             "available_upgrades": [
                 1,
                 2,
-                8,
-                8,
-                13,
-                14,
-                18
+                3,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_55",
-            "force_side": null,
-            "id": 55,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6891,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6892,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6893,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6894,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Fuorilegge Ossessionato",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>I temibili Inquisitori dispongono di un alto grado di autonomia e possono accedere alle tecnologie più evolute dell’Impero, come i prototipi del TIE Advanced v1.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6187,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6188,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6189,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6190,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6191,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 1,
-            "cost": "40",
+            "cost": "84",
             "faction_id": 2,
-            "ffg_id": "XW_P_102",
-            "force_side": 1,
-            "id": 102,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Inquisitore",
+            "ffg_id": "XW_P_122",
+            "force_side": null,
+            "id": 122,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 25,
+            "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7143,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7078,
+                    "id": 7144,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7145,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7080,
+                    "id": 7146,
                     "recurring": false,
                     "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7081,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
+                    "value": "4"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Capo Onyx",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -14768,6 +10774,169 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Il TIE/ag, concepito per ingaggi prolungati, è comandato soprattutto da quei piloti scelti e addestrati per sfruttare al meglio sia i suoi armamenti unici che la sua manovrabilità.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6294,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6295,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6296,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_129",
+            "force_side": null,
+            "id": 129,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Esploratore della Squadriglia Onyx",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7171,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7172,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7173,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7174,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Durante lo sviluppo del TIE Aggressor, la Sienar Fleet Systems diede la precedenza alle sue prestazioni e alla sua versatilità, anziché alla cruda efficienza in costo.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6297,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6298,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6299,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 2,
+            "ffg_id": "XW_P_130",
+            "force_side": null,
+            "id": 130,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Specialista della Sienar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7175,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7176,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7177,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7178,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Dopo che hai effettuato un attacco che ha colpito, ottieni 1 segnalino schivata.<return><shipability><sabold>Apparato di Stygium:</sabold> Dopo che ti sei deoccultato, puoi effettuare 1 azione <evade>. All’inizio della Fase Finale, puoi spendere 1 segnalino schivata per ottenere 1 segnalino occultamento.</shipability>",
             "available_actions": [
                 {
@@ -15029,6 +11198,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Il TIE Phantom, il risultato primario della struttura di ricerca segreta chiamata Imdaar Alfa, è ciò che molti consideravano impossibile: un piccolo astrocaccia dotato di un evoluto dispositivo di occultamento.</flavor><return><shipability><sabold>Apparato di Stygium:</sabold> Dopo che ti sei deoccultato, puoi effettuare 1 azione <evade>. All’inizio della Fase Finale, puoi spendere 1 segnalino schivata per ottenere 1 segnalino occultamento.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6312,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6313,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6314,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 7,
+                    "base_action_side_effect": null,
+                    "id": 6315,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_134",
+            "force_side": null,
+            "id": 134,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Pilota Collaudatoredi Imdaar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 27,
+            "statistics": [
+                {
+                    "id": 7191,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7192,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7193,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7194,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre difendi, se sei disarmato, tira 1 dado di difesa aggiuntivo.",
             "available_actions": [
                 {
@@ -15285,6 +11540,94 @@
                 },
                 {
                     "id": 7206,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Lo Star Wing Classe <untalic>Alfa</untalic>, la cui estetica si ispirava agli altri vascelli della Cygnus Spaceworks, era una nave versatile, assegnata alle unità specialistiche della Flotta Imperiale bisognose di un astrocaccia che potesse svolgere molte mansioni diverse.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6328,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6329,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6330,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6331,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                6,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "35",
+            "faction_id": 2,
+            "ffg_id": "XW_P_138",
+            "force_side": null,
+            "id": 138,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilota dellaSquadriglia Nu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 14,
+            "statistics": [
+                {
+                    "id": 7207,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7208,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7209,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7210,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -15590,6 +11933,101 @@
             "weapon_range": null
         },
         {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 o più navi amiche a gittata 0-3. Se lo fai, trasferisci tutti i segnalini bersaglio acquisito nemici dalle navi scelte a te.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6347,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6348,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 6349,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6350,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                8,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 2,
+            "ffg_id": "XW_P_142",
+            "force_side": null,
+            "id": 142,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Capitano Kagi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 26,
+            "statistics": [
+                {
+                    "id": 7223,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7224,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 7225,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7226,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7227,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Pilota della Navetta dell’Imperatore",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "All’inizio della Fase di Attivazione, puoi spendere 1<nonbreak><standardcharge>. Se lo fai, mentre le navi amiche acquisiscono bersagli in questo round, devono acquisire bersagli oltre gittata 3 invece che a gittata 0-3.",
             "available_actions": [
                 {
@@ -15876,6 +12314,202 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Puoi effettuare attacchi primari a gittata 0.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6363,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6364,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6365,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6366,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6367,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 2,
+            "ffg_id": "XW_P_146",
+            "force_side": null,
+            "id": 146,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitano Oicunn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7244,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7245,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7246,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7247,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Tattico Ispirato",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco, se sei rinforzato e il difensore è nel <fullfront> o <fullrear> corrispondente al tuo segnalino rinforzo, puoi cambiare 1 tuo risultato <focus> in 1 risultato <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6368,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6369,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6370,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6371,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6372,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "88",
+            "faction_id": 2,
+            "ffg_id": "XW_P_147",
+            "force_side": null,
+            "id": 147,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Contrammiraglio Chiraneau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7248,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7249,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7250,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7251,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Consigliere dell’Ammiraglio Piett",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -16174,6 +12808,104 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre effettui un attacco primario, se ci sono navi amiche non limitate a gittata 0 dal difensore, tira 1 dadodi attacco aggiuntivo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6386,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6387,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": "stress",
+                    "id": 6388,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6389,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
+            "card_set_ids": [
+                6,
+                11
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 3,
+            "ffg_id": "XW_P_151",
+            "force_side": null,
+            "id": 151,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kath Scarlet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 10,
+            "statistics": [
+                {
+                    "id": 7266,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7267,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "3"
+                },
+                {
+                    "id": 7268,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7269,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7270,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Capitano dei Pirati di Binayre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre difendi o effettui un attacco, se la nave nemica è in tensione, puoi ripetere il tiro di 1 tuo dado.",
             "available_actions": [
                 {
@@ -16466,6 +13198,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre difendi o effettui un attacco, se la gittata di attacco è 1, puoi tirare 1 dado aggiuntivo.<return><sabold>Carica Frontale di Concordia:</sabold> Mentre difendi, se la gittata di attacco è 1 e sei nel <frontarc> dell’attaccante, cambia 1 risultato in 1 risultato <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6402,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6403,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6404,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6405,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 3,
+            "ffg_id": "XW_P_155",
+            "force_side": null,
+            "id": 155,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7286,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7287,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7288,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Capo Skull",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave nemica a gittata 1. Se lo fai e sei nel suo <frontarc>, quella nave rimuove tutti i suoi segnalini verdi.<return><sabold>Carica Frontale di Concordia:</sabold> Mentre difendi, se la gittata di attacco è 1 e sei nel <frontarc> dell’attaccante, cambia 1 risultato in 1 risultato <evade>.",
             "available_actions": [
                 {
@@ -16705,6 +13517,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Gli assi della Squadriglia Skull prediligono un approccio aggressivo e usano la tecnologia ad ali ruotanti del loro vascello per acquisire un’agilità ineguagliata all’inseguimento delle loro prede.</flavor><return><sabold>Carica Frontale di Concordia:</sabold> Mentre difendi, se la gittata di attacco è 1 e sei nel <frontarc> dell’attaccante, cambia 1 risultato in 1 risultato <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6418,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6419,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6420,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6421,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_159",
+            "force_side": null,
+            "id": 159,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Pilota dellaSquadriglia Skull",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7298,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7299,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7300,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>I piloti dei Caccia Fang mandaloriani devono imparare a padroneggiare la Carica Frontale di Concordia, una manovra che sfrutta l’esile profilo di attacco delle loro navi per lanciarsi in una micidiale carica frontale.</flavor><return><sabold>Carica Frontale di Concordia:</sabold> Mentre difendi, se la gittata di attacco è 1 e sei nel <frontarc> dell’attaccante, cambia 1 risultato in 1 risultato <evade>.",
             "available_actions": [
                 {
@@ -16935,6 +13827,156 @@
             "weapon_range": null
         },
         {
+            "ability_text": "All’inizio della Fase di Ingaggio, se ci sono altre navi a gittata 0, tu e ogni altra nave a gittata 0 ottenete 1 segnalino raggio traente.<return><shipability><sabold>Apparato Traente da Rimorchiatore:</sabold> <smallcaps>Azione:</smallcaps> Scegli 1 nave nel tuo <frontarc> a gittata 1. Quella nave ottiene 1 segnalino raggio traente, oppure 2 segnalini raggio traente se è nel tuo <bullseye> a gittata 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6432,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6433,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6434,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 3,
+            "ffg_id": "XW_P_163",
+            "force_side": null,
+            "id": 163,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Unkar Plutt",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7310,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7311,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7312,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Avaro Dispensatore di Porzioni",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Il Rimorchiatore Spaziale Quadrijet, comunemente chiamato “Quadjumper”, è un vascello agile sia nello spazio che in atmosfera, qualità che lo rende popolare sia presso i contrabbandieri che gli esploratori.</flavor><return><shipability><sabold>Apparato Traente da Rimorchiatore:</sabold> <smallcaps>Azione:</smallcaps> Scegli 1 nave nel tuo <frontarc> a gittata 1. Quella nave ottiene 1 segnalino raggio traente, oppure 2 segnalini raggio traente se è nel tuo <bullseye> a gittata 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6435,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6436,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6437,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 3,
+            "ffg_id": "XW_P_164",
+            "force_side": null,
+            "id": 164,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Mercante d’Armidi Jakku",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7313,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7314,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7315,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre effettui un attacco non <frontarc>, tira 1 dado di attacco aggiuntivo.",
             "available_actions": [
                 {
@@ -17021,6 +14063,188 @@
                 }
             ],
             "subtitle": "Corsaro Cinico",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre una nave amica non limitata effettua un attacco, se il difensore è nel tuo arco di fuoco, l’attaccante può ripetere il tiro di 1 dado di attacco.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6442,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6443,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6444,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6445,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 3,
+            "ffg_id": "XW_P_166",
+            "force_side": null,
+            "id": 166,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Drea Renthal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7320,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7321,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7322,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7323,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Signore dei Pirati",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>È sufficiente parlare di crediti Imperiali per vedere una schiera di individui poco affidabili accorrere al proprio fianco.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6446,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6447,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6448,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6449,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 3,
+            "ffg_id": "XW_P_167",
+            "force_side": null,
+            "id": 167,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Sicario Prezzolato",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7324,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7325,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7326,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7327,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17271,6 +14495,85 @@
                 }
             ],
             "subtitle": "Predone Imponente",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Puoi schierarti solo tramite uno schieramento di emergenza e possiedi il nome, l’iniziativa, le <standardcharge> della nave e la capacità del pilota dell’<smallcaps>Hound’s Tooth</smallcaps> amico distrutto.<return><shipability><sabold>Navetta di Fuga:</sabold> <smallcaps>Preparazione:</smallcaps>Richiede l’<smallcaps>Hound’s Tooth</smallcaps>. Devi iniziare la partita attraccato all’<smallcaps>Hound’s Tooth</smallcaps>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6460,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6461,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6462,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "6",
+            "faction_id": 3,
+            "ffg_id": "XW_P_171",
+            "force_side": null,
+            "id": 171,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Nashtah Pup</italic>",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 7340,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7341,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7342,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7343,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Piano di Riserva",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17532,6 +14835,102 @@
                 }
             ],
             "subtitle": "Mercenario della Fascia Esterna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave nemica nel tuo arco di fuoco a gittata 0-2.Se lo fai, trasferisci 1 segnalino concentrazione o schivata da quella nave a te stesso.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6474,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6475,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6476,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6477,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6478,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 3,
+            "ffg_id": "XW_P_175",
+            "force_side": null,
+            "id": 175,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Palob Godalhi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 7357,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7358,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7359,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7360,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Membro della Resistenza Tethana",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17815,6 +15214,94 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Dopo che hai eseguito completamente una manovra, puoi ottenere 1 segnalino tensione per ruotare la tua nave di 90°.<return><sabold>Micropropulsori:</sabold> Mentre effettui un avvitamento, devi usare il modello <leftbank> o <rightbank> invece del modello <straight>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6493,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6494,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6495,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6496,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_179",
+            "force_side": null,
+            "id": 179,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Dalan Oberos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 3,
+            "statistics": [
+                {
+                    "id": 7373,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7374,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7375,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7376,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Cacciatore di Taglie d’Elite",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre difendi, dopo il passo “Neutralizzare i Risultati”, 1 altra nave amica a gittata 0-1 e nell’arco di attacco può subire 1 danno <hit> o <crit>. Se lo fa, annulla 1 risultato corrispondente.<return><sabold>Micropropulsori:</sabold> Mentre effettui un avvitamento, devi usare il modello <leftbank> o <rightbank> invece del modello <straight>.",
             "available_actions": [
                 {
@@ -18078,6 +15565,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre una nave amica a gittata 0-1 difende, può ripetere il tiro di 1 suo dado.<return><shipability><sabold>Innesto Armato:</sabold> Puoi dotarti di 1 miglioria <cannon>, <torpedo> o <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6509,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6510,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6511,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6512,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_183",
+            "force_side": null,
+            "id": 183,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Serissu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7389,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7390,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7391,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7392,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Istruttore di Volo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Dopo aver acquisito un bersaglio, devi rimuovere tutti i tuoi segnalini concentrazione e schivata. Poi ottieni lo stesso numero di segnalini concentrazione e schivata posseduti dalla nave acquisita come bersaglio.<return><shipability><sabold>Innesto Armato:</sabold> Puoi dotarti di 1 miglioria <cannon>, <torpedo> o <missile>.</shipability>",
             "available_actions": [
                 {
@@ -18331,6 +15904,91 @@
                 }
             ],
             "subtitle": "Cercatore di Fortuna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi o effettui un attacco, puoi subire 1 danno <hit> per ripetere il tiro di un qualsiasi numero di tuoi dadi.<return><shipability><sabold>Innesto Armato:</sabold> Puoi dotarti di 1 miglioria <cannon>, <torpedo> o <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6525,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6526,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6527,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6528,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 3,
+            "ffg_id": "XW_P_187",
+            "force_side": null,
+            "id": 187,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Inaldra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7405,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7406,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7407,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7408,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Boss di Punta Tansarii",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -18592,6 +16250,88 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre difendi a gittata di attacco 3 o effettui un attacco a gittata di attacco 1, tira 1 dado aggiuntivo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6541,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6542,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6543,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_191",
+            "force_side": null,
+            "id": 191,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Talonbane Cobra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7421,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7422,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7423,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7424,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Flagello di Punta Tansarii",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre difendi, se sei dietro l’attaccante, tira 1 dado di difesa aggiuntivo.<return>Mentre effettui un attacco, se sei dietro il difensore, tira 1 dado di attacco aggiuntivo.",
             "available_actions": [
                 {
@@ -18832,6 +16572,88 @@
                 }
             ],
             "subtitle": "Opportunista Aggressivo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Il caccia d’assalto Kihraxz fu sviluppato specificamente per il consorzio criminale del Sole Nero, i cui assi del volo, pagati profumatamente, esigevano una nave agile e potente, all’altezza delle loro abilità.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6553,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6554,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6555,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 3,
+            "ffg_id": "XW_P_195",
+            "force_side": null,
+            "id": 195,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Asso del Sole Nero",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7437,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7438,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7439,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7440,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19100,6 +16922,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Dopo che hai effettuato un’azione <boost>, puoi effettuare 1 azione <evade>.<return><shipability><sabold>Cervello Droide Evoluto:</sabold> Dopo che hai effettuato un’azione <calculate>, ottieni 1 segnalino calcolo.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6567,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6568,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6569,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6570,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 3,
+            "ffg_id": "XW_P_199",
+            "force_side": null,
+            "id": 199,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•IG-88C",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 21,
+            "statistics": [
+                {
+                    "id": 7453,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7454,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7455,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7456,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Costrutto Calcolatore",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre esegui una manovra loop di Segnor (<leftsloop> o <rightsloop>), puoi invece usare il modello curva (<leftturn> o <rightturn>) con la stessa direzione e velocità oppure il modello dritta (<straight>) con la stessa velocità.<return><shipability><sabold>Cervello Droide Evoluto:</sabold> Dopo che hai effettuato un’azione <calculate>, ottieni 1 segnalino calcolo.</shipability>",
             "available_actions": [
                 {
@@ -19355,6 +17268,87 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>I leggendari Cercatori di Gand venerano le nebbie che avviluppano il loro pianeta natio e fanno uso di presagi, premonizioni e rituali mistici per rintracciare le loro prede.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6581,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6582,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6583,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_203",
+            "force_side": null,
+            "id": 203,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Cercatore di Gand",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 22,
+            "statistics": [
+                {
+                    "id": 7469,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7470,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7471,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7472,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Prima che una bomba o una mina amica stia per detonare, puoi spendere 1 <standardcharge>per prevenirne la detonazione.<return>Mentre difendi contro un attacco ostruito da una bomba o da una mina, tira 1 dado di difesa aggiuntivo.",
             "available_actions": [
                 {
@@ -19604,6 +17598,95 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un attacco, ogni nave nemica nel tuo <bullseye> subisce 1 danno <hit> a meno che non rimuova 1 segnalino verde.<return><sabold>Nessuna Via di Fuga:</sabold> Mentre effettui un attacco, se il difensore è nel tuo <bullseye>, i dadi di difesa non possono essere modificati usando segnalini verdi.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6593,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6594,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6595,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6596,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                10,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_207",
+            "force_side": null,
+            "id": 207,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Torani Kulda",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 39,
+            "statistics": [
+                {
+                    "id": 7486,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7487,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7488,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "7"
+                },
+                {
+                    "id": 7489,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Agente Indipendente Rodiano",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19878,6 +17961,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Se stai per fuggire, puoi spendere 1 <standardcharge>. Se lo fai, collocati invece in riserva. All’inizio della Fase di Pianificazione successiva, collocati entro gittata 1 dal margine dell’area di gioco da cui stavi per fuggire.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6608,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6609,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6610,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                8,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 3,
+            "ffg_id": "XW_P_211",
+            "force_side": null,
+            "id": 211,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Moralo Eval",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 24,
+            "statistics": [
+                {
+                    "id": 7503,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 7504,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7505,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "9"
+                },
+                {
+                    "id": 7506,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                },
+                {
+                    "id": 7507,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Genio del Crimine",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave a gittata 1 e spendere 1 bersaglio acquisito che possiedi su quella nave. Se lo fai, quella nave ottiene 1 segnalino raggio traente.",
             "available_actions": [
                 {
@@ -20130,6 +18304,88 @@
                 }
             ],
             "subtitle": "Corelliano Vendicativo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave amica a gittata 0-1. Se lo fai, trasferisci tutti i tuoi segnalini verdi a quella nave.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6620,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6621,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6622,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_215",
+            "force_side": null,
+            "id": 215,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Manaroo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 45,
+            "statistics": [
+                {
+                    "id": 7521,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7522,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7523,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7524,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Affascinante Aruzan",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20689,38 +18945,39 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Molti naviganti si guadagnano da vivere percorrendo la Fascia Esterna, dove il confine tra contrabbandieri e legittimi mercanti si fa spesso sottile. Ai margini della galassia civilizzata i compratori non si curano troppo della provenienza della merce, almeno finché il prezzo è conveniente.</flavor>",
+            "ability_text": "Mentre difendi o effettui un attacco primario, se l’attacco è ostruito da un ostacolo, puoi ripetere il tiro di 1 dado aggiuntivo.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 6645,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 6646,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 6647,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 6648,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
+                1,
                 6,
                 8,
                 8,
@@ -20729,51 +18986,142 @@
                 15,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "54",
             "faction_id": 3,
-            "ffg_id": "XW_P_225",
+            "ffg_id": "XW_P_222",
             "force_side": null,
-            "id": 225,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Capitano di Mercantile",
+            "id": 222,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 7555,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 7556,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 7557,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 7558,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Ragazzino Corelliano",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai tirato i dadi, se non sei in tensione, puoi ottenere 1 segnalino tensione per ripetere il tiro di tutti i tuoi risultati vuoto.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6649,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6650,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6651,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6652,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 3,
+            "ffg_id": "XW_P_223",
+            "force_side": null,
+            "id": 223,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7559,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7560,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7561,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7562,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Giocatore d’Azzardo Persuasivo",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20869,6 +19217,96 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Molti naviganti si guadagnano da vivere percorrendo la Fascia Esterna, dove il confine tra contrabbandieri e legittimi mercanti si fa spesso sottile. Ai margini della galassia civilizzata i compratori non si curano troppo della provenienza della merce, almeno finché il prezzo è conveniente.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6657,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6658,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6659,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6660,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 3,
+            "ffg_id": "XW_P_225",
+            "force_side": null,
+            "id": 225,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Capitano di Mercantile",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7567,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7568,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7569,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7570,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Dopo che hai tirato i dadi, se non sei in tensione, puoi ottenere 1 segnalino tensione per ripetere il tiro di tutti i tuoi risultati vuoto.<return><shipability><sabold>Copilota:</sabold> Mentre sei attraccato, la tua nave madre possiede la tua capacità del pilota in aggiunta alla sua.</shipability>",
             "available_actions": [
                 {
@@ -20948,42 +19386,160 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mentre effettui un attacco primario, prima del passo “Neutralizzare i Risultati”, se il difensore è nel tuo <bullseye>,puoi spendere 1<nonbreak><standardcharge> per annullare 1 risultato<nonbreak><evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                9
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_1",
-            "force_side": null,
-            "id": 230,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Colpo da Maestro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
+            "ability_text": "Le navi amiche a gittata 0-1 possono effettuare attacchi a gittata 0 dagli ostacoli.<return><shipability><sabold>Copilota:</sabold> Mentre sei attraccato, la tua nave madre possiede la tua capacità del pilota in aggiunta alla sua.</shipability>",
+            "available_actions": [
                 {
-                    "id": 6632,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6664,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6665,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6666,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
                 }
             ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+            "available_upgrades": [
+                1,
+                8,
+                14
             ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "24",
+            "faction_id": 3,
+            "ffg_id": "XW_P_227",
+            "force_side": null,
+            "id": 227,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Pioniere della Fascia Esterna",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7575,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7576,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7577,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7578,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Abile Fuorilegge",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Se non possiedi scudi attivi, riduci la difficoltà delle tue manovre curva (<leftbank> e <rightbank>).<return><shipability><sabold>Copilota:</sabold> Mentre sei attraccato, la tua nave madre possiede la tua capacità del pilota in aggiunta alla sua.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6667,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6668,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6669,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "22",
+            "faction_id": 3,
+            "ffg_id": "XW_P_228",
+            "force_side": null,
+            "id": 228,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•L3-37",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7579,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7580,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7581,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7582,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rivoluzionario Droide",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21069,81 +19625,94 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Se non possiedi scudi attivi, riduci la difficoltà delle tue manovre curva (<leftbank> e <rightbank>).<return><shipability><sabold>Copilota:</sabold> Mentre sei attraccato, la tua nave madre possiede la tua capacità del pilota in aggiunta alla sua.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6667,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6668,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6669,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "ability_text": "Mentre effettui un attacco primario, prima del passo “Neutralizzare i Risultati”, se il difensore è nel tuo <bullseye>,puoi spendere 1<nonbreak><standardcharge> per annullare 1 risultato<nonbreak><evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
             "card_set_ids": [
-                13
+                4,
+                5,
+                6,
+                9
             ],
-            "card_type_id": 1,
-            "cost": "22",
-            "faction_id": 3,
-            "ffg_id": "XW_P_228",
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_1",
             "force_side": null,
-            "id": 228,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•L3-37",
+            "id": 230,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Colpo da Maestro",
             "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 6632,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7580,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7581,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7582,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
+                    "statistic_id": 7,
+                    "value": "1"
                 }
             ],
-            "subtitle": "Rivoluzionario Droide",
-            "upgrade_types": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un’azione <boost> bianca, puoi considerarla come se fosse rossa per usare invece il modello [1<nonbreak><leftturn>] o [1<nonbreak><rightturn>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                12
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_2",
+            "force_side": null,
+            "id": 231,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Temerario",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Boost",
+                            "pk": 1,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21351,6 +19920,39 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre una nave nemica a gittata 0 difende, tira 1 dado di difesa in meno.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_7",
+            "force_side": null,
+            "id": 236,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Intimidazione",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre effettui un attacco, se stai schivando, puoi cambiare 1 risultato <evade> del difensore in 1 risultato <focus>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21400,6 +20002,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre difendi o effettui un attacco, se non ci sono altre navi amiche a gittata 0-2, puoi spendere 1<nonbreak><standardcharge> per ripetere il tiro di 1 tuo dado.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_9",
+            "force_side": null,
+            "id": 238,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lupo Solitario",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6606,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre effettui un attacco, se il difensore è nel tuo <bullseye>, puoi cambiare 1 risultato <hit> in 1 risultato <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21420,6 +20062,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Mira Esperta",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco <frontarc>, se non sei nell’arco di fuoco del difensore, il difensore tira 1 dado di difesa in meno.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_11",
+            "force_side": null,
+            "id": 240,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Manovrabilità Superiore",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21558,37 +20233,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "All’inizio della Fase di Ingaggio, puoi spendere 1 <forcecharge>. Se lo fai, ingaggia a iniziativa 7 (invece che al tuo valore di iniziativa standard) per questa fase.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-            "card_set_ids": [
-                1,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_19",
-            "force_side": null,
-            "id": 248,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Percezione Ampliata",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                17
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Mentre un’altra nave amica a gittata 0-1 difende, prima del passo “Neutralizzare i Risultati”, se sei nell’arco di attacco, puoi subire 1 danno <crit>per annullare 1 risultato <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21630,6 +20274,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Mentre coordini, la nave che scegli può effettuare un’azione solo se quell’azione si trova anche nella tua barra delle azioni.",
+            "available_actions": [
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 5830,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_16",
+            "force_side": null,
+            "id": 245,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Caposquadra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave amica a gittata 1. Se lo fai, quella nave considera la sua iniziativa pari alla tua fino alla fine del round.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21658,6 +20343,70 @@
             "subtitle": null,
             "upgrade_types": [
                 1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco ostruito da un ostacolo, tira 1 dado di attacco aggiuntivo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_18",
+            "force_side": null,
+            "id": 247,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Tiro a Sorpresa",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi spendere 1 <forcecharge>. Se lo fai, ingaggia a iniziativa 7 (invece che al tuo valore di iniziativa standard) per questa fase.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+            "card_set_ids": [
+                1,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_19",
+            "force_side": null,
+            "id": 248,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Percezione Ampliata",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                17
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -21763,6 +20512,78 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Dopo che hai rivelato il tuo indicatore, puoi effettuare 1 azione.<return>Se lo fai, non puoi effettuare altre azioni durante la tua attivazione.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_23",
+            "force_side": null,
+            "id": 252,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Sensori Avanzati",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un’accelerazione o un avvitamento, puoi muoverti attraverso gli ostacoli e sovrapporti ad essi.<return>Dopo che ti sei mosso attraverso un ostacolo o ti sei sovrapposto ad esso, puoi spendere 1<nonbreak><standardcharge> per ignorarne gli effetti fino alla fine del round.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_24",
+            "force_side": null,
+            "id": 253,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Rilevatore di Collisione",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6626,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre effettui un attacco, se hai acquisito il difensore come bersaglio, puoi ripetere il tiro di 1 dado di attacco. Se lo fai, non puoi spendere il tuo bersaglio acquisito durante questo attacco.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21783,6 +20604,37 @@
             "initiative": null,
             "is_unique": false,
             "name": "Sistema di Mira Assistita",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la Fase di Sistema, se stai per sganciare o lanciare una bomba, puoi invece lanciarla usando il modello [5<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_set_ids": [
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_26",
+            "force_side": null,
+            "id": 255,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Simulatore di Traiettoria",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21836,83 +20688,43 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Durante la Fase di Sistema, se stai per sganciare o lanciare una bomba, puoi invece lanciarla usando il modello [5<nonbreak><straight>].",
+            "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
             "card_set_ids": [
+                4,
                 5,
                 6
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "5",
             "faction_id": null,
-            "ffg_id": "XW_U_26",
+            "ffg_id": "XW_U_28",
             "force_side": null,
-            "id": 255,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "id": 257,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Simulatore di Traiettoria",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5835,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_32",
-            "force_side": null,
-            "id": 261,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Torretta Cannone a Ioni",
+            "name": "Cannone a Ioni",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6645,
+                    "id": 6643,
                     "recurring": false,
-                    "statistic_id": 12,
+                    "statistic_id": 10,
                     "value": "3"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
-                4
+                3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 - 3"
         },
         {
             "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, tutti i risultati <hit>/<crit> infliggono segnalini disturbo invece di danni.",
@@ -21993,48 +20805,144 @@
             "weapon_range": "1 - 3"
         },
         {
-            "ability_text": "<smallcaps>Attacco (</smallcaps><focus><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Se il difensore è nel tuo <bullseye>, puoi spendere 1 o più <standardcharge> per ripetere il tiro di un pari ammontare di dadi di attacco.",
-            "available_actions": [],
+            "ability_text": "<smallcaps>Attacco</smallcaps>",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5832,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
             "card_set_ids": [
-                5
+                4,
+                5,
+                6
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_36",
+            "ffg_id": "XW_U_31",
             "force_side": null,
-            "id": 265,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "id": 260,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Razzi di Sbarramento",
+            "name": "Torretta Dorsale",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6619,
+                    "id": 6633,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6621,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "5"
+                    "statistic_id": 12,
+                    "value": "2"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Attacco:</smallcaps> Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5835,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+            "card_set_ids": [
+                4,
+                5,
                 6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_32",
+            "force_side": null,
+            "id": 261,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Torretta Cannone a Ioni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6645,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Cambia 1 risultato <hit> in 1 risultato <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+            "card_set_ids": [
+                4,
+                5,
                 6
             ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_33",
+            "force_side": null,
+            "id": 262,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Siluri Protonici Avanzati",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6615,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "5"
+                },
+                {
+                    "id": 6617,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                5
+            ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "1"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Se questo attacco colpisce, spendi 1 risultato <hit> o <crit> per far subire 1 danno <hit> al difensore. Tutti i risultati <hit>/<crit> rimanenti infliggono segnalini ioni invece di danni.",
@@ -22129,6 +21037,96 @@
             ],
             "weapon_no_bonus": true,
             "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Attacco (</smallcaps><focus><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Se il difensore è nel tuo <bullseye>, puoi spendere 1 o più <standardcharge> per ripetere il tiro di un pari ammontare di dadi di attacco.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_36",
+            "force_side": null,
+            "id": 265,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Razzi di Sbarramento",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6619,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6621,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "5"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6,
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Dopo questo attacco, puoi effettuare questo attacco come attacco bonus contro un bersaglio diverso a gittata 0-1 dal difensore, ignorando il requisito <targetlock>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_37",
+            "force_side": null,
+            "id": 266,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Missili a Grappolo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6623,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6625,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "4"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "1 - 2"
         },
         {
             "ability_text": "<smallcaps>Attacco (</smallcaps><targetlock><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>. Dopo che questo attacco ha colpito, ogni nave a gittata 0-1 dal difensore espone 1 sua carta danno.",
@@ -22267,38 +21265,6 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Mentre difendi, prima che i dadi di attacco siano tirati, puoi spendere 1 bersaglio acquisito che possiedi sull’attaccante per tirare 1 dado di attacco. Se lo fai, l’attaccante ottiene 1 segnalino disturbo. Poi, con un risultato <hit> o <crit>, ottieni 1 segnalino disturbo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_42",
-            "force_side": null,
-            "id": 271,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Slicer Indipendente",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Attacco (</smallcaps><focus><smallcaps>):</smallcaps> Spendi 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22344,6 +21310,109 @@
             "weapon_range": "1 - 2"
         },
         {
+            "ability_text": "Mentre difendi, prima che i dadi di attacco siano tirati, puoi spendere 1 bersaglio acquisito che possiedi sull’attaccante per tirare 1 dado di attacco. Se lo fai, l’attaccante ottiene 1 segnalino disturbo. Poi, con un risultato <hit> o <crit>, ottieni 1 segnalino disturbo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_42",
+            "force_side": null,
+            "id": 271,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Slicer Indipendente",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Preparazione:</smallcaps> Perdi 1<nonbreak><standardcharge>.<return><smallcaps>Azione:</smallcaps> Recupera 1<nonbreak><standardcharge>.<return><smallcaps>Azione:</smallcaps> Spendi 1<nonbreak><standardcharge> per recuperare 1 scudo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_43",
+            "force_side": null,
+            "id": 272,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Droide GNK “Gonk” ",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6636,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Preparazione:</smallcaps> Dopo il passo “Collocare le Forze”, scegli 1 nave nemica e assegnale la condizione <smallcaps>Dispositivo di Spionaggio</smallcaps>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_44",
+            "force_side": null,
+            "id": 273,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Informatore",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Alla fine del round, puoi tirare 1 dado di attacco per riparare 1 carta danno a faccia in su. Poi, con un risultato <hit>, esponi 1 carta danno.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22363,6 +21432,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Tecnico Novizio",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un’azione <focus>, ottieni 1 segnalino concentrazione.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_46",
+            "force_side": null,
+            "id": 275,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Copilota Percettivo",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -22456,6 +21558,38 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco <turretarc>, dopo il passo “Modificare i Dadi di Difesa”, il difensore rimuove 1 segnalino concentrazione o calcolo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_49",
+            "force_side": null,
+            "id": 278,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Artigliere Spericolato",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -22587,6 +21721,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Dopo che hai rivelato il tuo indicatore, puoi spendere 1 <standardcharge> e ottenere 1 segnalino disarmo per recuperare 1 scudo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+            "card_set_ids": [
+                1,
+                4,
+                6,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_53",
+            "force_side": null,
+            "id": 282,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Droide Astromeccanico R2",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6663,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Puoi mantenere fino a 2 bersagli acquisiti, ciascuno su un oggetto diverso.<return>Dopo che hai effettuato un’azione <targetlock>, puoi acquisire un bersaglio.<return>",
             "available_actions": [],
             "available_upgrades": [],
@@ -22702,6 +21876,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallcaps>Azione:</smallcaps> Spendi 1<nonbreak><standardcharge> per effettuare 1 azione <cloak>. <return>All’inizio della Fase di Pianificazione, tira 1 dado di attacco. Con un risultato <focus>, deoccultati o scarta il tuo segnalino occultamento.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_57",
+            "force_side": null,
+            "id": 286,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Dispositivo Occultante",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6594,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Prima di attivarti, puoi spendere 1 <standardcharge>. Se lo fai, fino alla fine del round puoi effettuare azioni ed eseguire manovre rosse anche mentre sei in tensione.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_58",
+            "force_side": null,
+            "id": 287,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cibernetica di Contrabbando",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6631,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Dopo che sei stato distrutto, ogni altra nave a gittata 0-1 subisce 1 danno<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22797,45 +22062,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 rete conner usando il modello [1<nonbreak><straight>].<return>Le <standardcharge> di questa carta non possono essere recuperate.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_64",
-            "force_side": null,
-            "id": 393,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Reti Conner",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6630,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Azione:</smallcaps> Spendi 1 <standardcharge>. Sgancia 1 carico sparso usando il modello [1<nonbreak><straight>].",
             "available_actions": [],
             "available_upgrades": [],
@@ -22890,18 +22116,10 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Attacco</smallcaps>",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5832,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
+            "ability_text": "Prima che tu stia per subire danni da un ostacolo o da una bomba amica che detona, puoi spendere 1<nonbreak><standardcharge>. Se lo fai, previeni 1 danno.",
+            "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
             "card_set_ids": [
                 4,
                 5,
@@ -22910,60 +22128,35 @@
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_31",
+            "ffg_id": "XW_U_68",
             "force_side": null,
-            "id": 260,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+            "id": 292,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Torretta Dorsale",
-            "restrictions": [],
+            "name": "Blindatura Ablativa",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "LARGE"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6633,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                4
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 bomba protonica usando il modello [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_65",
-            "force_side": null,
-            "id": 394,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Bombe Protoniche",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6655,
+                    "id": 6614,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -22971,88 +22164,50 @@
             ],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 mina di prossimità usando il modello [1<nonbreak><straight>].<return>Le <standardcharge> di questa carta non possono essere recuperate.",
+            "ability_text": "Dopo che hai effettuato un’azione <slam>, se hai eseguito completamente la manovra, puoi effettuare 1 azione bianca nella tua barra delle azioni considerandola come se fosse rossa.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
             "card_set_ids": [
                 4,
                 5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_66",
-            "force_side": null,
-            "id": 395,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Mine di Prossimità",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6662,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 carica sismica usando il modello [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8,
-                11
+                6
             ],
             "card_type_id": 2,
             "cost": "3",
             "faction_id": null,
-            "ffg_id": "XW_U_67",
+            "ffg_id": "XW_U_69",
             "force_side": null,
-            "id": 396,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "id": 293,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Cariche Sismiche",
-            "restrictions": [],
+            "name": "SLAM Avanzato",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Slam",
+                            "pk": 13,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6666,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23187,6 +22342,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Per chi non può permettersi un generatore di scudo potenziato, saldare ulteriori strati di piastre sullo scafo di una nave può fungere da alternativa adeguata.</flavor>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "*",
+            "faction_id": null,
+            "ffg_id": "XW_U_73",
+            "force_side": null,
+            "id": 297,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Miglioria allo Scafo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6642,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "+1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre effettui un attacco <torpedo> o <missile>, dopo aver tirato i dadi di attacco, puoi annullare tutti i risultati dei dadi per recuperare 1<nonbreak><standardcharge> spesa come costo dell’attacco.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23291,54 +22486,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Prima di tirare i dadi di difesa, puoi spendere 1 segnalino calcolo per dichiarare a voce alta un numero pari o superiore a 1. Se lo fai e ottieni esattamente quel numero di risultati <evade>, aggiungi 1 risultato<nonbreak><evade>.<return>Dopo che hai effettuato un’azione <calculate>, ottieni 1 segnalino calcolo.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5827,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_80",
-            "force_side": null,
-            "id": 304,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•C-3PO",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Mentre difendi, se la tua <standardcharge> è attiva, tira 1 dado di difesa aggiuntivo. <return>Dopo che hai subito danni, perdi 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23422,6 +22569,94 @@
             "subtitle": null,
             "upgrade_types": [
                 14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un’azione <focus>, puoi considerarla come se fosse rossa. Se lo fai, ottieni 1 segnalino concentrazione aggiuntivo per ogni nave nemica a gittata 0-1, fino a un massimo di 2.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_79",
+            "force_side": null,
+            "id": 303,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Baze Malbus",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Prima di tirare i dadi di difesa, puoi spendere 1 segnalino calcolo per dichiarare a voce alta un numero pari o superiore a 1. Se lo fai e ottieni esattamente quel numero di risultati <evade>, aggiungi 1 risultato<nonbreak><evade>.<return>Dopo che hai effettuato un’azione <calculate>, ottieni 1 segnalino calcolo.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5827,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "12",
+            "faction_id": null,
+            "ffg_id": "XW_U_80",
+            "force_side": null,
+            "id": 304,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•C-3PO",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23514,6 +22749,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante il passo “Effettuare l’Azione”, puoi effettuare 1 azione anche mentre sei in tensione. Dopo che hai effettuato un’azione mentre sei in tensione, subisci 1 danno <hit> a meno che tu non esponga 1 tua carta danno.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_83",
+            "force_side": null,
+            "id": 307,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Puoi eseguire le manovre rosse anche mentre sei in tensione. Dopo che hai eseguito completamente una manovra rossa, se possiedi 3 o più segnalini tensione, rimuovi 1 segnalino tensione e subisci 1 danno<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23531,6 +22806,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Hera Syndulla",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Se una nave amica a gittata 0-3 sta per ottenere un segnalino concentrazione, può invece ottenere 1 segnalino schivata.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_85",
+            "force_side": null,
+            "id": 309,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Jyn Erso",
             "restrictions": [
                 [
                     {
@@ -23688,6 +23003,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Dopo che hai difeso, se l’attacco ha colpito, puoi acquisire l’attaccante come bersaglio.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_89",
+            "force_side": null,
+            "id": 313,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Riduci la difficoltà delle tue manovre curva (<leftbank> e <rightbank>).",
             "available_actions": [],
             "available_upgrades": [],
@@ -23705,6 +23060,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Nien Nunb",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la Fase Finale, se sei danneggiato e non possiedi scudi attivi, puoi tirare 1 dado di attacco per recuperare 1 scudo. Con un risultato <hit>, esponi 1 tua carta danno.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_91",
+            "force_side": null,
+            "id": 315,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R2-D2",
             "restrictions": [
                 [
                     {
@@ -23768,23 +23163,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Durante la Fase Finale, se sei danneggiato e non possiedi scudi attivi, puoi tirare 1 dado di attacco per recuperare 1 scudo. Con un risultato <hit>, esponi 1 tua carta danno.",
+            "ability_text": "Mentre effettui un attacco, puoi subire 1 danno <hit> per cambiare tutti i tuoi risultati <focus> in risultati <crit>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
             "card_set_ids": [
-                4
+                2
             ],
             "card_type_id": 2,
             "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_91",
+            "ffg_id": "XW_U_93",
             "force_side": null,
-            "id": 315,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "id": 317,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R2-D2",
+            "name": "•Saw Gerrera",
             "restrictions": [
                 [
                     {
@@ -23803,6 +23198,86 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Puoi effettuare attacchi primari a gittata 0. Le navi nemiche a gittata 0 possono effettuare attacchi primari contro di te.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_94",
+            "force_side": null,
+            "id": 318,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un attacco primario, se sei concentrato, puoi effettuare un attacco <turretarc> bonus contro una nave che non hai già attaccato in questo round.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "14",
+            "faction_id": null,
+            "ffg_id": "XW_U_95",
+            "force_side": null,
+            "id": 319,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bistan",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23895,46 +23370,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mentre effettui un attacco, puoi subire 1 danno <hit> per cambiare tutti i tuoi risultati <focus> in risultati <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_93",
-            "force_side": null,
-            "id": 317,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "All’inizio della Fase di Ingaggio, puoi spendere 1 <forcecharge> per ruotare il tuo segnalatore <turretarc>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23977,6 +23412,46 @@
             "subtitle": null,
             "upgrade_types": [
                 16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Azione:</smallcaps> Spendi 1 <standardcharge> non ricorsivada un’altra miglioria di cui sei dotato per recuperare 1 scudo.<return><smallcaps>Azione:</smallcaps> Spendi 2 scudi per recuperare 1 <standardcharge> non ricorsiva su una miglioria di cui sei dotato.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_99",
+            "force_side": null,
+            "id": 323,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24076,23 +23551,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Puoi effettuare attacchi primari a gittata 0. Le navi nemiche a gittata 0 possono effettuare attacchi primari contro di te.",
+            "ability_text": "Puoi far attraccare 1 Navetta di Attacco o 1 Navetta Classe Sheathipede.<return>Le tue navi attraccate possono essere schierate soltanto dalle tue guide posteriori.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 2,
-            "cost": "1",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_94",
+            "ffg_id": "XW_U_102",
             "force_side": null,
-            "id": 318,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "id": 326,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•“Zeb” Orrelios",
+            "name": "•<italic>Ghost</italic>",
             "restrictions": [
                 [
                     {
@@ -24102,6 +23577,15 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 23,
+                            "raw_name": "VCX-100 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
@@ -24110,40 +23594,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre effettui un attacco ostruito da un ostacolo, tira 1 dado di attacco aggiuntivo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_18",
-            "force_side": null,
-            "id": 247,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Tiro a Sorpresa",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24311,6 +23762,103 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Puoi attraccare a gittata 0-1.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_106",
+            "force_side": null,
+            "id": 330,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Phantom</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 32,
+                            "raw_name": "Attack Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    },
+                    {
+                        "kwargs": {
+                            "pk": 8,
+                            "raw_name": "Sheathipede-class Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Prima di attivarti, puoigirare questa carta.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+            "card_set_ids": [
+                2,
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_107",
+            "force_side": null,
+            "id": 331,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ali Orientabili (Aperte)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 15,
+                            "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre difendi, tira 1 dado di difesa in meno.<return>Dopo che hai eseguito una manovra [0 <stop>], puoi ruotare la tua nave di 90° o 180°.<return>Prima di attivarti, puoi girare questa carta.<return>",
             "available_actions": [],
             "available_upgrades": [],
@@ -24332,6 +23880,49 @@
                         "kwargs": {
                             "pk": 15,
                             "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Before you activate, you may flip this card.Prima di attivarti, puoi girare questa carta.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_set_ids": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_108",
+            "force_side": null,
+            "id": 333,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Alettoni-S a Servomotore (Aperti)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 33,
+                            "raw_name": "T-65 X-wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -24402,34 +23993,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Before you activate, you may flip this card.Prima di attivarti, puoi girare questa carta.",
+            "ability_text": "Dopo che un’altra nave amica a gittata 0-3 ha difeso, se è distrutta, l’attaccante ottiene 2 segnalini tensione.<return>Mentre una nave amica a gittata 0-3 effettua un attacco contro una nave in tensione, può ripetere il tiro di 1 dado di attacco.<return>",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
             "card_set_ids": [
-                1,
-                2,
-                4,
-                7
+                5
             ],
             "card_type_id": 2,
-            "cost": "0",
+            "cost": "10",
             "faction_id": null,
-            "ffg_id": "XW_U_108",
+            "ffg_id": "XW_U_109",
             "force_side": null,
-            "id": 333,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "id": 335,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Alettoni-S a Servomotore (Aperti)",
+            "is_unique": true,
+            "name": "•Ammiraglio Sloane",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "pk": 33,
-                            "raw_name": "T-65 X-wing"
+                            "name": "Galactic Empire",
+                            "pk": 2
                         },
-                        "type": "SHIP_TYPE"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -24439,7 +24027,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                18
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24590,6 +24178,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante la Fase di Attivazione, le navi nemiche a gittata 0-1 non possono rimuovere i segnalini tensione.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_113",
+            "force_side": null,
+            "id": 339,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Assaltatori della Morte",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8,
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallcaps>Preparazione:</smallcaps> Prima del passo “Collocare le Forze”, assegna la condizione <smallcaps>Prototipo Ottimizzato</smallcaps> a un’altra nave amica.",
             "available_actions": [
                 {
@@ -24733,6 +24362,111 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante la Fase di Sistema, puoi spendere 2 <standardcharge>. Se lo fai, ogni nave amica può acquisire come bersaglio una nave che hai acquisito come bersaglio.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_117",
+            "force_side": null,
+            "id": 343,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Gran Moff Tarkin",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6601,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la Fase Finale, le navi nemiche a gittata 1-2 non possono rimuovere i segnalini disturbo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_118",
+            "force_side": null,
+            "id": 344,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Slicer dell’ISB",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "All’inizio della Fase di Ingaggio, se sei danneggiato, puoi effettuare 1 azione <reinforce> rossa.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24838,23 +24572,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Durante la Fase Finale, le navi nemiche a gittata 1-2 non possono rimuovere i segnalini disturbo.",
+            "ability_text": "Se una nave nemica a gittata 0-1 sta per ottenere un segnalino tensione, puoi spendere 1 <forcecharge> per farle invece ottenere 1 segnalino disturbo o raggio traente.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
             "card_set_ids": [
-                3
+                5
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "12",
             "faction_id": null,
-            "ffg_id": "XW_U_118",
+            "ffg_id": "XW_U_121",
             "force_side": null,
-            "id": 344,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "id": 347,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Slicer dell’ISB",
+            "is_unique": true,
+            "name": "•Settima Sorella",
             "restrictions": [
                 [
                     {
@@ -24869,7 +24603,14 @@
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [],
+            "statistics": [
+                {
+                    "id": 6613,
+                    "recurring": false,
+                    "statistic_id": 4,
+                    "value": "+1"
+                }
+            ],
             "subtitle": null,
             "upgrade_types": [
                 8
@@ -24925,94 +24666,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Se una nave nemica a gittata 0-1 sta per ottenere un segnalino tensione, puoi spendere 1 <forcecharge> per farle invece ottenere 1 segnalino disturbo o raggio traente.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_121",
-            "force_side": null,
-            "id": 347,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Settima Sorella",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6613,
-                    "recurring": false,
-                    "statistic_id": 4,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Prima di attivarti, puoigirare questa carta.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
-            "card_set_ids": [
-                2,
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_107",
-            "force_side": null,
-            "id": 331,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ali Orientabili (Aperte)",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 15,
-                            "raw_name": "UT-60D U-wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Dopo che hai eseguito parzialmente una manovra, puoi effettuare 1 azione bianca, considerandola come se fosse rossa.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25062,38 +24715,29 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Dopo che hai effettuato un’azione <coordinate>, puoi scegliere 1 nave nemica a gittata 0-3 dalla nave che hai coordinato. Se lo fai, acquisisci quella nave nemica come bersaglio, ignorando le restrizioni di gittata.",
+            "ability_text": "Mentre possiedi esattamente 1 segnalino disarmo, puoi comunque effettuare attacchi <torpedo> e <missile> contro i bersagli che hai acquisito come bersaglio. Se lo fai, non puoi spendere il tuo bersaglio acquisito durante l’attacco.<return>Aggiungi 1 slot <torpedo> e 1 slot <missile>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_124",
+            "ffg_id": "XW_U_125",
             "force_side": null,
-            "id": 391,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "id": 350,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
             "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>ST-321</italic>",
+            "is_unique": false,
+            "name": "Arsenale Armamenti Os-1",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 26,
-                            "raw_name": "Lambda-class T-4a Shuttle"
+                            "pk": 14,
+                            "raw_name": "Alpha-class Star Wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -25105,7 +24749,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                15
+                18
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25146,6 +24790,60 @@
             "subtitle": null,
             "upgrade_types": [
                 18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase di Ingaggio, puoi scegliere 1 nave nemica a gittata 0-1. Se lo fai, ottieni 1 segnalino calcolo a meno che quella nave non scelga di ottenere 1 segnalino tensione.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_127",
+            "force_side": null,
+            "id": 352,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•0-0-0",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 338
+                        },
+                        "type": "CARD_INCLUDED"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 93
+                        },
+                        "type": "CARD_INCLUDED"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25249,6 +24947,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Cad Bane",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante la Fase Finale, puoi scegliere 2 migliorie <illicit> di cui siano dotate navi amiche a gittata 0-1. Se lo fai, puoi scambiare quelle migliorie.<return><smallcaps>Fine della Partita:</smallcaps> Rimetti tutte le migliorie <illicit> sulle loro navi originali.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_131",
+            "force_side": null,
+            "id": 356,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Cikatro Vizago",
             "restrictions": [
                 [
                     {
@@ -25385,6 +25123,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Ketsu Onyo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre difendi, se l’attaccante è in tensione, puoi rimuovere 1 segnalino tensione dall’attaccante per cambiare 1 tuo risultato vuoto/<focus> in 1 risultato <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_135",
+            "force_side": null,
+            "id": 360,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Latts Razzi",
             "restrictions": [
                 [
                     {
@@ -25563,6 +25341,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Dopo che hai effettuato un attacco primario che ha mancato, se non sei in tensione, devi ricevere 1 segnalino tensione per effettuare 1 attacco primario bonus contro lo stesso bersaglio.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_139",
+            "force_side": null,
+            "id": 364,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bossk",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Mentre effettui un attacco, puoi cambiare 1 risultato <hit> in 1 risultato <crit> per ogni segnalino tensione posseduto dal difensore.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25711,6 +25529,133 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Dopo che hai eseguito completamente una manovra, se non hai sganciato o lanciato un congegno in questo round, puoi sganciare 1 bomba.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_143",
+            "force_side": null,
+            "id": 368,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Genius”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre effettui un attacco contro un difensore nel tuo <frontarc>, puoi spendere 1 <standardcharge> per ripetere il tiro di 1 dado di attacco. Se il risultato del tiro ripetuto è <crit>, subisci 1 danno<nonbreak><crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_144",
+            "force_side": null,
+            "id": 369,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-P8",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6612,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Puoi effettuare attacchi contro le navi amiche.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_145",
+            "force_side": null,
+            "id": 370,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-TK",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Aggiungi 1 slot <bomb>.",
             "available_actions": [
                 {
@@ -25818,23 +25763,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Mentre effettui un attacco contro un difensore nel tuo <frontarc>, puoi spendere 1 <standardcharge> per ripetere il tiro di 1 dado di attacco. Se il risultato del tiro ripetuto è <crit>, subisci 1 danno<nonbreak><crit>.",
+            "ability_text": "Puoi far attraccare 1 Headhunter Z-95-AF4.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "4",
+            "cost": "1",
             "faction_id": null,
-            "ffg_id": "XW_U_144",
+            "ffg_id": "XW_U_148",
             "force_side": null,
-            "id": 369,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "id": 373,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R5-P8",
+            "name": "•<italic>Hound’s Tooth</italic>",
             "restrictions": [
                 [
                     {
@@ -25844,22 +25789,73 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 24,
+                            "raw_name": "YV-666 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6612,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "3"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                10
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Possiedi la capacità del pilota di ogni altra nave amica con la miglioria <sabold>IG-2000</sabold>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_149",
+            "force_side": null,
+            "id": 374,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "<italic>IG-2000</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 21,
+                            "raw_name": "Aggressor Assault Fighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25971,23 +25967,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Possiedi la capacità del pilota di ogni altra nave amica con la miglioria <sabold>IG-2000</sabold>.",
+            "ability_text": "Mentre effettui un attacco primario, se il difensore è nel tuo <frontarc>, tira 1 dado di attacco aggiuntivo.<return>Rimuovi 1 slot <crew>. Aggiungi 1 slot <astro>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_149",
+            "ffg_id": "XW_U_152",
             "force_side": null,
-            "id": 374,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "id": 377,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "<italic>IG-2000</italic>",
+            "is_unique": true,
+            "name": "•<italic>Punishing One</italic>",
             "restrictions": [
                 [
                     {
@@ -26001,8 +25997,8 @@
                 [
                     {
                         "kwargs": {
-                            "pk": 21,
-                            "raw_name": "Aggressor Assault Fighter"
+                            "pk": 45,
+                            "raw_name": "JumpMaster 5000"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -26172,23 +26168,72 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Preparazione:</smallcaps> Dotati di questa miglioria con questo lato a faccia in su.<return>Mentre difendi, puoi girare questa carta. Se lo fai, l’attaccante deve ripetere il tiro di tutti i dadi di attacco.",
+            "ability_text": "Dopo che hai fallito un’azione, se non possiedi segnalini verdi, puoi effettuare 1 azione <focus>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_156",
+            "force_side": null,
+            "id": 381,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Compostezza",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "All’inizio della Fase Finale, puoi spendere 1 segnalino concentrazione per riparare 1 tua carta danno a faccia in su.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_158",
+            "ffg_id": "XW_U_157",
             "force_side": null,
-            "id": 384,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+            "id": 382,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•L3-37",
+            "name": "•Chewbacca",
             "restrictions": [
                 [
                     {
@@ -26250,40 +26295,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Dopo che hai fallito un’azione, se non possiedi segnalini verdi, puoi effettuare 1 azione <focus>.",
+            "ability_text": "<smallcaps>Preparazione:</smallcaps> Dotati di questa miglioria con questo lato a faccia in su.<return>Mentre difendi, puoi girare questa carta. Se lo fai, l’attaccante deve ripetere il tiro di tutti i dadi di attacco.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_156",
+            "ffg_id": "XW_U_158",
             "force_side": null,
-            "id": 381,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "id": 384,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Compostezza",
+            "is_unique": true,
+            "name": "•L3-37",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "STRESS"
+                            "name": "Scum and Villainy",
+                            "pk": 3
                         },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -26293,7 +26329,47 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                1
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai tirato i dadi, puoi spendere 1 segnalino verde per ripetere il tiro di un massimo di 2 tuoi dadi.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_159",
+            "force_side": null,
+            "id": 385,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26316,6 +26392,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Tobias Beckett",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Mentre ti muovi ed effettui attacchi, ignora gli ostacoli che hai acquisito come bersaglio.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_161",
+            "force_side": null,
+            "id": 387,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Qi’ra",
             "restrictions": [
                 [
                     {
@@ -26369,46 +26485,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Dopo che hai tirato i dadi, puoi spendere 1 segnalino verde per ripetere il tiro di un massimo di 2 tuoi dadi.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_159",
-            "force_side": null,
-            "id": 385,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Prima di ingaggiare, puoi effettuare 1 azione <focus> rossa.",
             "available_actions": [],
             "available_upgrades": [],
@@ -26444,331 +26520,6 @@
             "subtitle": null,
             "upgrade_types": [
                 16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre ti muovi ed effettui attacchi, ignora gli ostacoli che hai acquisito come bersaglio.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_161",
-            "force_side": null,
-            "id": 387,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Qi’ra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai ricevuto un segnalino tensione, puoi tirare 1 dado di attacco per rimuoverlo. Con un risultato <hit>, subisci 1 danno<nonbreak><hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5851,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5852,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5853,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_5",
-            "force_side": null,
-            "id": 5,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Jek Porkins",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6688,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6689,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6690,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6691,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rosso Sei",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puoi effettuare attacchi primari a gittata 0.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6363,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6364,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6365,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6366,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6367,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_146",
-            "force_side": null,
-            "id": 146,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitano Oicunn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7244,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7245,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7246,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7247,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Tattico Ispirato",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Mentre una nave nemica a gittata 0 difende, tira 1 dado di difesa in meno.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_7",
-            "force_side": null,
-            "id": 236,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Intimidazione",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Dopo che hai effettuato un’azione <focus>, ottieni 1 segnalino concentrazione.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_46",
-            "force_side": null,
-            "id": 275,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Copilota Percettivo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Puoi effettuare attacchi contro le navi amiche.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_145",
-            "force_side": null,
-            "id": 370,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•R5-TK",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26818,6 +26569,255 @@
             "subtitle": null,
             "upgrade_types": [
                 15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Dopo che hai effettuato un’azione <coordinate>, puoi scegliere 1 nave nemica a gittata 0-3 dalla nave che hai coordinato. Se lo fai, acquisisci quella nave nemica come bersaglio, ignorando le restrizioni di gittata.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_124",
+            "force_side": null,
+            "id": 391,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>ST-321</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 26,
+                            "raw_name": "Lambda-class T-4a Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 bomba a frammentazione usando il modello [1<nonbreak><straight>].<return>All’inizio della Fase di Attivazione, puoi spendere 1 scudo per recuperare 2 <standardcharge>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_63",
+            "force_side": null,
+            "id": 392,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Generatore di Bombe a Frammentazione",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6622,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12,
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 rete conner usando il modello [1<nonbreak><straight>].<return>Le <standardcharge> di questa carta non possono essere recuperate.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_64",
+            "force_side": null,
+            "id": 393,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Reti Conner",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6630,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 bomba protonica usando il modello [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_65",
+            "force_side": null,
+            "id": 394,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Bombe Protoniche",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6655,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 mina di prossimità usando il modello [1<nonbreak><straight>].<return>Le <standardcharge> di questa carta non possono essere recuperate.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_66",
+            "force_side": null,
+            "id": 395,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Mine di Prossimità",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6662,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante la Fase di Sistema, puoi spendere 1<nonbreak><standardcharge> per sganciare 1 carica sismica usando il modello [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_67",
+            "force_side": null,
+            "id": 396,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cariche Sismiche",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6666,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
             ],
             "weapon_no_bonus": false,
             "weapon_range": null

--- a/translation_helper/api_export_pl.json
+++ b/translation_helper/api_export_pl.json
@@ -1,6 +1,745 @@
 {
     "cards": [
         {
+            "ability_text": "Gdy wykonujesz atak, obrońca rzuca 1 kością obrony mniej.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5839,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5840,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5841,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_1",
+            "force_side": null,
+            "id": 1,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Wedge Antilles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6671,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6672,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6673,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6674,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Czerwony Dwa",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy zostaniesz obrońcą (przed rzutami kośćmi), możesz odzyskać 1<nonbreak><forcecharge>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5842,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5843,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5844,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                17,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "62",
+            "faction_id": 1,
+            "ffg_id": "XW_P_2",
+            "force_side": 2,
+            "id": 2,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Luke Skywalker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6675,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6676,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6677,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6678,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 6679,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Czerwony Pięć",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak, możesz wydać 1 wynik <focus>, <hit> albo <crit>, aby podejrzeć zakryte karty uszkodzeń obrońcy, wybrać 1 i ją odkryć.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5845,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5846,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5847,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_set_ids": [
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_3",
+            "force_side": null,
+            "id": 3,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Thane Kyrell",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6680,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6681,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6682,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6683,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Korona Cztery",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wydasz żeton skupienia, możesz wskazać 1 przyjazny statek w zasięgu 1–3. Wskazany statek otrzymuje 1 żeton skupienia.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5848,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5849,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5850,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_4",
+            "force_side": null,
+            "id": 4,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6684,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6685,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6686,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6687,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Dowódca Czerwonych",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy otrzymasz żeton stresu, możesz rzucić 1 kością ataku, aby go usunąć. Jeżeli wypadnie <hit>, przyjmujesz 1 uszkodzenie <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5851,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5852,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5853,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_5",
+            "force_side": null,
+            "id": 5,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Jek Porkins",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6688,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6689,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6690,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6691,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Czerwony Sześć",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz akcję <barrelroll> albo <boost>, możesz odwrócić kartę rozwinięcia <config>, w którą jesteś wyposażony. ",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5854,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5855,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5856,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_6",
+            "force_side": null,
+            "id": 6,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kullbee Sperado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6692,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6693,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6694,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6695,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Tajemniczy strzelec",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy inny przyjazny statek w zasięgu 0–1 się broni i ty również znajdujesz się w strefie ataku atakującego, możesz, przed etapem neutralizacji wyników, przyjąć 1 uszkodzenie <hit> albo <crit>, aby anulować analogiczny wynik na kości.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5857,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5858,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5859,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_7",
+            "force_side": null,
+            "id": 7,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Biggs Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6696,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6697,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6698,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6699,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Czerwony Trzy",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz akcję <barrelroll> albo <boost>, możesz wykonać czerwoną akcję <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5860,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5861,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5862,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_8",
+            "force_side": null,
+            "id": 8,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Leevan Tenza",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6700,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6701,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6702,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6703,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Dezerter z Rebelii",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim się aktywujesz, jeżeli posiadasz żeton skupienia, możesz wykonać akcję.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5863,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5864,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5865,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_9",
+            "force_side": null,
+            "id": 9,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Edrio „Dwururowiec”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6704,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6705,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6706,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6707,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Weteran Jaskiniowych Aniołów",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Eskadra Czerwonych to elitarna jednostka, w której służą najlepsi piloci Sojuszu Rebeliantów.</flavor>",
             "available_actions": [
                 {
@@ -84,164 +823,164 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonujesz atak, obrońca rzuca 1 kością obrony mniej.",
+            "ability_text": "<flavor>Zaprojektowany przez Incom Corporation X-Wing T-65 szybko stał się jednym z najbardziej wszechstronnych i najskuteczniejszych myśliwców w Galaktyce. Dla Rebeliantów jest wprost nieoceniony.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 5869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 5870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 5871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
             "card_set_ids": [
+                1,
                 4,
                 7
             ],
             "card_type_id": 1,
-            "cost": "52",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_1",
+            "ffg_id": "XW_P_11",
             "force_side": null,
-            "id": 1,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Wedge Antilles",
+            "id": 11,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Weteran Eskadry Niebieskich",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 6712,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 6713,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 6714,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 6715,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Czerwony Dwa",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonujesz atak, możesz wydać 1 wynik <focus>, <hit> albo <crit>, aby podejrzeć zakryte karty uszkodzeń obrońcy, wybrać 1 i ją odkryć.",
+            "ability_text": "<flavor>W przeciwieństwie do większości komórek Rebeliantów, partyzanci Sawa Gerrery uciekają się do ekstremalnych metod, aby osłabić Galaktyczne Imperium w brutalnych starciach, które rozgrywają się od Geonosis aż po Jedhę.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 5872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 5873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 5874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
+                13,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
             "card_set_ids": [
-                7
+                2
             ],
             "card_type_id": 1,
-            "cost": "48",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_3",
+            "ffg_id": "XW_P_12",
             "force_side": null,
-            "id": 3,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Thane Kyrell",
+            "id": 12,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Fanatyk Jaskiniowych Aniołów",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 6716,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 6717,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 6718,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 6719,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Korona Cztery",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -332,343 +1071,6 @@
                 }
             ],
             "subtitle": "Złoty Dziewięć",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wydasz żeton skupienia, możesz wskazać 1 przyjazny statek w zasięgu 1–3. Wskazany statek otrzymuje 1 żeton skupienia.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5848,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5849,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5850,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_4",
-            "force_side": null,
-            "id": 4,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6684,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6685,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6686,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6687,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Dowódca Czerwonych",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Zaprojektowany przez Incom Corporation X-Wing T-65 szybko stał się jednym z najbardziej wszechstronnych i najskuteczniejszych myśliwców w Galaktyce. Dla Rebeliantów jest wprost nieoceniony.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5869,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5870,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5871,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_11",
-            "force_side": null,
-            "id": 11,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Weteran Eskadry Niebieskich",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6712,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6713,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6714,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6715,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonuujesz atak, możesz przerzucić 1 kość ataku za każdy przyjazny statek w zasięgu 0–1 od obrońcy.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5883,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5884,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5885,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5886,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
-            "card_set_ids": [
-                4,
-                8
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_15",
-            "force_side": null,
-            "id": 15,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Horton Salm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 6728,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6729,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6730,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6731,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Dowódca Szarych",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz akcję <barrelroll> albo <boost>, możesz odwrócić kartę rozwinięcia <config>, w którą jesteś wyposażony. ",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5854,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5855,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5856,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_6",
-            "force_side": null,
-            "id": 6,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kullbee Sperado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6692,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6693,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6694,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6695,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Tajemniczy strzelec",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -765,42 +1167,183 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Na początku fazy końcowej możesz wydać 1 żeton skupienia, aby naprawić 1 z twoich odkrytych kart uszkodzeń.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+            "ability_text": "Gdy wykonuujesz atak, możesz przerzucić 1 kość ataku za każdy przyjazny statek w zasięgu 0–1 od obrońcy.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5883,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5884,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5885,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5886,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
             "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_157",
-            "force_side": null,
-            "id": 382,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
+                4,
                 8
             ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_15",
+            "force_side": null,
+            "id": 15,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Horton Salm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6728,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6729,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6730,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6731,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Dowódca Szarych",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki możesz wydać 1 żeton skupienia, aby wskazać przyjazny statek w zasięgu 0-1.Jeżeli tak zrobisz, do końca tej rundy wskazany statek rzuca 1 dodatkową kością, gdy się broni.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5887,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5888,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5889,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5890,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_set_ids": [
+                8
+            ],
+            "card_type_id": 1,
+            "cost": "36",
+            "faction_id": 1,
+            "ffg_id": "XW_P_16",
+            "force_side": null,
+            "id": 16,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Evaan Verlaine",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6732,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6733,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6734,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6735,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Złoty Trzy",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -896,39 +1439,38 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Na początku fazy walki możesz wydać 1 żeton skupienia, aby wskazać przyjazny statek w zasięgu 0-1.Jeżeli tak zrobisz, do końca tej rundy wskazany statek rzuca 1 dodatkową kością, gdy się broni.",
+            "ability_text": "<flavor>Jeszcze długo po wycofaniu Y-wingów przez Imperium Galaktyczne, siły Rebeliantów wciąż polegały na ich wytrzymałości, niezawodności i potężnym uzbrojeniu.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 5895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 5896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 5897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 5898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 4,
                 5,
                 10,
@@ -936,51 +1478,52 @@
                 14,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
             "card_set_ids": [
+                4,
                 8
             ],
             "card_type_id": 1,
-            "cost": "36",
+            "cost": "32",
             "faction_id": 1,
-            "ffg_id": "XW_P_16",
+            "ffg_id": "XW_P_18",
             "force_side": null,
-            "id": 16,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Evaan Verlaine",
+            "id": 18,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Bombowiec Eskadry Szarych",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 6740,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 6741,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 6742,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 6743,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Złoty Trzy",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1078,167 +1621,179 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonasz akcję <barrelroll> albo <boost>, możesz wykonać czerwoną akcję <evade>.",
+            "ability_text": "Możesz wykonywać ataki podstawowe w zasięgu 0.<return>Gdy akcja <boost> miałaby ci się nie udać z powodu nachodzenia na inny statek, rozpatrz ją tak, jakbyś zamiast tego wykonywał manewr częściowy.<return><sabold>Sterowanie wektorem ciągu:</sabold> Gdy wykonasz akcję, możesz wykonać czerwoną akcję <boost>.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 5904,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 5906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 5907,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                5,
-                10,
-                13,
-                14,
-                18
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
             "card_set_ids": [
-                2
+                4
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_8",
+            "ffg_id": "XW_P_20",
             "force_side": null,
-            "id": 8,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "id": 20,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "•Leevan Tenza",
+            "name": "•Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 33,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 6748,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6701,
-                    "recurring": false,
-                    "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 6749,
                     "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
+                    "statistic_id": 1,
+                    "value": "3"
                 },
                 {
-                    "id": 6703,
+                    "id": 6750,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6751,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Dezerter z Rebelii",
+            "subtitle": "Dowódca Zielonych",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Jeszcze długo po wycofaniu Y-wingów przez Imperium Galaktyczne, siły Rebeliantów wciąż polegały na ich wytrzymałości, niezawodności i potężnym uzbrojeniu.</flavor>",
+            "ability_text": "<flavor>Niezwykle czułe stery i wysoka zwrotność sprawiają, że z pilotowaniem A-wingów radzą sobie tylko najbardziej utalentowani piloci.</flavor><return><sabold>Sterowanie wektorem ciągu:</sabold> Gdy wykonasz akcję, możesz wykonać czerwoną akcję <boost>.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 5909,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 5911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "base_action_side_effect": null,
+                    "id": 5912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
+                1,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
             "card_set_ids": [
-                4,
-                8
+                4
             ],
             "card_type_id": 1,
-            "cost": "32",
+            "cost": "34",
             "faction_id": 1,
-            "ffg_id": "XW_P_18",
+            "ffg_id": "XW_P_21",
             "force_side": null,
-            "id": 18,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-            "initiative": 2,
+            "id": 21,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
+            "initiative": 3,
             "is_unique": false,
-            "name": "Bombowiec Eskadry Szarych",
+            "name": "Pilot Eskadry Zielonych",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 12,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 6752,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 6753,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "1"
+                    "value": "3"
                 },
                 {
-                    "id": 6742,
+                    "id": 6754,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "6"
+                    "value": "2"
                 },
                 {
-                    "id": 6743,
+                    "id": 6755,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1246,46 +1801,6 @@
             ],
             "subtitle": "",
             "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy masz dokładnie 1 żeton rozbrojenia, wciąż możesz wykonywać ataki <torpedo> oraz <missile> przeciwko celom, które masz namierzone. Jeżeli tak zrobisz, podczas tego ataku nie możesz wydać swojego namierzenia.<return>Dodaj gniazda <torpedo> oraz <missile>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_125",
-            "force_side": null,
-            "id": 350,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Wyposażenie z arsenału Os-1",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 14,
-                            "raw_name": "Alpha-class Star Wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -1381,93 +1896,3985 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Możesz wykonywać ataki podstawowe w zasięgu 0.<return>Gdy akcja <boost> miałaby ci się nie udać z powodu nachodzenia na inny statek, rozpatrz ją tak, jakbyś zamiast tego wykonywał manewr częściowy.<return><sabold>Sterowanie wektorem ciągu:</sabold> Gdy wykonasz akcję, możesz wykonać czerwoną akcję <boost>.",
+            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli posiadasz żeton stresu, możesz przerzucić maksymalnie 2 ze swoich kości.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5905,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
+                    "id": 5919,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 5920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 5921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                6
+                2,
+                3,
+                3,
+                5,
+                14
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_23",
+            "force_side": null,
+            "id": 23,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Braylen Stramm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6760,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6761,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6762,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6763,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Dowódca Ostrzy",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz albo wykonujesz atak, możesz wydać 1 żeton stresu, aby zmienić wszystkie swoje wyniki <focus> na <evade> albo <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5922,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5923,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5924,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_24",
+            "force_side": null,
+            "id": 24,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Ten Numb",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6764,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6765,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6766,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6767,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Niebieski Pięć",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Kokpit B-winga umieszczony jest w unikalnym systemie żyrostabilizatorów, dzięki czemu pilot zawsze jest nieruchomy podczas walki.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5925,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5926,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5927,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 1,
+            "ffg_id": "XW_P_25",
+            "force_side": null,
+            "id": 25,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Weteran Eskadry Ostrzy",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6768,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6769,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6770,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6771,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Bogaty arsenał uzbrojenia i silne osłony sprawiają, że B-wing jest najnowocześniejszym myśliwcem szturmowym Sojuszu Rebeliantów.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5928,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5929,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5930,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_26",
+            "force_side": null,
+            "id": 26,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot Eskadry Niebieskich",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6772,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6773,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6774,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6775,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz atak, możesz wskazać 1 przyjazny statek w zasięgu 1. Wskazany statek może wykonać dodatkową akcję, traktując ją, jak gdyby była czerwona.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5931,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5932,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5933,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 1,
             "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_20",
+            "ffg_id": "XW_P_27",
             "force_side": null,
-            "id": 20,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-            "initiative": 3,
+            "id": 27,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
+            "initiative": 5,
             "is_unique": true,
-            "name": "•Arvel Crynyd",
+            "name": "•Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 35,
+            "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 6776,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 6777,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "3"
+                    "value": "2"
                 },
                 {
-                    "id": 6750,
+                    "id": 6778,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 6779,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Dowódca Zielonych",
+            "subtitle": "Szef wywiadu",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak podstawowy i w zasięgu 0–1 od obrońcy znajduje się przynajmniej 1 inny przyjazny statek, możesz rzucić 1 dodatkową kością ataku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5934,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5935,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5936,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_28",
+            "force_side": null,
+            "id": 28,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Porucznik Blount",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6780,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6781,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6782,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6783,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gracz zespołowy",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>AF4 to najnowszy model w długiej serii typu Łowca Głów. Jest tani i stosunkowo wytrzymały, co sprawia, że cieszy się sporą popularnością w niezależnych formacjach, a także w Rebelii.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5937,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5938,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5939,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "25",
+            "faction_id": 1,
+            "ffg_id": "XW_P_29",
+            "force_side": null,
+            "id": 29,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot Eskadry Tala",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6784,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6785,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6786,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6787,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Z-95 Łowca Głów stanowił główną inspirację dla projektu myśliwca gwiezdnego Incom Corporation X-wing T-65. Choć jest już nieco przestarzały, to jednak wciąż bardzo wszechstronny i skuteczny myśliwiec.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5940,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5941,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5942,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "23",
+            "faction_id": 1,
+            "ffg_id": "XW_P_30",
+            "force_side": null,
+            "id": 30,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Pilot Eskadry Bandytów",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6788,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6789,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6790,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6791,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak podstawowy i jesteś uszkodzony, możesz rzucić 1 dodatkową kością ataku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5943,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5944,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5945,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "56",
+            "faction_id": 1,
+            "ffg_id": "XW_P_31",
+            "force_side": null,
+            "id": 31,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Wullffwarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6792,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6793,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6794,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6795,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Wódz Wookiech",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy przyjazny statek w zasięgu 0–1 zostanie wskazany jako obrońca, możesz wydać 1 żeton wzmocnienia. Jeżeli tak zrobisz, wskazany statek otrzymuje 1 żeton uników.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5946,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5947,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5948,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_32",
+            "force_side": null,
+            "id": 32,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Lowhhrick",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6796,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6797,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6798,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6799,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Zbiegły gladiator",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Atutem kanonierek Auzituck jest szerokie pole rażenia zapewniane przez trzy podwójnie sprzężone działa laserowe typu Sureggi. Statki te skutecznie odstraszają z systemu Kashyyyk łowców niewolników.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5949,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5950,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5951,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_33",
+            "force_side": null,
+            "id": 33,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Obrońca Kashyyyk",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6800,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6801,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6802,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6803,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Po odsłonięciu czerwonego albo niebieskiego manewru, możesz ustawić na tarczy inny manewr o tej samej trudności.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5952,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5953,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5954,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "39",
+            "faction_id": 1,
+            "ffg_id": "XW_P_34",
+            "force_side": null,
+            "id": 34,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6804,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6805,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6806,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6807,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Upiór-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim się aktywujesz, możesz wykonać akcję <barrelroll> albo <boost>.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5955,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5956,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5957,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_35",
+            "force_side": null,
+            "id": 35,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6808,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6809,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6810,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6811,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Upiór-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli posiadasz żeton stresu, możesz wydać 1 <forcecharge>, aby zmienić maksymalnie 2 ze swoich wyników <focus> na wynik <evade> albo <hit>.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5958,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5959,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5960,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "41",
+            "faction_id": 1,
+            "ffg_id": "XW_P_36",
+            "force_side": 2,
+            "id": 36,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6812,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6813,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6814,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6815,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6816,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Upiór-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz, wyniki <crit> są neutralizowane przed wynikami <hit>.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5961,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5962,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5963,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 1,
+            "ffg_id": "XW_P_37",
+            "force_side": null,
+            "id": 37,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6817,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6818,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6819,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6820,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Upiór-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wrogi statek w twojej strefie rażenia rozpocznie walkę, jeżeli nie posiadasz żetonu stresu, możesz otrzymać 1 żeton stresu. Jeżeli tak zrobisz, walczący statek nie może w tej fazie wydawać żetonów, aby modyfikować kości, gdy wykonuje atak.<return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5964,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5965,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_38",
+            "force_side": null,
+            "id": 38,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6821,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6822,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6823,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6824,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6825,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Niechętny rebeliant",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz albo atakujesz, jeżeli posiadasz żeton stresu, możesz wydać 1 <forcecharge>, aby zmienić maksymalnie 2 ze swoich wyników <focus> na wyniki <evade>/<hit>. <return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5966,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5967,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                10,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_39",
+            "force_side": 2,
+            "id": 39,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6826,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6827,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6828,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6829,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6830,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6831,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Upiór-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz, wyniki <crit> są neutralizowane przed wynikami <hit>.<return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5968,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5969,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_40",
+            "force_side": null,
+            "id": 40,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Zeb” Orrelios ",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6832,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6833,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6834,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6835,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6836,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Upiór-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "W trakcie koordynacji, jeżeli wskażesz statek, który ma dokładnie 1 żeton stresu, może on wykonywać akcje.<return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5970,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5971,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_41",
+            "force_side": null,
+            "id": 41,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
+            "initiative": 1,
+            "is_unique": true,
+            "name": "•AP-5",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6837,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6838,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6839,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6840,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6841,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Zbiegły droid analityczny",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy przyjazny statek w twojej strefie rażenia wykonuje atak podstawowy i nie posiadasz żetonu stresu, możesz otrzymać 1 żeton stresu. Jeżeli tak zrobisz, atakujący statek rzuca 1 kością ataku więcej.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5972,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5973,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5974,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5975,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5976,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_42",
+            "force_side": null,
+            "id": 42,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Jan Ors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6842,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6843,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6844,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6845,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Ekspert wywiadu",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki możesz przenieść 1 ze swoich żetonów skupienia na inny przyjazny statek w twojej strefie rażenia.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5977,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5978,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5979,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5980,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5981,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_43",
+            "force_side": null,
+            "id": 43,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kyle Katarn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6846,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6847,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6848,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6849,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Niestrudzony agent",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki możesz wskazać 1 statek w swojej strefie rażenia. Jeżeli tak zrobisz, wskazany statek walczy w tej fazie z inicjatywą 7 zamiast swojej normalnej inicjatywy.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5982,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5983,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5984,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5985,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5986,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_44",
+            "force_side": null,
+            "id": 44,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Roark Garnet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6850,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6851,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6852,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6853,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Dobroduszny przemytnik",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Zaprojektowany na podobieństwo drapieżnego ptaka w locie statek Corellian Engineering Corporation „Jastrząb” to wyjątkowy transportowiec. Szybkie i wytrzymałe HWK-290 często służą rebelianckim agentom jako mobilne bazy.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5987,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5988,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5989,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5990,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5991,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_45",
+            "force_side": null,
+            "id": 45,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebeliancki zwiadowca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6854,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6855,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6856,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6857,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli posiadasz żeton stresu, możesz wydać 1 <forcecharge>, aby zmienić maksymalnie 2 ze swoich wyników <focus> na wynik <evade> albo <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5992,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5993,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5994,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_46",
+            "force_side": 2,
+            "id": 46,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6858,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6859,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6860,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6861,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Upiór-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim się aktywujesz, możesz wykonać akcję <barrelroll> albo <boost>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5995,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5996,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5997,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 1,
+            "ffg_id": "XW_P_47",
+            "force_side": null,
+            "id": 47,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6862,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6863,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6864,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Upiór-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz atak, przypisz obrońcy stan: <sabold>Ogień zaporowy</sabold>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5998,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5999,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6000,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_48",
+            "force_side": null,
+            "id": 48,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Kapitan Rex",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6865,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6866,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6867,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Weteran Wojen Klonów",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz, wyniki <crit> są neutralizowane przed wynikami <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6001,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6002,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6003,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "26",
+            "faction_id": 1,
+            "ffg_id": "XW_P_49",
+            "force_side": null,
+            "id": 49,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6868,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6869,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6870,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Upiór-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "W inicjatywie 0 możesz wykonać dodatkowy atak podstawowy przeciwko statkowi wroga w twojej <bullseye>. Jeżeli tak zrobisz, na początku następnej fazy planowania otrzymujesz 1 żeton rozbrojenia.<return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6004,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6005,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6006,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6007,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6008,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 1,
+            "ffg_id": "XW_P_50",
+            "force_side": null,
+            "id": 50,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Corran Horn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6871,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6872,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6873,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6874,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Niestrudzony śledczy",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy przyjazny statek wykonuje atak i obrońca znajduje się w twojej <frontarc>, atakujący może zmienić 1 wynik <hit> na <crit>.<return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6009,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6010,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6011,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6012,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6013,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 1,
+            "ffg_id": "XW_P_51",
+            "force_side": null,
+            "id": 51,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Gavin Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6875,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6876,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6877,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6878,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Dzielny skrzydłowy",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>W Eskadrze Łotrów służą jedni z najlepszych pilotów Rebelii. </flavor><return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6014,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6015,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6016,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6017,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6018,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "63",
+            "faction_id": 1,
+            "ffg_id": "XW_P_52",
+            "force_side": null,
+            "id": 52,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Eskortowiec Eskadry Łotrów",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6879,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6880,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6881,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6882,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>E-wing został zaprojektowany, aby połączyć najlepsze cechy serii X-wing i A-wing; ma zwiększoną siłę ognia, prędkość i zwrotność.</flavor><return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6019,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6020,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6021,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6022,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6023,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "61",
+            "faction_id": 1,
+            "ffg_id": "XW_P_53",
+            "force_side": null,
+            "id": 53,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Eskortowiec Eskadry Szelm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6883,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6884,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6885,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6886,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Przyjazne statki mogą wykonywać namierzenie w zasięgu 0–3 od dowolnego przyjaznego statku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6024,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6025,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6026,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 1,
+            "ffg_id": "XW_P_54",
+            "force_side": null,
+            "id": 54,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Bodhi Rook",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6887,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6888,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6889,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6890,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Imperialny zbieg",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy uszkodzony przyjazny statek w zasięgu 0–3 wykonuje atak, może przerzucić 1 kość ataku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6027,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6028,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6029,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_55",
+            "force_side": null,
+            "id": 55,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Saw Gerrera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6891,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6892,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6893,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6894,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Zagorzały radykał",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy aktywacji możesz wskazać 1 przyjazny statek w zasięgu 1–3. Jeżeli tak zrobisz, wskazany statek usuwa 1 żeton stresu.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6030,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6031,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6032,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_56",
+            "force_side": null,
+            "id": 56,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Cassian Andor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6895,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6896,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6897,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6898,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Wychowany przez Rebelię",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy przyjazny statek w zasięgu 0–2 się broni, atakujący nie może przerzucić więcej niż 1 kość ataku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6033,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6034,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6035,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_57",
+            "force_side": null,
+            "id": 57,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6899,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6900,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6901,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6902,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Wypatrywacz Jaskiniowych Aniołów",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz akcję <focus>,możesz przenieść 1 z twoich żetonów skupienia na przyjazny statekw zasięgu 1–2.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6036,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6037,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6038,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_58",
+            "force_side": null,
+            "id": 58,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Benthic „Dwururowiec”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6903,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6904,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6905,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6906,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Strzelec wyborowy Jaskiniowych Aniołów",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wrogi statek wykona manewr i będzie w zasięgu 0, możesz wykonać akcję.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6039,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6040,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6041,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_59",
+            "force_side": null,
+            "id": 59,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Heff Tobber",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6907,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6908,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6909,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6910,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Niebieski Osiem",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>U-wing UT-60D służy do desantowania żołnierzy pod osłoną ciemności lub w warunkach bojowych. Idealnie nadaje się jako szybki i odporny transportowiec dla Rebelii.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6042,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6043,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6044,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_60",
+            "force_side": null,
+            "id": 60,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Zwiadowca Eskadry Niebieskich",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6911,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6912,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6913,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6914,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>W przeciwieństwie do większości komórek Rebeliantów, partyzanci Sawa Gerrery uciekają się do ekstremalnych metod, aby osłabić Galaktyczne Imperium w brutalnych starciach, które rozgrywają się od Geonosis aż po Jedhę.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6045,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6046,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6047,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_61",
+            "force_side": null,
+            "id": 61,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Buntowniczy partyzant",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6915,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6916,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6917,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6918,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak podstawowy, możesz wydać 1 osłonę, aby rzucić 1 dodatkową kością ataku albo, jeżeli nie masz aktywnych osłon, rzucić 1 kością ataku mniej, aby odzyskać 1 osłonę.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6048,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6049,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6050,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6051,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6052,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_62",
+            "force_side": null,
+            "id": 62,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Miranda Doni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6919,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6920,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6921,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6922,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Ciężkie wsparcie",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy przyjazny statek w zasięgu 0–2 broni się albo wykonuje atak, może wydawać twoje żetony skupienia, jak gdyby były jego.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6053,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6054,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6055,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6056,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6057,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_63",
+            "force_side": null,
+            "id": 63,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Esege Tuketu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6923,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6924,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6925,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6926,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Bezinteresowny bohater",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Produkowany przez Koensayr Manufacturing K-Wing ma zaawansowany napęd podświetlny (SubLight Acceleration Motor) i 18 punktów podczepienia, dzięki czemu dysponuje niezrównaną prędkością i siłą ognia.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6058,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6059,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6060,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6061,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6062,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 1,
+            "ffg_id": "XW_P_64",
+            "force_side": null,
+            "id": 64,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot Eskadry Strażników",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6927,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6928,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6929,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6930,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz i w zasięgu 0–1 znajduje się wrogi statek, możesz do swoich wyników rzutu dodać 1 wynik <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6063,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6064,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6065,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "55",
+            "faction_id": 1,
+            "ffg_id": "XW_P_65",
+            "force_side": null,
+            "id": 65,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Norra Wexley",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6931,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6932,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6933,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6934,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6935,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Złoty Dziewięć",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wydasz żeton skupienia, możesz wskazać 1 przyjazny statek w zasięgu 1–3. Wskazany statek otrzymuje 1 żeton skupienia.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6066,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6067,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6068,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "51",
+            "faction_id": 1,
+            "ffg_id": "XW_P_66",
+            "force_side": null,
+            "id": 66,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6936,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6937,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6938,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6939,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6940,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Dowódca Czerwonych",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz albo wykonujesz atak podstawowy, możesz wydać twoje namierzenie z wrogiego statku, z którym walczysz, aby dodać do twoich wyników rzutu 1 wynik <focus>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6069,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6070,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6071,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "53",
+            "faction_id": 1,
+            "ffg_id": "XW_P_67",
+            "force_side": null,
+            "id": 67,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Shara Bey",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6941,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6942,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6943,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6944,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6945,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Zielony Cztery",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Po wykonaniu pełnego manewru, jeżeli posiadasz żeton stresu, możesz rzucić 1 kością ataku. Jeżeli wypadnie <hit> albo <crit>, usuwasz 1 żeton stresu.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6072,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6073,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6074,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_68",
+            "force_side": null,
+            "id": 68,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ibtisam",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6946,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6947,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6948,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6949,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6950,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Ocalała z Endoru",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy rzucisz koścmi i znajdujesz się w zasięgu 0–1 od przeszkody, możesz przerzucić wszystkie swoje kości. Na potrzeby innych efektów nie jest to traktowane jako przerzut.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6075,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6076,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6077,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6078,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "92",
+            "faction_id": 1,
+            "ffg_id": "XW_P_69",
+            "force_side": null,
+            "id": 69,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6951,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6952,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6953,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6954,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Łajdak do wynajęcia",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1559,6 +5966,533 @@
                 }
             ],
             "subtitle": "Generał Sojuszu",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim otrzymasz odkrytą kartę uszkodzenia, możesz wydać 1 <standardcharge>, aby zamiast tego otrzymać zakrytą kartę uszkodzenia.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6083,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6084,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6085,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6086,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 1,
+            "ffg_id": "XW_P_71",
+            "force_side": null,
+            "id": 71,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Chewbacca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6959,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6960,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6961,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6962,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                },
+                {
+                    "id": 6963,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Potężny",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Znany z niezwykłej wytrzymałości i modularnej konstrukcji YT-1300 jest jednym z najpopularniejszych, najczęściej stosowanych i najbardziej modyfikowanych frachtowców w galaktyce.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6087,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6088,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6089,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6090,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "78",
+            "faction_id": 1,
+            "ffg_id": "XW_P_72",
+            "force_side": null,
+            "id": 72,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Przemytnik z Zewnętrznych Rubieży",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6964,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6965,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6966,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6967,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Po odsłonięciu czerwonego albo niebieskiego manewru, możesz ustawić na tarczy inny manewr o tej samej trudności.<return><shipability><sabold>Działko ogonowe: </sabold>Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6091,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6092,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6093,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "76",
+            "faction_id": 1,
+            "ffg_id": "XW_P_73",
+            "force_side": null,
+            "id": 73,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6968,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6969,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6970,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6971,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Upiór-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy przyjazny statek w twojej strefie rażenia się broni, możesz wydać 1 <forcecharge>. Jeżeli tak zrobisz, atakujący rzuca 1 kością ataku mniej.<return><shipability><sabold>Działko ogonowe:</sabold> Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6094,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6095,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6096,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "90",
+            "faction_id": 1,
+            "ffg_id": "XW_P_74",
+            "force_side": 2,
+            "id": 74,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kanan Jarrus",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6972,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6973,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6974,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6975,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                },
+                {
+                    "id": 6976,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Upiór-1",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki każdy wrogi statek w zasięgu 0 otrzymuje 2 żetony zakłócania. <return><shipability><sabold>Działko ogonowe:</sabold> Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6097,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6098,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6099,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 1,
+            "ffg_id": "XW_P_75",
+            "force_side": null,
+            "id": 75,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Chopper”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6977,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6978,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6979,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6980,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Upiór-3",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Kolejny udany frachtowiec Corellian Engineering Corporation. VCX-100, jest większy niż wszechobecne modele serii YT, ma większy przedział dla załogi i daje większe pole do modyfikacji.</flavor><return><shipability><sabold>Działko ogonowe:</sabold> Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6100,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6101,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6102,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 1,
+            "ffg_id": "XW_P_76",
+            "force_side": null,
+            "id": 76,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebeliant z Lothal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6981,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6982,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6983,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6984,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1973,87 +6907,6 @@
                 }
             ],
             "subtitle": "Dowódca Obsydianowych",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>W przeciwieństwie do większości komórek Rebeliantów, partyzanci Sawa Gerrery uciekają się do ekstremalnych metod, aby osłabić Galaktyczne Imperium w brutalnych starciach, które rozgrywają się od Geonosis aż po Jedhę.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5872,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5873,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5874,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_12",
-            "force_side": null,
-            "id": 12,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Fanatyk Jaskiniowych Aniołów",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6716,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6717,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6718,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6719,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -2647,9455 +7500,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonasz akcję, możesz wydać 1 <forcecharge>, aby wykonać kolejną akcję.<return><sabold>Zaawansowany komputer namierzania:</sabold> Gdy wykonujesz atak podstawowy przeciwko obrońcy, którego namierzyłeś, rzucasz 1 dodatkową kością ataku i zmieniasz 1 wynik <hit> na <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6154,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6155,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6156,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 2,
-            "ffg_id": "XW_P_93",
-            "force_side": 1,
-            "id": 93,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Darth Vader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7038,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7039,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7040,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7041,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7042,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Dowódca Czarnych",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Myśliwce TIE Advanced x1 były produkowane w bardzo ograniczonej liczbie egzemplarzy, ale inżynierowie Sienar wykorzystali wiele najlepszych cech tego myśliwca, projektując kolejny model: TIE Interceptor.</flavor><return><sabold>Zaawansowany komputer namierzania:</sabold> Gdy wykonujesz atak podstawowy przeciwko obrońcy, którego namierzyłeś, rzucasz 1 dodatkową kością ataku i zmieniasz 1 wynik <hit> na <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6166,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6167,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6168,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 2,
-            "ffg_id": "XW_P_97",
-            "force_side": null,
-            "id": 97,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "As Eskadry Sztormu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7055,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7056,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7057,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7058,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>TIE Advanced v1 korporacji Sienar Fleet System to rewolucyjny projekt myśliwca z ulepszonymi silnikami, wyrzutnią rakiet i składanymi stabilizatorami.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6182,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6183,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6184,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6185,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6186,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_101",
-            "force_side": null,
-            "id": 101,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Baron Imperium",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 25,
-            "statistics": [
-                {
-                    "id": 7073,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7074,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7075,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7076,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz akcję <reload>, możesz odzyskać 1 <standardcharge> z 1 z kart rozwinięć <talent>, w które jesteś wyposażony. <return><shipability><sabold>Zwrotny bombowiec:</sabold> Jeżeli masz zrzucić urządzenie przy pomocy wzornika <straight>, możesz zamiast tego skorzystać z wzornika <leftbank> albo <rightbank> o tej samej prędkości.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6208,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6209,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6210,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6211,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_107",
-            "force_side": null,
-            "id": 107,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Tomax Bren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7094,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7095,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7096,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Lekkomyślny indywidualista",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy zostaniesz zniszczony, zanim zostaniesz usunięty, możesz wykonać atak i zrzucić albo wystrzelić 1 urządzenie.<return><shipability><sabold>Zwrotny bombowiec:</sabold> Jeżeli masz zrzucić urządzenie przy pomocy wzornika <straight>, możesz zamiast tego skorzystać z wzornika <leftbank> albo <rightbank> o tej samej prędkości.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6220,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6221,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6222,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6223,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_110",
-            "force_side": null,
-            "id": 110,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Deathfire”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7103,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7104,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7105,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Niezłomny twardziel",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz, a atakujący nie ma zielonych żetonów, możesz zmienić 1 z twoich pustych albo <focus> wyników na wynik <evade>.<return><sabold>Lotki adaptacyjne:</sabold> Zanim odsłonisz swojątarczę manewrów, jeśli nie posiadasz żetonu stresu, <bold>musisz</bold> wykonać biały manewr [1 <leftbank>],[1 <straight>] albo [1 <rightbank>].",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6236,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6237,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6238,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6239,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 2,
-            "ffg_id": "XW_P_114",
-            "force_side": null,
-            "id": 114,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kapitan Feroph",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 43,
-            "statistics": [
-                {
-                    "id": 7116,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7117,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7118,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7119,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Imperialny kurier",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz, po etapie neutralizacji wyników, jeżeli nie posiadasz żetonu stresu, możesz przyjąć 1 uszkodzenie <hit> i otrzymać 1 żeton stresu. Jeżeli tak zrobisz, anulujesz wyniki wszystkich rzutów kości.<return><sabold>Lotki adaptacyjne: </sabold>Zanim odsłonisz swoją tarczę manewrów, jeśli nie posiadasz żetonu stresu, musisz wykonać biały manewr [1 <leftbank>], [1 <straight>] albo [1<nonbreak><rightbank>].",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6251,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6252,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6253,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_118",
-            "force_side": null,
-            "id": 118,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•„Countdown”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 16,
-            "statistics": [
-                {
-                    "id": 7131,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7132,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7133,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Niezniszczalny",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz atak, który trafił, i posiadasz żeton uniku, odkryj 1 z kart uszkodzeń obrońcy.<return><shipability><sabold>Pełny ciąg:</sabold> Gdy wykonasz pełny manewr o prędkości 3–5, możesz wykonać akcję <evade>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6263,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6264,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6265,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6266,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6267,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_122",
-            "force_side": null,
-            "id": 122,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Rexler Brath",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 18,
-            "statistics": [
-                {
-                    "id": 7143,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7144,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7145,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7146,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Dowódca Onyksowych",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Podczas projektowania myśliwca TIE Aggressor inżynierowie Sienar Fleet Systems skupili się na osiągach i wszechstronności, nie licząc się z kosztami.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6297,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6298,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6299,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 2,
-            "ffg_id": "XW_P_130",
-            "force_side": null,
-            "id": 130,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Specjalista Sienar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7175,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7176,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7177,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7178,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>TIE Phantom jest efektem prac w ukrytej bazie na Imdaar Alpha. Inżynierom udało się dokonać czegoś, co wydawało się niemożliwe - stworzyć myśliwiec z zaawansowanym urządzeniem maskującym.</flavor><return><shipability><sabold>Matryca ze stygium:</sabold> Gdy wyłączysz maskowanie, możesz wykonać akcję <evade>. Na początku fazy końcowej możesz wydać 1 żeton uniku, aby otrzymać 1 żeton maskowania.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6312,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6313,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6314,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 7,
-                    "base_action_side_effect": null,
-                    "id": 6315,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_134",
-            "force_side": null,
-            "id": 134,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Oblatywacz z Imdaar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 27,
-            "statistics": [
-                {
-                    "id": 7191,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7192,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7193,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7194,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Projekt Star Winga klasy <untalic>Alfa</untalic> był inspirowany innymi statkami Cygnus Spaceworks. To wszechstronny statek wykorzystywany przez specjalistyczne jednostki floty, które wykonują różnorodne zadania.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6328,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6329,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6330,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6331,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                6,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "35",
-            "faction_id": 2,
-            "ffg_id": "XW_P_138",
-            "force_side": null,
-            "id": 138,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot Eskadry Nu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 14,
-            "statistics": [
-                {
-                    "id": 7207,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7208,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7209,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7210,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki możesz wskazać 1 albo więcej przyjaznych statków w zasięgu 0–3. Jeżeli tak zrobisz, przenieś na twój statek wszystkie wrogie żetony namierzenia ze wskazanych statków.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6347,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6348,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 6349,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6350,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                8,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 2,
-            "ffg_id": "XW_P_142",
-            "force_side": null,
-            "id": 142,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kapitan Kagi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 26,
-            "statistics": [
-                {
-                    "id": 7223,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7224,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 7225,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7226,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7227,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Pilot promu Imperatora",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak i jesteś wzmocniony, a obrońca jest w twojej <fullfront> albo <fullrear> pasującej do twojego żetonu wzmocnienia, możesz zmienić 1 ze swoich wyników <focus> na wynik <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6368,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6369,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6370,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6371,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6372,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "88",
-            "faction_id": 2,
-            "ffg_id": "XW_P_147",
-            "force_side": null,
-            "id": 147,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Kontradmirał Chiraneau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7248,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7249,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7250,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7251,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Doradca admirała Pietta",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak podstawowy i w zasięgu 0 od obrońcy znajduje się przynajmniej 1 przyjazny nie limitowany statek, rzucasz 1 dodatkową kością ataku.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6386,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6387,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": "stress",
-                    "id": 6388,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6389,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
-            "card_set_ids": [
-                6,
-                11
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 3,
-            "ffg_id": "XW_P_151",
-            "force_side": null,
-            "id": 151,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kath Scarlet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 10,
-            "statistics": [
-                {
-                    "id": 7266,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7267,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "3"
-                },
-                {
-                    "id": 7268,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7269,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7270,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Kapitan piratów z Binayre",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak i zasięg ataku wynosi 1, możesz rzucić 1 dodatkową kością.<return><sabold>Natarcie Concordyjskie:</sabold> Gdy się bronisz, a zasięg ataku wynosi 1 i znajdujesz się w <frontarc> atakującego, zmień 1 wynik na <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6402,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6403,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6404,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6405,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 3,
-            "ffg_id": "XW_P_155",
-            "force_side": null,
-            "id": 155,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7286,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7287,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7288,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Dowódca Czaszek",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Niezwykle czułe stery i wysoka zwrotność sprawiają, że z pilotowaniem A-wingów radzą sobie tylko najbardziej utalentowani piloci.</flavor><return><sabold>Sterowanie wektorem ciągu:</sabold> Gdy wykonasz akcję, możesz wykonać czerwoną akcję <boost>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5909,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5910,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5911,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5912,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5913,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_21",
-            "force_side": null,
-            "id": 21,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Pilot Eskadry Zielonych",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 35,
-            "statistics": [
-                {
-                    "id": 6752,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6753,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6754,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6755,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Asy Eskadry Czaszki stosują agresywną taktykę i wykorzystują obracane skrzydła, aby wykorzystać w walce pełnię możliwości swoich maszyn i osiągnąć przewagę nad wrogiem.</flavor><return> <sabold>Natarcie Concordyjskie:</sabold> Gdy się bronisz, a zasięg ataku wynosi 1 i znajdujesz się w <frontarc> atakującego, zmień 1 wynik na <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6418,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6419,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6420,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6421,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_159",
-            "force_side": null,
-            "id": 159,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Pilot Eskadry Czaszki",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7298,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7299,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7300,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki, jeżeli w zasięgu 0 znajduje się co najmniej jeden statek, ty i każdy statek w zasięgu 0 otrzymujecie po 1 żetonie wiązki ściągającej.<return><shipability><sabold>Wiązka ściągająca holownika: Akcja:</sabold> wskaż statek w swojej <frontarc> w zasięgu 1. Wskazany statek otrzymuje 1 żeton wiązki ściągającej albo 2 żetony wiązki ściągającej, jeżeli znajduje się w twojej <bullseye> w zasięgu 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6432,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6433,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6434,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 3,
-            "ffg_id": "XW_P_163",
-            "force_side": null,
-            "id": 163,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Unkar Plutt",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7310,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7311,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7312,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Skąpy Zarządca",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny, nie limitowany statek wykonuje atak, a obrońca znajduje się w twojej strefie rażenia, atakujący może przerzucić 1 kość ataku.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6442,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6443,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6444,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6445,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 3,
-            "ffg_id": "XW_P_166",
-            "force_side": null,
-            "id": 166,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Drea Renthal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7320,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7321,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7322,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7323,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Władczyni piratów",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Nawet drobna wzmianka o imperialnych kredytach może przeciągnąć na twoją stronę wielu osobników o wątpliwej reputacji.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6446,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6447,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6448,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6449,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 3,
-            "ffg_id": "XW_P_167",
-            "force_side": null,
-            "id": 167,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Najemnik",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7324,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7325,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7326,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7327,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Możesz startować tylko awaryjnie i przejmujesz nazwę, inicjatywę, zdolności pilota oraz <standardcharge> przyjaznego, zniszczonego Wściekłego Psa.<return><shipability><sabold>Kapsuła ratunkowa: Przygotowanie gry: </sabold>Wymaga <sabold>Wściekłego Psa.</sabold> <bold>Musisz</bold> rozpocząć grę zadokowany do <sabold>Wściekłego Psa</sabold>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6460,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6461,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6462,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "6",
-            "faction_id": 3,
-            "ffg_id": "XW_P_171",
-            "force_side": null,
-            "id": 171,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Szczeniak Nashtah</italic>",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 7340,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7341,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7342,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7343,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Plan awaryjny",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki możesz wskazać 1 wrogi statek w twojej strefie rażenia, w zasięgu 0–2. Jeżeli tak zrobisz, przenieś 1 żeton skupienia albo uników ze wskazanego statku na ciebie.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6474,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6475,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6476,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6477,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6478,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 3,
-            "ffg_id": "XW_P_175",
-            "force_side": null,
-            "id": 175,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Palob Godalhi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 7357,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7358,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7359,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7360,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Powstaniec z Tethanu",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz pełny manewr, możesz otrzymać 1 żeton stresu, aby obrócić statek o 90 stopni.<return> <sabold>Mikroregulacja ciągu:</sabold> Gdy wykonujesz beczkę, <bold>musisz</bold> użyć wzornika <leftbank> albo <rightbank> zamiast wzornika <straight>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6493,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6494,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6495,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6496,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_179",
-            "force_side": null,
-            "id": 179,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Dalan Oberos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 3,
-            "statistics": [
-                {
-                    "id": 7373,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7374,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7375,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7376,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Elitarny łowca nagród",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny statek broni się w zasięgu 0–1, może przerzucić 1 ze swoich kości.<return><shipability><sabold>Punkt podczepienia:</sabold> Możesz się wyposażyć w 1 rozwinięcie <cannon>, <torpedo> albo <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6509,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6510,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6511,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6512,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_183",
-            "force_side": null,
-            "id": 183,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Serissu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7389,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7390,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7391,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7392,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Instruktor pilotażu",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak, możesz przyjąć 1 uszkodzenie <hit>, aby przerzucić dowolną liczbę swoich kości.<return><shipability><sabold>Punkt podczepienia:</sabold> Możesz się wyposażyć w 1 rozwinięcie <cannon>, <torpedo> albo <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6525,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6526,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6527,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6528,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 3,
-            "ffg_id": "XW_P_187",
-            "force_side": null,
-            "id": 187,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Inaldra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7405,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7406,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7407,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7408,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Szefowa stacji Tansarii Point",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz w zasięgu ataku 3 albo wykonujesz atak w zasięgu 1, rzucasz 1 dodatkową kością.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6541,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6542,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6543,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_191",
-            "force_side": null,
-            "id": 191,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Talonbane Cobra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7421,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7422,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7423,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7424,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Pogromca z Tansarii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Myśliwiec szturmowy Kihraxz został zaprojektowany specjalnie dla syndykatu Czarnego Słońca, którego szczodrze opłacane asy pilotażu domagały się zwinnego, potężnego statku, który pozwoliłby im w pełni wykorzystać umiejętności.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6553,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6554,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6555,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 3,
-            "ffg_id": "XW_P_195",
-            "force_side": null,
-            "id": 195,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "As Czarnego Słońca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7437,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7438,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7439,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7440,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz akcję <boost>, możesz wykonać akcję <evade>.<return><shipability><sabold>Zaawansowany mózg droida:</sabold> Gdy wykonasz akcję <calculate>, otrzymujesz 1 żeton obliczeń.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6567,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6568,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6569,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6570,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 3,
-            "ffg_id": "XW_P_199",
-            "force_side": null,
-            "id": 199,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•IG-88C",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 21,
-            "statistics": [
-                {
-                    "id": 7453,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7454,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7455,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7456,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Podstępna maszyna",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Legendarni tropiciele z Gand czczą mgły spowijające ich rodzinną planetę. Zwierzynę tropią przy pomocy znaków, wróżb i tajemnych rytuałów.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6581,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6582,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6583,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_203",
-            "force_side": null,
-            "id": 203,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Gandyjski tropiciel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 22,
-            "statistics": [
-                {
-                    "id": 7469,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7470,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7471,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7472,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz atak, każdy wrogi statek w twojej <bullseye> przyjmuje 1 uszkodzenie <hit>, chyba że usunie 1 zielony żeton.<return><sabold>Na gorącym uczynku: </sabold>Gdy wykonujesz atak, a obrońca znajduje się w twojej <bullseye>, nie można modyfikować kości obrony za pomocą zielonych żetonów.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6593,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6594,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6595,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6596,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                10,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_207",
-            "force_side": null,
-            "id": 207,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Torani Kulda",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 39,
-            "statistics": [
-                {
-                    "id": 7486,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7487,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7488,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "7"
-                },
-                {
-                    "id": 7489,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Rodiański wolny strzelec",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli posiadasz żeton stresu, możesz przerzucić maksymalnie 2 ze swoich kości.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5919,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5920,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5921,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_23",
-            "force_side": null,
-            "id": 23,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Braylen Stramm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6760,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6761,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6762,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6763,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Dowódca Ostrzy",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Jeżeli masz uciec, możesz wydać 1 <standardcharge>. Jeżeli tak zrobisz, zamiast uciec, umieść się w rezerwie. Na początku następnej fazy planowania umieść się w zasięgu 1 od krawędzi obszaru gry, przez którą uciekłeś.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6608,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6609,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6610,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                8,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 3,
-            "ffg_id": "XW_P_211",
-            "force_side": null,
-            "id": 211,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Moralo Eval",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 24,
-            "statistics": [
-                {
-                    "id": 7503,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 7504,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7505,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "9"
-                },
-                {
-                    "id": 7506,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                },
-                {
-                    "id": 7507,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Geniusz przestępczy",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki możesz wskazać 1 przyjazny statek w zasięgu 0–1. Jeżeli tak zrobisz, przenieś na wskazany statek wszystkie zielone żetony przypisane do twojego statku.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6620,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6621,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6622,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_215",
-            "force_side": null,
-            "id": 215,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Manaroo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 45,
-            "statistics": [
-                {
-                    "id": 7521,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7522,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7523,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7524,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Urokliwa Aruzanka",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Bogaty arsenał uzbrojenia i silne osłony sprawiają, że B-wing jest najnowocześniejszym myśliwcem szturmowym Sojuszu Rebeliantów.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5928,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5929,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5930,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_26",
-            "force_side": null,
-            "id": 26,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot Eskadry Niebieskich",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6772,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6773,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6774,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6775,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak, możesz wydać 1 żeton stresu, aby zmienić wszystkie swoje wyniki <focus> na <evade> albo <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5922,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5923,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5924,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_24",
-            "force_side": null,
-            "id": 24,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Ten Numb",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6764,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6765,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6766,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6767,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Niebieski Pięć",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Kokpit B-winga umieszczony jest w unikalnym systemie żyrostabilizatorów, dzięki czemu pilot zawsze jest nieruchomy podczas walki.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5925,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5926,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5927,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 1,
-            "ffg_id": "XW_P_25",
-            "force_side": null,
-            "id": 25,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Weteran Eskadry Ostrzy",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6768,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6769,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6770,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6771,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak podstawowy, jeśli atak jest przesłonięty przez przeszkodę, możesz rzucić 1 dodatkową kością.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6645,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6646,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6647,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6648,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_222",
-            "force_side": null,
-            "id": 222,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7555,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7556,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7557,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7558,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Dzieciak z Korelii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak podstawowy i w zasięgu 0–1 od obrońcy znajduje się przynajmniej 1 inny przyjazny statek, możesz rzucić 1 dodatkową kością ataku.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5934,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5935,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5936,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_28",
-            "force_side": null,
-            "id": 28,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Porucznik Blount",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6780,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6781,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6782,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6783,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gracz zespołowy",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>TIE/ag zaprojektowano z myślą o dłuższych starciach. Za sterami maszyn tego typu zasiadają zwykle najlepsi z najlepszych pilotów, bo tylko oni potrafią w pełni wykorzystać unikalne uzbrojenie i niezwykłą zwrotność.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6294,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6295,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6296,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_129",
-            "force_side": null,
-            "id": 129,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Zwiadowca Eskadry Onyksowych",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7171,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7172,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7173,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7174,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Przyjazne statki w zasięgu 0–1 mogą wykonywać ataki, będąc w zasięgu 0 od przeszkód.<return><shipability><sabold>Drugi pilot:</sabold> Gdy jesteś zadokowany, statek, który cię przewozi, zyskuje dodatkowo twoją zdolność pilota.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6664,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6665,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6666,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "24",
-            "faction_id": 3,
-            "ffg_id": "XW_P_227",
-            "force_side": null,
-            "id": 227,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Pionier z Zewnętrznych Rubieży",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
-            "statistics": [
-                {
-                    "id": 7575,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7576,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7577,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7578,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Zaradny banita",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Z-95 Łowca Głów stanowił główną inspirację dla projektu myśliwca gwiezdnego Incom Corporation X-wing T-65. Choć jest już nieco przestarzały, to jednak wciąż bardzo wszechstronny i skuteczny myśliwiec.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5940,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5941,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5942,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "23",
-            "faction_id": 1,
-            "ffg_id": "XW_P_30",
-            "force_side": null,
-            "id": 30,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Pilot Eskadry Bandytów",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6788,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6789,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6790,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6791,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz rzut kośćmi, jeśli nie posiadasz żetonu stresu, możesz otrzymać 1 żeton stresu, aby przerzucić wszystkie puste wyniki.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6649,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6650,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6651,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6652,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 3,
-            "ffg_id": "XW_P_223",
-            "force_side": null,
-            "id": 223,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7559,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7560,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7561,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7562,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Wygadany hazardzista",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy inny przyjazny statek w zasięgu 0–1 się broni i ty również znajdujesz się w strefie ataku atakującego, możesz, przed etapem neutralizacji wyników, przyjąć 1 uszkodzenie <hit> albo <crit>, aby anulować analogiczny wynik na kości.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5857,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5858,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5859,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_7",
-            "force_side": null,
-            "id": 7,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Biggs Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6696,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6697,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6698,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6699,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Czerwony Trzy",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zanim się aktywujesz, jeżeli posiadasz żeton skupienia, możesz wykonać akcję.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5863,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5864,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5865,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_9",
-            "force_side": null,
-            "id": 9,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Edrio „Dwururowiec”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6704,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6705,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6706,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6707,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Weteran Jaskiniowych Aniołów",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny statek w zasięgu 0–1 zostanie wskazany jako obrońca, możesz wydać 1 żeton wzmocnienia. Jeżeli tak zrobisz, wskazany statek otrzymuje 1 żeton uników.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5946,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5947,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5948,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_32",
-            "force_side": null,
-            "id": 32,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Lowhhrick",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6796,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6797,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6798,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6799,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Zbiegły gladiator",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>AF4 to najnowszy model w długiej serii typu Łowca Głów. Jest tani i stosunkowo wytrzymały, co sprawia, że cieszy się sporą popularnością w niezależnych formacjach, a także w Rebelii.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5937,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5938,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5939,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "25",
-            "faction_id": 1,
-            "ffg_id": "XW_P_29",
-            "force_side": null,
-            "id": 29,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot Eskadry Tala",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6784,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6785,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6786,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6787,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak podstawowy i jesteś uszkodzony, możesz rzucić 1 dodatkową kością ataku.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5943,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5944,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5945,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "56",
-            "faction_id": 1,
-            "ffg_id": "XW_P_31",
-            "force_side": null,
-            "id": 31,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Wullffwarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6792,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6793,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6794,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6795,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Wódz Wookiech",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz atak, możesz wskazać 1 przyjazny statek w zasięgu 1. Wskazany statek może wykonać dodatkową akcję, traktując ją, jak gdyby była czerwona.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5931,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5932,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5933,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "36",
-            "faction_id": 1,
-            "ffg_id": "XW_P_27",
-            "force_side": null,
-            "id": 27,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Airen Cracken",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6776,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6777,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6778,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6779,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Szef wywiadu",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zanim się aktywujesz, możesz wykonać akcję <barrelroll> albo <boost>.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5955,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5956,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5957,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_35",
-            "force_side": null,
-            "id": 35,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6808,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6809,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6810,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6811,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Upiór-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Holownik transferowy Quadrijet, znany potocznie jako „Quadjumper” radzi sobie zarówno w przestrzeni kosmicznej, jak i w atmosferze, przez co jest niezwykle popularny wśród przemytników i odkrywców.</flavor><return><shipability><sabold>Wiązka ściągająca holownika: Akcja:</sabold> wskaż statek w swojej <frontarc> w zasięgu 1. Wskazany statek otrzymuje 1 żeton wiązki ściągającej albo 2 żetony wiązki ściągającej, jeżeli znajduje się w twojej <bullseye> w zasięgu 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6435,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6436,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6437,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 3,
-            "ffg_id": "XW_P_164",
-            "force_side": null,
-            "id": 164,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Szmugler broni z Jakku",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7313,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7314,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7315,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Atutem kanonierek Auzituck jest szerokie pole rażenia zapewniane przez trzy podwójnie sprzężone działa laserowe typu Sureggi. Statki te skutecznie odstraszają z systemu Kashyyyk łowców niewolników.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5949,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5950,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5951,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_33",
-            "force_side": null,
-            "id": 33,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Obrońca Kashyyyk",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6800,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6801,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6802,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6803,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli posiadasz żeton stresu, możesz wydać 1 <forcecharge>, aby zmienić maksymalnie 2 ze swoich wyników <focus> na wynik <evade> albo <hit>.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5958,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5959,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5960,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_36",
-            "force_side": 2,
-            "id": 36,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6812,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6813,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6814,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6815,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6816,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Upiór-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak podstawowy, możesz wydać 1 osłonę, aby rzucić 1 dodatkową kością ataku albo, jeżeli nie masz aktywnych osłon, rzucić 1 kością ataku mniej, aby odzyskać 1 osłonę.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6048,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6049,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6050,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6051,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6052,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_62",
-            "force_side": null,
-            "id": 62,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Miranda Doni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6919,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6920,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6921,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6922,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Ciężkie wsparcie",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "W trakcie etapu wykonywania akcji możesz wykonać 1 akcję nawet wtedy, gdy posiadasz żeton stresu. Gdy wykonasz akcję, posiadając żeton stresu, przyjmujesz 1 uszkodzenie<nonbreak><hit>, chyba że odkryjesz 1 ze swoich kart uszkodzeń.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_83",
-            "force_side": null,
-            "id": 307,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•„Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Akcja:</smallcaps> Wydaj 1 nieodnawialny <standardcharge> z innego rozwinięcia, w które jesteś wyposażony, aby odzyskać 1 osłonę.<return><smallcaps>Akcja:</smallcaps> Wydaj 2 osłony, aby odzyskać 1 nieodnawialny <standardcharge> na rozwinięciu, w które jesteś wyposażony.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_99",
-            "force_side": null,
-            "id": 323,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•„Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz pełny manewr i nie zrzuciłeś ani nie wystrzeliłeś żadnego urzadzenia w tej rundzie, możesz zrzucić 1 bombę.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_143",
-            "force_side": null,
-            "id": 368,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•„Geniusz”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Może do ciebie dokować 1 prom sztumowy albo prom klasy Sheathipede. <return>Zadokowane do ciebie statki mogą startować tylko z tylnych wypustek.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_102",
-            "force_side": null,
-            "id": 326,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Duch</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 23,
-                            "raw_name": "VCX-100 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Może do ciebie dokować 1 Z-95-AF4 Łowca Głów.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_148",
-            "force_side": null,
-            "id": 373,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Wściekły Pies</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 24,
-                            "raw_name": "YV-666 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Możesz dokować w zasięgu 0–1.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_106",
-            "force_side": null,
-            "id": 330,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Upiór</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 32,
-                            "raw_name": "Attack Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    },
-                    {
-                        "kwargs": {
-                            "pk": 8,
-                            "raw_name": "Sheathipede-class Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak podstawowy i obrońca znajduje się w twojej <frontarc>, rzuć 1 dodatkową kością ataku.<return>Usuń gniazdo <crew>. Dodaj gniazdo <astro>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_152",
-            "force_side": null,
-            "id": 377,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Karząca Ręka</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 45,
-                            "raw_name": "JumpMaster 5000"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki możesz wskazać 1 wrogi statek w zasięgu 0–1. Jeżeli tak zrobisz, otrzymujesz 1 żeton obliczeń, chyba że wskazany statek postanowi przyjąć 1 żeton stresu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_127",
-            "force_side": null,
-            "id": 352,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•0-0-0",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 338
-                        },
-                        "type": "CARD_INCLUDED"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 93
-                        },
-                        "type": "CARD_INCLUDED"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy inny przyjazny statek w zasięgu 0–3 się broni i zostanie zniszczony, atakujący otrzymuje 2 żetony stresu.<return>Gdy przyjazny statek w zasięgu 0–3 wykonuje atak na statek z żetonem stresu, może przerzucić 1 kość ataku.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_109",
-            "force_side": null,
-            "id": 335,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Admirał Sloane",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz atak podstawowy i posiadasz żeton skupienia, możesz wykonać dodatkowy atak <turretarc> przeciwko statkowi, którego jeszcze w tej rundzie nie atakowałeś.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "14",
-            "faction_id": null,
-            "ffg_id": "XW_U_95",
-            "force_side": null,
-            "id": 319,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bistan",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz atak podstawowy, który nie trafi, i nie posiadasz żetonu stresu, musisz otrzymać 1 żeton stresu i wykonać dodatkowy atak podstawowy przeciwko temu samemu celowi.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_139",
-            "force_side": null,
-            "id": 364,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bossk",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz akcję <focus>, możesz ją traktować jak czerwoną. Jeżeli tak zrobisz, otrzymujesz 1 dodatkowy żeton skupienia za każdy wrogi statek w zasięgu 0–1, ale nie więcej niż 2 żetony.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_79",
-            "force_side": null,
-            "id": 303,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Baze Malbus",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "W fazie końcowej możesz wybrać 2 rozwinięcia <illicit>, w które wyposażone są przyjazne statki w zasięgu 0–1. Jeżeli tak zrobisz, możesz zamienić miejscami te rozwinięcia.<return><smallcaps>Zakończenie gry:</smallcaps> Odłóż wszystkie rozwinięcia <illicit> na statki, z których pochodzą.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_131",
-            "force_side": null,
-            "id": 356,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Cikatro Vizago",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Akcja:</smallcaps> Wydaj 1<nonbreak><standardcharge> aby wykonać akcję <cloak>.<return>Na początku fazy planowania rzuć 1 kością ataku. Jeżeli wypadnie <focus>, wyłącz maskowanie albo odrzuć swój żeton maskowania.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_57",
-            "force_side": null,
-            "id": 286,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•System maskowania",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6594,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "W fazie aktywacji wrogie statki w zasięgu 0–1 nie mogą usuwać żetonów stresu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_113",
-            "force_side": null,
-            "id": 339,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Szturmowcy śmierci",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8,
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "W fazie systemowej możesz wydać 2 <standardcharge>. Jeżeli tak zrobisz, każdy przyjazny statek może namierzyć statek, który namierzyłeś.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_117",
-            "force_side": null,
-            "id": 343,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Wielki Moff Tarkin",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "STRESS"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6601,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Przygotowanie gry:</smallcaps> Po rozmieszczeniu sił wybierz 1 statek wroga i przypisz mu stan <smallcaps>Urządzenie nasłuchowe</smallcaps>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_44",
-            "force_side": null,
-            "id": 273,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Informator",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Jeżeli przyjazny statek w zasięgu 0–3 ma otrzymać żeton skupienia, może zamiast tego otrzymać 1 żeton uników.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_85",
-            "force_side": null,
-            "id": 309,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Jyn Erso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz i atakujący posiada żeton stresu, możesz usunąć z niego 1 żeton stresu i zmienić 1 ze swoich pustych/<focus> wyników na wynik <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_135",
-            "force_side": null,
-            "id": 360,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Latts Razzi",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli w zasięgu 0–2 nie ma innych przyjaznych statków, możesz wydać 1 <standardcharge>, aby przerzucić 1 ze swoich kości.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_9",
-            "force_side": null,
-            "id": 238,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Samotny wilk",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6606,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy zakończysz obronę, jeżeli atak trafił, możesz namierzyć atakującego.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_89",
-            "force_side": null,
-            "id": 313,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz koordynację, wskazany przez ciebie statek może wykonać akcję tylko wtedy, gdy znajduje się ona także na twoim pasku akcji.",
-            "available_actions": [
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 5830,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_16",
-            "force_side": null,
-            "id": 245,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Dowódca eskadry",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zanim przyjmiesz uszkodzenia od przeszkody albo wybuchu przyjaznej bomby, możesz wydać 1<nonbreak><standardcharge>. Jeżeli tak zrobisz, zapobiegasz 1 uszkodzeniu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_68",
-            "force_side": null,
-            "id": 292,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Poszycie ablacyjne",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "LARGE"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6614,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>): </smallcaps>Wydaj 1 <standardcharge>. Zmień 1 wynik <hit> na wynik <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_33",
-            "force_side": null,
-            "id": 262,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Zaaw. torpedy protonowe",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6615,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "5"
-                },
-                {
-                    "id": 6617,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                5
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1"
-        },
-        {
-            "ability_text": "Gdy odsłonisz swoją tarczę manewrów, możesz wykonać 1 akcję. <return>Jeżeli tak zrobisz, nie możesz już wykonać kolejnej akcji podczas twojej aktywacji.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_23",
-            "force_side": null,
-            "id": 252,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Zaawansowane czujniki",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz akcję <slam>, jeśli wykonałeś pełny manewr, możesz wykonać białą akcję z twojego paska akcji, traktując ją tak, jak gdyby była czerwona.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_69",
-            "force_side": null,
-            "id": 293,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Zaawansowany SLAM",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Slam",
-                            "pk": 13,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>W fazie systemowej możesz wydać 1 <standardcharge>, aby zrzucić bombę kasetową, korzystając z wzornika [1 <straight>].<return>Na początku fazy aktywacji możesz wydać 1 osłonę, aby odzyskać 2 <standardcharge>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_63",
-            "force_side": null,
-            "id": 392,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Wytwornica bomb kasetowych",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6622,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12,
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Po wykonaniu tego ataku możesz wykonać go raz jeszcze jako dodatkowy atak przeciwko innemu celowi w zasięgu 0–1 od obrońcy, ignorując wymaganie <targetlock>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_37",
-            "force_side": null,
-            "id": 266,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Rakiety kasetowe",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6623,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6625,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "4"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                6
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<flavor>U-wing UT-60D służy do desantowania żołnierzy pod osłoną ciemności lub w warunkach bojowych. Idealnie nadaje się jako szybki i odporny transportowiec dla Rebelii.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6042,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6043,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6044,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_60",
-            "force_side": null,
-            "id": 60,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Zwiadowca Eskadry Niebieskich",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6911,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6912,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6913,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6914,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz beczkę albo przyspieszenie, możesz ruszać się przez i nachodzić na przeszkody.<return>Gdy ruszasz się przez lub nachodzisz na przeszkodę, możesz wydać 1 <standardcharge>, aby do końca tej rundy ignorować efekty tej przeszkody.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_24",
-            "force_side": null,
-            "id": 253,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Wykrywacz kolizji",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6626,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zanim się aktywujesz, możesz wydać 1<nonbreak><standardcharge>. Jeżeli tak zrobisz, do końca rundy możesz wykonywać akcje i czerwone manewry nawet wtedy, gdy posiadasz żeton strasu.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_58",
-            "force_side": null,
-            "id": 287,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Cybernetyka z kontrabandy",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6631,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz białą akcję <boost>, możesz ją traktować jak czerwoną, aby zamiasttego wykonać ją z użyciem wzornika [1 <leftturn>] albo [1 <rightturn>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                12
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_2",
-            "force_side": null,
-            "id": 231,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Śmiałek",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Boost",
-                            "pk": 1,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Przygotowanie gry:</smallcaps> Tracisz 1<nonbreak><standardcharge>.<return><smallcaps>Akcja:</smallcaps> Odzyskaj 1<nonbreak><standardcharge>.<return><smallcaps>Akcja:</smallcaps> Wydaj 1<nonbreak><standardcharge>, aby odzyskać 1 osłonę.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_43",
-            "force_side": null,
-            "id": 272,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Droid GNK „Gonk”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6636,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak <turretarc>, po etapie modyfikowania rzutów obrony, obrońca usuwa 1 żeton skupienia albo obliczeń.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_49",
-            "force_side": null,
-            "id": 278,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Narwany strzelec",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Gdy kogoś nie stać na zaawansowany generator osłon, zawsze może zamontować na kadłubie dodatkowe płyty pancerza.</flavor>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "*",
-            "faction_id": null,
-            "ffg_id": "XW_U_73",
-            "force_side": null,
-            "id": 297,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Ulepszenie kadłuba",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6642,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_28",
-            "force_side": null,
-            "id": 257,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Działo jonowe",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6643,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                3
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak <frontarc> i nie znajdujesz się w strefie rażenia obrońcy, obrońca rzuca 1 kością obrony mniej.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_11",
-            "force_side": null,
-            "id": 240,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Wymanewrowanie",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy odsłonisz swoją tarczę menwrów, możesz wydać 1<nonbreak><standardcharge>, aby otrzymać 1 żeton rozbrojenia i odzyskać 1 osłonę.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-            "card_set_ids": [
-                1,
-                4,
-                6,
-                7
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_53",
-            "force_side": null,
-            "id": 282,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Astromech R2",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6663,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz, wyniki <crit> są neutralizowane przed wynikami <hit>.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5961,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5962,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5963,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_37",
-            "force_side": null,
-            "id": 37,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6817,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6818,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6819,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6820,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Upiór-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wrogi statek w twojej strefie rażenia rozpocznie walkę, jeżeli nie posiadasz żetonu stresu, możesz otrzymać 1 żeton stresu. Jeżeli tak zrobisz, walczący statek nie może w tej fazie wydawać żetonów, aby modyfikować kości, gdy wykonuje atak.<return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5964,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5965,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_38",
-            "force_side": null,
-            "id": 38,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6821,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6822,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6823,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6824,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6825,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Niechętny rebeliant",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Zaprojektowany na podobieństwo drapieżnego ptaka w locie statek Corellian Engineering Corporation „Jastrząb” to wyjątkowy transportowiec. Szybkie i wytrzymałe HWK-290 często służą rebelianckim agentom jako mobilne bazy.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5987,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5988,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5989,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5990,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5991,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_45",
-            "force_side": null,
-            "id": 45,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebeliancki zwiadowca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6854,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6855,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6856,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6857,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo atakujesz, jeżeli posiadasz żeton stresu, możesz wydać 1 <forcecharge>, aby zmienić maksymalnie 2 ze swoich wyników <focus> na wyniki <evade>/<hit>. <return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5966,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5967,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                10,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_39",
-            "force_side": 2,
-            "id": 39,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6826,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6827,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6828,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6829,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6830,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6831,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Upiór-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz, wyniki <crit> są neutralizowane przed wynikami <hit>.<return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5968,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5969,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_40",
-            "force_side": null,
-            "id": 40,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Zeb” Orrelios ",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6832,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6833,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6834,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6835,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6836,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Upiór-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "W trakcie koordynacji, jeżeli wskażesz statek, który ma dokładnie 1 żeton stresu, może on wykonywać akcje.<return><sabold>Prom komunikacyjny:</sabold> Gdy jesteś zadokowany, statek, który cię transportuje, otrzymuje <coordinate>. Zanim transportujący cię statek się aktywuje, może wykonać akcję <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5970,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5971,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_41",
-            "force_side": null,
-            "id": 41,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-            "initiative": 1,
-            "is_unique": true,
-            "name": "•AP-5",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6837,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6838,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6839,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6840,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6841,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Zbiegły droid analityczny",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny statek w twojej strefie rażenia wykonuje atak podstawowy i nie posiadasz żetonu stresu, możesz otrzymać 1 żeton stresu. Jeżeli tak zrobisz, atakujący statek rzuca 1 kością ataku więcej.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5972,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5973,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5974,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5975,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5976,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_42",
-            "force_side": null,
-            "id": 42,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Jan Ors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6842,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6843,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6844,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6845,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Ekspert wywiadu",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki możesz przenieść 1 ze swoich żetonów skupienia na inny przyjazny statek w twojej strefie rażenia.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5977,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5978,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5979,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5980,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5981,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_43",
-            "force_side": null,
-            "id": 43,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kyle Katarn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6846,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6847,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6848,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6849,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Niestrudzony agent",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki możesz wskazać 1 statek w swojej strefie rażenia. Jeżeli tak zrobisz, wskazany statek walczy w tej fazie z inicjatywą 7 zamiast swojej normalnej inicjatywy.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5982,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5983,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5984,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5985,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5986,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_44",
-            "force_side": null,
-            "id": 44,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Roark Garnet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6850,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6851,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6852,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6853,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Dobroduszny przemytnik",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zanim się aktywujesz, możesz wykonać akcję <barrelroll> albo <boost>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5995,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5996,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5997,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 1,
-            "ffg_id": "XW_P_47",
-            "force_side": null,
-            "id": 47,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6862,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6863,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6864,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Upiór-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy zostaniesz obrońcą (przed rzutami kośćmi), możesz odzyskać 1<nonbreak><forcecharge>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5842,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5843,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5844,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                17,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "62",
-            "faction_id": 1,
-            "ffg_id": "XW_P_2",
-            "force_side": 2,
-            "id": 2,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Luke Skywalker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6675,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6676,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6677,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6678,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 6679,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Czerwony Pięć",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny statek wykonuje atak i obrońca znajduje się w twojej <frontarc>, atakujący może zmienić 1 wynik <hit> na <crit>.<return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6009,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6010,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6011,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6012,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6013,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 1,
-            "ffg_id": "XW_P_51",
-            "force_side": null,
-            "id": 51,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Gavin Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6875,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6876,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6877,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6878,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Dzielny skrzydłowy",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>W Eskadrze Łotrów służą jedni z najlepszych pilotów Rebelii. </flavor><return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6014,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6015,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6016,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6017,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6018,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "63",
-            "faction_id": 1,
-            "ffg_id": "XW_P_52",
-            "force_side": null,
-            "id": 52,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Eskortowiec Eskadry Łotrów",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6879,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6880,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6881,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6882,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>E-wing został zaprojektowany, aby połączyć najlepsze cechy serii X-wing i A-wing; ma zwiększoną siłę ognia, prędkość i zwrotność.</flavor><return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6019,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6020,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6021,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6022,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6023,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "61",
-            "faction_id": 1,
-            "ffg_id": "XW_P_53",
-            "force_side": null,
-            "id": 53,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Eskortowiec Eskadry Szelm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6883,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6884,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6885,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6886,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Po odsłonięciu czerwonego albo niebieskiego manewru, możesz ustawić na tarczy inny manewr o tej samej trudności.<return><sabold>Gotowy do akcji:</sabold> Jeżeli statek, w którym jesteś zadokowany, wykona atak podstawowy <frontarc> albo <turret>, może po nim wykonać dodatkowy atak podstawowy <reararc>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5952,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5953,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5954,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "39",
-            "faction_id": 1,
-            "ffg_id": "XW_P_34",
-            "force_side": null,
-            "id": 34,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6804,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6805,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6806,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6807,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Upiór-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wrogi statek wykona manewr i będzie w zasięgu 0, możesz wykonać akcję.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6039,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6040,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6041,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_59",
-            "force_side": null,
-            "id": 59,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Heff Tobber",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6907,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6908,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6909,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6910,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Niebieski Osiem",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>W przeciwieństwie do większości komórek Rebeliantów, partyzanci Sawa Gerrery uciekają się do ekstremalnych metod, aby osłabić Galaktyczne Imperium w brutalnych starciach, które rozgrywają się od Geonosis aż po Jedhę.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6045,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6046,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6047,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_61",
-            "force_side": null,
-            "id": 61,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Buntowniczy partyzant",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6915,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6916,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6917,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6918,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Produkowany przez Koensayr Manufacturing K-Wing ma zaawansowany napęd podświetlny (SubLight Acceleration Motor) i 18 punktów podczepienia, dzięki czemu dysponuje niezrównaną prędkością i siłą ognia.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6058,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6059,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6060,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6061,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6062,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 1,
-            "ffg_id": "XW_P_64",
-            "force_side": null,
-            "id": 64,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Pilot Eskadry Strażników",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6927,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6928,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6929,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6930,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli posiadasz żeton stresu, możesz wydać 1 <forcecharge>, aby zmienić maksymalnie 2 ze swoich wyników <focus> na wynik <evade> albo <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5992,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5993,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5994,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_46",
-            "force_side": 2,
-            "id": 46,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6858,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6859,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6860,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6861,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Upiór-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz atak, przypisz obrońcy stan: <sabold>Ogień zaporowy</sabold>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5998,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5999,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6000,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_48",
-            "force_side": null,
-            "id": 48,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Kapitan Rex",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6865,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6866,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6867,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Weteran Wojen Klonów",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz, wyniki <crit> są neutralizowane przed wynikami <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6001,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6002,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6003,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "26",
-            "faction_id": 1,
-            "ffg_id": "XW_P_49",
-            "force_side": null,
-            "id": 49,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6868,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6869,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6870,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Upiór-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "W inicjatywie 0 możesz wykonać dodatkowy atak podstawowy przeciwko statkowi wroga w twojej <bullseye>. Jeżeli tak zrobisz, na początku następnej fazy planowania otrzymujesz 1 żeton rozbrojenia.<return><sabold>Skanery eksperymentalne:</sabold> Możesz wykonywać namierzenie w zasięgu  większym niż 3. Nie możesz wykonywać namierzenia w zasięgu 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6004,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6005,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6006,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6007,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6008,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 1,
-            "ffg_id": "XW_P_50",
-            "force_side": null,
-            "id": 50,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Corran Horn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6871,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6872,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6873,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6874,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Niestrudzony śledczy",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz i w zasięgu 0–1 znajduje się wrogi statek, możesz do swoich wyników rzutu dodać 1 wynik <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6063,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6064,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6065,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "55",
-            "faction_id": 1,
-            "ffg_id": "XW_P_65",
-            "force_side": null,
-            "id": 65,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Norra Wexley",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6931,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6932,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6933,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6934,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6935,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Złoty Dziewięć",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Przyjazne statki mogą wykonywać namierzenie w zasięgu 0–3 od dowolnego przyjaznego statku.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6024,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6025,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6026,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 1,
-            "ffg_id": "XW_P_54",
-            "force_side": null,
-            "id": 54,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Bodhi Rook",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6887,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6888,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6889,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6890,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Imperialny zbieg",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy aktywacji możesz wskazać 1 przyjazny statek w zasięgu 1–3. Jeżeli tak zrobisz, wskazany statek usuwa 1 żeton stresu.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6030,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6031,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6032,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_56",
-            "force_side": null,
-            "id": 56,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Cassian Andor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6895,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6896,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6897,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6898,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Wychowany przez Rebelię",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny statek w zasięgu 0–2 się broni, atakujący nie może przerzucić więcej niż 1 kość ataku.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6033,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6034,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6035,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_57",
-            "force_side": null,
-            "id": 57,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6899,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6900,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6901,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6902,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Wypatrywacz Jaskiniowych Aniołów",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz akcję <focus>,możesz przenieść 1 z twoich żetonów skupienia na przyjazny statekw zasięgu 1–2.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6036,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6037,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6038,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_58",
-            "force_side": null,
-            "id": 58,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Benthic „Dwururowiec”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6903,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6904,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6905,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6906,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Strzelec wyborowy Jaskiniowych Aniołów",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny statek w zasięgu 0–2 broni się albo wykonuje atak, może wydawać twoje żetony skupienia, jak gdyby były jego.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6053,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6054,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6055,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6056,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6057,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_63",
-            "force_side": null,
-            "id": 63,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Esege Tuketu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6923,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6924,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6925,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6926,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Bezinteresowny bohater",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wydasz żeton skupienia, możesz wskazać 1 przyjazny statek w zasięgu 1–3. Wskazany statek otrzymuje 1 żeton skupienia.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6066,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6067,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6068,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "51",
-            "faction_id": 1,
-            "ffg_id": "XW_P_66",
-            "force_side": null,
-            "id": 66,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6936,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6937,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6938,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6939,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6940,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Dowódca Czerwonych",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy się bronisz albo wykonujesz atak podstawowy, możesz wydać twoje namierzenie z wrogiego statku, z którym walczysz, aby dodać do twoich wyników rzutu 1 wynik <focus>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6069,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6070,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6071,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "53",
-            "faction_id": 1,
-            "ffg_id": "XW_P_67",
-            "force_side": null,
-            "id": 67,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Shara Bey",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6941,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6942,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6943,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6944,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6945,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Zielony Cztery",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Po wykonaniu pełnego manewru, jeżeli posiadasz żeton stresu, możesz rzucić 1 kością ataku. Jeżeli wypadnie <hit> albo <crit>, usuwasz 1 żeton stresu.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6072,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6073,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6074,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_68",
-            "force_side": null,
-            "id": 68,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ibtisam",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6946,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6947,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6948,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6949,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6950,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Ocalała z Endoru",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy rzucisz koścmi i znajdujesz się w zasięgu 0–1 od przeszkody, możesz przerzucić wszystkie swoje kości. Na potrzeby innych efektów nie jest to traktowane jako przerzut.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6075,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6076,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6077,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6078,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "92",
-            "faction_id": 1,
-            "ffg_id": "XW_P_69",
-            "force_side": null,
-            "id": 69,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6951,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6952,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6953,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6954,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Łajdak do wynajęcia",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zanim otrzymasz odkrytą kartę uszkodzenia, możesz wydać 1 <standardcharge>, aby zamiast tego otrzymać zakrytą kartę uszkodzenia.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6083,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6084,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6085,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6086,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 1,
-            "ffg_id": "XW_P_71",
-            "force_side": null,
-            "id": 71,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6959,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6960,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6961,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6962,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                },
-                {
-                    "id": 6963,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Potężny",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Znany z niezwykłej wytrzymałości i modularnej konstrukcji YT-1300 jest jednym z najpopularniejszych, najczęściej stosowanych i najbardziej modyfikowanych frachtowców w galaktyce.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6087,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6088,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6089,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6090,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "78",
-            "faction_id": 1,
-            "ffg_id": "XW_P_72",
-            "force_side": null,
-            "id": 72,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Przemytnik z Zewnętrznych Rubieży",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6964,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6965,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6966,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6967,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Po odsłonięciu czerwonego albo niebieskiego manewru, możesz ustawić na tarczy inny manewr o tej samej trudności.<return><shipability><sabold>Działko ogonowe: </sabold>Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6091,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6092,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6093,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "76",
-            "faction_id": 1,
-            "ffg_id": "XW_P_73",
-            "force_side": null,
-            "id": 73,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6968,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6969,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6970,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6971,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Upiór-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy przyjazny statek w twojej strefie rażenia się broni, możesz wydać 1 <forcecharge>. Jeżeli tak zrobisz, atakujący rzuca 1 kością ataku mniej.<return><shipability><sabold>Działko ogonowe:</sabold> Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6094,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6095,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6096,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "90",
-            "faction_id": 1,
-            "ffg_id": "XW_P_74",
-            "force_side": 2,
-            "id": 74,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kanan Jarrus",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6972,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6973,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6974,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6975,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                },
-                {
-                    "id": 6976,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Upiór-1",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Na początku fazy walki każdy wrogi statek w zasięgu 0 otrzymuje 2 żetony zakłócania. <return><shipability><sabold>Działko ogonowe:</sabold> Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6097,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6098,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6099,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 1,
-            "ffg_id": "XW_P_75",
-            "force_side": null,
-            "id": 75,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•„Chopper”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6977,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6978,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6979,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6980,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Upiór-3",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Kolejny udany frachtowiec Corellian Engineering Corporation. VCX-100, jest większy niż wszechobecne modele serii YT, ma większy przedział dla załogi i daje większe pole do modyfikacji.</flavor><return><shipability><sabold>Działko ogonowe:</sabold> Gdy jest do ciebie zadokowany statek, dysponujesz bronią podstawową <reararc>, której wartość ataku jest równa wartości podstawowego ataku <frontarc> zadokowanego do ciebie statku.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6100,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6101,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6102,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 1,
-            "ffg_id": "XW_P_76",
-            "force_side": null,
-            "id": 76,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebeliant z Lothal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6981,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6982,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6983,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6984,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>Elitarni piloci myśliwców TIE/ln z Eskadry Czarnych towarzyszyli Darthowi Vaderowi w niszczycielskim ataku przeciwko siłom Rebeliantów podczas Bitwy o Yavin.</flavor>",
             "available_actions": [
                 {
@@ -12311,6 +7715,93 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz akcję, możesz wydać 1 <forcecharge>, aby wykonać kolejną akcję.<return><sabold>Zaawansowany komputer namierzania:</sabold> Gdy wykonujesz atak podstawowy przeciwko obrońcy, którego namierzyłeś, rzucasz 1 dodatkową kością ataku i zmieniasz 1 wynik <hit> na <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6154,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6155,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6156,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 2,
+            "ffg_id": "XW_P_93",
+            "force_side": 1,
+            "id": 93,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Darth Vader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7038,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7039,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7040,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7041,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7042,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Dowódca Czarnych",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12552,6 +8043,87 @@
                 }
             ],
             "subtitle": "Bezlitosny nadzorca",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Myśliwce TIE Advanced x1 były produkowane w bardzo ograniczonej liczbie egzemplarzy, ale inżynierowie Sienar wykorzystali wiele najlepszych cech tego myśliwca, projektując kolejny model: TIE Interceptor.</flavor><return><sabold>Zaawansowany komputer namierzania:</sabold> Gdy wykonujesz atak podstawowy przeciwko obrońcy, którego namierzyłeś, rzucasz 1 dodatkową kością ataku i zmieniasz 1 wynik <hit> na <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6166,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6167,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6168,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 2,
+            "ffg_id": "XW_P_97",
+            "force_side": null,
+            "id": 97,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "As Eskadry Sztormu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7055,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7056,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7057,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7058,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12835,6 +8407,278 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>TIE Advanced v1 korporacji Sienar Fleet System to rewolucyjny projekt myśliwca z ulepszonymi silnikami, wyrzutnią rakiet i składanymi stabilizatorami.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6182,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6183,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6184,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6185,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6186,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_101",
+            "force_side": null,
+            "id": 101,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Baron Imperium",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7073,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7074,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7075,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7076,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Budzący strach Inkwizytorzy mają sporą autonomię i dostęp do najnowszej technologii Imperium. Między innymi do prototypowych myśliwców TIE Advanced v1.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6187,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6188,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6189,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6190,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6191,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 2,
+            "ffg_id": "XW_P_102",
+            "force_side": 1,
+            "id": 102,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Inkwizytor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7077,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7078,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7079,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7080,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7081,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Jeżeli na początku fazy walki w twojej <bullseye> znajduje się wrogi statek, otrzymujesz 1 żeton skupienia.<return><shipability><sabold>Regulator ciągu: </sabold>Gdy wykonasz akcję, możesz wykonać czerwoną akcję <barrelroll> albo czerwoną akcję <boost>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6192,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6193,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6194,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6195,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 2,
+            "ffg_id": "XW_P_103",
+            "force_side": null,
+            "id": 103,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Soontir Fel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 41,
+            "statistics": [
+                {
+                    "id": 7082,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7083,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7084,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Legendarny as",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonasz atak, możesz wykonać akcję <barrelroll> albo <boost>, nawet jeżeli posiadasz żeton stresu.<return><shipability><sabold>Regulator ciągu:</sabold> Gdy wykonasz akcję, możesz wykonać czerwoną akcję <barrelroll> albo czerwoną akcję <boost>.</shipability>",
             "available_actions": [
                 {
@@ -12995,86 +8839,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Jeżeli na początku fazy walki w twojej <bullseye> znajduje się wrogi statek, otrzymujesz 1 żeton skupienia.<return><shipability><sabold>Regulator ciągu: </sabold>Gdy wykonasz akcję, możesz wykonać czerwoną akcję <barrelroll> albo czerwoną akcję <boost>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6192,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6193,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6194,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6195,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 2,
-            "ffg_id": "XW_P_103",
-            "force_side": null,
-            "id": 103,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Soontir Fel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 41,
-            "statistics": [
-                {
-                    "id": 7082,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7083,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7084,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Legendarny as",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>Inżynierowie Sienar Fleet Systems zaprojektowali myśliwiec TIE Interceptor z czterema zamontowanymi w skrzydłach działkami laserowymi, dzięki czemu ma znacznie większą siłę ognia od wcześniejszych modeli.</flavor><return><shipability><sabold>Regulator ciągu:</sabold> Gdy wykonasz akcję, możesz wykonać czerwoną akcję <barrelroll> albo czerwoną akcję <boost>.</shipability>",
             "available_actions": [
                 {
@@ -13149,6 +8913,91 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz akcję <reload>, możesz odzyskać 1 <standardcharge> z 1 z kart rozwinięć <talent>, w które jesteś wyposażony. <return><shipability><sabold>Zwrotny bombowiec:</sabold> Jeżeli masz zrzucić urządzenie przy pomocy wzornika <straight>, możesz zamiast tego skorzystać z wzornika <leftbank> albo <rightbank> o tej samej prędkości.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6208,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6209,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6210,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6211,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_107",
+            "force_side": null,
+            "id": 107,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Tomax Bren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7094,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7095,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7096,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Lekkomyślny indywidualista",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13319,6 +9168,90 @@
                 }
             ],
             "subtitle": "Dowódca Sejmitarów",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy zostaniesz zniszczony, zanim zostaniesz usunięty, możesz wykonać atak i zrzucić albo wystrzelić 1 urządzenie.<return><shipability><sabold>Zwrotny bombowiec:</sabold> Jeżeli masz zrzucić urządzenie przy pomocy wzornika <straight>, możesz zamiast tego skorzystać z wzornika <leftbank> albo <rightbank> o tej samej prędkości.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6220,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6221,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6222,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6223,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_110",
+            "force_side": null,
+            "id": 110,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•„Deathfire”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7103,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7104,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7105,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Niezłomny twardziel",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13580,6 +9513,93 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy się bronisz, a atakujący nie ma zielonych żetonów, możesz zmienić 1 z twoich pustych albo <focus> wyników na wynik <evade>.<return><sabold>Lotki adaptacyjne:</sabold> Zanim odsłonisz swojątarczę manewrów, jeśli nie posiadasz żetonu stresu, <bold>musisz</bold> wykonać biały manewr [1 <leftbank>],[1 <straight>] albo [1 <rightbank>].",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6236,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6237,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6238,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6239,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 2,
+            "ffg_id": "XW_P_114",
+            "force_side": null,
+            "id": 114,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kapitan Feroph",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 43,
+            "statistics": [
+                {
+                    "id": 7116,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7117,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7118,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7119,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Imperialny kurier",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonasz pełny manewr o prędkości 1, korzystając ze zdolności <sabold>Lotki adaptacyjne</sabold>, możesz wykonać akcję <coordinate>. Jeżeli tak zrobisz, pomijasz twój etap wykonywania akcji.<return><sabold>Lotki adaptacyjne:</sabold> Zanim odsłonisz swoją tarczę manewrów, jeśli nie posiadasz żetonu stresu, <bold>musisz</bold> wykonać biały manewr [1 <leftbank>], [1 <straight>] albo [1 <rightbank>].",
             "available_actions": [
                 {
@@ -13826,6 +9846,80 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy się bronisz, po etapie neutralizacji wyników, jeżeli nie posiadasz żetonu stresu, możesz przyjąć 1 uszkodzenie <hit> i otrzymać 1 żeton stresu. Jeżeli tak zrobisz, anulujesz wyniki wszystkich rzutów kości.<return><sabold>Lotki adaptacyjne: </sabold>Zanim odsłonisz swoją tarczę manewrów, jeśli nie posiadasz żetonu stresu, musisz wykonać biały manewr [1 <leftbank>], [1 <straight>] albo [1<nonbreak><rightbank>].",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6251,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6252,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6253,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_118",
+            "force_side": null,
+            "id": 118,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•„Countdown”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 16,
+            "statistics": [
+                {
+                    "id": 7131,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7132,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7133,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Niezniszczalny",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz atak i masz 1 albo mniej kart uszkodzeń, możesz rzucić 1 dodatkową kością ataku.<return><sabold>Lotki adaptacyjne: </sabold>Zanim odsłonisz swoją tarczę manewrów, jeśli nie posiadasz żetonu stresu, musisz wykonać biały manewr [1 <leftbank>], [1 <straight>] albo [1<nonbreak><rightbank>].",
             "available_actions": [
                 {
@@ -14047,26 +10141,40 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy uszkodzony przyjazny statek w zasięgu 0–3 wykonuje atak, może przerzucić 1 kość ataku.",
+            "ability_text": "Gdy wykonasz atak, który trafił, i posiadasz żeton uniku, odkryj 1 z kart uszkodzeń obrońcy.<return><shipability><sabold>Pełny ciąg:</sabold> Gdy wykonasz pełny manewr o prędkości 3–5, możesz wykonać akcję <evade>.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6263,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6266,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14074,156 +10182,54 @@
             "available_upgrades": [
                 1,
                 2,
-                8,
-                8,
-                13,
-                14,
-                18
+                3,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_55",
-            "force_side": null,
-            "id": 55,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6891,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6892,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6893,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6894,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Zagorzały radykał",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Budzący strach Inkwizytorzy mają sporą autonomię i dostęp do najnowszej technologii Imperium. Między innymi do prototypowych myśliwców TIE Advanced v1.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6187,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6188,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6189,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6190,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6191,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 1,
-            "cost": "40",
+            "cost": "84",
             "faction_id": 2,
-            "ffg_id": "XW_P_102",
-            "force_side": 1,
-            "id": 102,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Inkwizytor",
+            "ffg_id": "XW_P_122",
+            "force_side": null,
+            "id": 122,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 25,
+            "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7143,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7078,
+                    "id": 7144,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7145,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7080,
+                    "id": 7146,
                     "recurring": false,
                     "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7081,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
+                    "value": "4"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Dowódca Onyksowych",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -14768,6 +10774,169 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>TIE/ag zaprojektowano z myślą o dłuższych starciach. Za sterami maszyn tego typu zasiadają zwykle najlepsi z najlepszych pilotów, bo tylko oni potrafią w pełni wykorzystać unikalne uzbrojenie i niezwykłą zwrotność.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6294,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6295,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6296,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_129",
+            "force_side": null,
+            "id": 129,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Zwiadowca Eskadry Onyksowych",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7171,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7172,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7173,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7174,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Podczas projektowania myśliwca TIE Aggressor inżynierowie Sienar Fleet Systems skupili się na osiągach i wszechstronności, nie licząc się z kosztami.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6297,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6298,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6299,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 2,
+            "ffg_id": "XW_P_130",
+            "force_side": null,
+            "id": 130,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Specjalista Sienar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7175,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7176,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7177,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7178,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonasz atak, który trafił, zyskujesz 1 żeton uniku.<return><shipability><sabold>Matryca ze stygium:</sabold> Gdy wyłączysz maskowanie, możesz wykonać akcję <evade>. Na początku fazy końcowej możesz wydać 1 żeton uniku, aby otrzymać 1 żeton maskowania.</shipability>",
             "available_actions": [
                 {
@@ -15018,6 +11187,92 @@
                 },
                 {
                     "id": 7190,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>TIE Phantom jest efektem prac w ukrytej bazie na Imdaar Alpha. Inżynierom udało się dokonać czegoś, co wydawało się niemożliwe - stworzyć myśliwiec z zaawansowanym urządzeniem maskującym.</flavor><return><shipability><sabold>Matryca ze stygium:</sabold> Gdy wyłączysz maskowanie, możesz wykonać akcję <evade>. Na początku fazy końcowej możesz wydać 1 żeton uniku, aby otrzymać 1 żeton maskowania.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6312,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6313,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6314,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 7,
+                    "base_action_side_effect": null,
+                    "id": 6315,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_134",
+            "force_side": null,
+            "id": 134,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Oblatywacz z Imdaar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 27,
+            "statistics": [
+                {
+                    "id": 7191,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7192,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7193,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7194,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15285,6 +11540,94 @@
                 },
                 {
                     "id": 7206,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Projekt Star Winga klasy <untalic>Alfa</untalic> był inspirowany innymi statkami Cygnus Spaceworks. To wszechstronny statek wykorzystywany przez specjalistyczne jednostki floty, które wykonują różnorodne zadania.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6328,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6329,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6330,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6331,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                6,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "35",
+            "faction_id": 2,
+            "ffg_id": "XW_P_138",
+            "force_side": null,
+            "id": 138,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Pilot Eskadry Nu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 14,
+            "statistics": [
+                {
+                    "id": 7207,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7208,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7209,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7210,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -15590,6 +11933,101 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Na początku fazy walki możesz wskazać 1 albo więcej przyjaznych statków w zasięgu 0–3. Jeżeli tak zrobisz, przenieś na twój statek wszystkie wrogie żetony namierzenia ze wskazanych statków.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6347,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6348,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 6349,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6350,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                8,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 2,
+            "ffg_id": "XW_P_142",
+            "force_side": null,
+            "id": 142,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kapitan Kagi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 26,
+            "statistics": [
+                {
+                    "id": 7223,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7224,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 7225,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7226,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7227,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Pilot promu Imperatora",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Na początku fazy aktywacji możesz wydać 1 <standardcharge>. Jeżeli tak zrobisz, przyjazne statki wykonujące w tej rundzie namierzenie, muszą je wykonywać w zasięgu większym niż 3 (zamiast 0–3).",
             "available_actions": [
                 {
@@ -15876,6 +12314,202 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Możesz wykonywać ataki podstawowe w zasięgu 0.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6363,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6364,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6365,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6366,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6367,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 2,
+            "ffg_id": "XW_P_146",
+            "force_side": null,
+            "id": 146,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kapitan Oicunn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7244,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7245,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7246,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7247,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Genialny taktyk",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak i jesteś wzmocniony, a obrońca jest w twojej <fullfront> albo <fullrear> pasującej do twojego żetonu wzmocnienia, możesz zmienić 1 ze swoich wyników <focus> na wynik <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6368,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6369,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6370,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6371,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6372,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "88",
+            "faction_id": 2,
+            "ffg_id": "XW_P_147",
+            "force_side": null,
+            "id": 147,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Kontradmirał Chiraneau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7248,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7249,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7250,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7251,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Doradca admirała Pietta",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -16174,6 +12808,104 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy wykonujesz atak podstawowy i w zasięgu 0 od obrońcy znajduje się przynajmniej 1 przyjazny nie limitowany statek, rzucasz 1 dodatkową kością ataku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6386,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6387,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": "stress",
+                    "id": 6388,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6389,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
+            "card_set_ids": [
+                6,
+                11
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 3,
+            "ffg_id": "XW_P_151",
+            "force_side": null,
+            "id": 151,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kath Scarlet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 10,
+            "statistics": [
+                {
+                    "id": 7266,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7267,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "3"
+                },
+                {
+                    "id": 7268,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7269,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7270,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Kapitan piratów z Binayre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli statek wroga posiada żeton stresu, możesz przerzucić 1 ze swych kości.",
             "available_actions": [
                 {
@@ -16466,6 +13198,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy się bronisz albo wykonujesz atak i zasięg ataku wynosi 1, możesz rzucić 1 dodatkową kością.<return><sabold>Natarcie Concordyjskie:</sabold> Gdy się bronisz, a zasięg ataku wynosi 1 i znajdujesz się w <frontarc> atakującego, zmień 1 wynik na <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6402,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6403,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6404,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6405,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 3,
+            "ffg_id": "XW_P_155",
+            "force_side": null,
+            "id": 155,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7286,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7287,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7288,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Dowódca Czaszek",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Na początku fazy walki możesz wskazać 1 wrogi statek w zasięgu 1. Jeżeli tak zrobisz i znajdujesz się w jego <frontarc>, wskazany statek usuwa wszystkie swoje zielone żetony.<return><sabold>Natarcie Concordyjskie:</sabold> Gdy się bronisz, a zasięg ataku wynosi 1 i znajdujesz się w <frontarc> atakującego, zmień 1 wynik na <evade>.",
             "available_actions": [
                 {
@@ -16705,6 +13517,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Asy Eskadry Czaszki stosują agresywną taktykę i wykorzystują obracane skrzydła, aby wykorzystać w walce pełnię możliwości swoich maszyn i osiągnąć przewagę nad wrogiem.</flavor><return> <sabold>Natarcie Concordyjskie:</sabold> Gdy się bronisz, a zasięg ataku wynosi 1 i znajdujesz się w <frontarc> atakującego, zmień 1 wynik na <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6418,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6419,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6420,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6421,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_159",
+            "force_side": null,
+            "id": 159,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Pilot Eskadry Czaszki",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7298,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7299,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7300,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Piloci Mandaloriańskich myśliwców Fang muszą w mistrzowski sposób opanować manewr Konfrontacji Concordyjskkiej, minimalizując profil ataku i wykonując groźne ataki na wprost.</flavor><return> <sabold>Natarcie Concordyjskie:</sabold> Gdy się bronisz, a zasięg ataku wynosi 1 i znajdujesz się w <frontarc> atakującego, zmień 1 wynik na <evade>.",
             "available_actions": [
                 {
@@ -16935,6 +13827,156 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Na początku fazy walki, jeżeli w zasięgu 0 znajduje się co najmniej jeden statek, ty i każdy statek w zasięgu 0 otrzymujecie po 1 żetonie wiązki ściągającej.<return><shipability><sabold>Wiązka ściągająca holownika: Akcja:</sabold> wskaż statek w swojej <frontarc> w zasięgu 1. Wskazany statek otrzymuje 1 żeton wiązki ściągającej albo 2 żetony wiązki ściągającej, jeżeli znajduje się w twojej <bullseye> w zasięgu 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6432,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6433,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6434,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 3,
+            "ffg_id": "XW_P_163",
+            "force_side": null,
+            "id": 163,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Unkar Plutt",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7310,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7311,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7312,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Skąpy Zarządca",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Holownik transferowy Quadrijet, znany potocznie jako „Quadjumper” radzi sobie zarówno w przestrzeni kosmicznej, jak i w atmosferze, przez co jest niezwykle popularny wśród przemytników i odkrywców.</flavor><return><shipability><sabold>Wiązka ściągająca holownika: Akcja:</sabold> wskaż statek w swojej <frontarc> w zasięgu 1. Wskazany statek otrzymuje 1 żeton wiązki ściągającej albo 2 żetony wiązki ściągającej, jeżeli znajduje się w twojej <bullseye> w zasięgu 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6435,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6436,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6437,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 3,
+            "ffg_id": "XW_P_164",
+            "force_side": null,
+            "id": 164,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Szmugler broni z Jakku",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7313,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7314,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7315,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz atak inny niż <frontarc>, rzucasz dodatkową kością ataku.",
             "available_actions": [
                 {
@@ -17021,6 +14063,188 @@
                 }
             ],
             "subtitle": "Bezduszny korsarz",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy przyjazny, nie limitowany statek wykonuje atak, a obrońca znajduje się w twojej strefie rażenia, atakujący może przerzucić 1 kość ataku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6442,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6443,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6444,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6445,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 3,
+            "ffg_id": "XW_P_166",
+            "force_side": null,
+            "id": 166,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Drea Renthal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7320,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7321,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7322,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7323,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Władczyni piratów",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Nawet drobna wzmianka o imperialnych kredytach może przeciągnąć na twoją stronę wielu osobników o wątpliwej reputacji.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6446,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6447,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6448,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6449,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 3,
+            "ffg_id": "XW_P_167",
+            "force_side": null,
+            "id": 167,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Najemnik",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7324,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7325,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7326,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7327,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17271,6 +14495,85 @@
                 }
             ],
             "subtitle": "Imponujący maruder",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Możesz startować tylko awaryjnie i przejmujesz nazwę, inicjatywę, zdolności pilota oraz <standardcharge> przyjaznego, zniszczonego Wściekłego Psa.<return><shipability><sabold>Kapsuła ratunkowa: Przygotowanie gry: </sabold>Wymaga <sabold>Wściekłego Psa.</sabold> <bold>Musisz</bold> rozpocząć grę zadokowany do <sabold>Wściekłego Psa</sabold>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6460,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6461,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6462,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "6",
+            "faction_id": 3,
+            "ffg_id": "XW_P_171",
+            "force_side": null,
+            "id": 171,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Szczeniak Nashtah</italic>",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 7340,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7341,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7342,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7343,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Plan awaryjny",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17532,6 +14835,102 @@
                 }
             ],
             "subtitle": "Najemnik z Zewnętrznych Rubieży",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki możesz wskazać 1 wrogi statek w twojej strefie rażenia, w zasięgu 0–2. Jeżeli tak zrobisz, przenieś 1 żeton skupienia albo uników ze wskazanego statku na ciebie.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6474,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6475,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6476,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6477,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6478,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 3,
+            "ffg_id": "XW_P_175",
+            "force_side": null,
+            "id": 175,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Palob Godalhi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 7357,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7358,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7359,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7360,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Powstaniec z Tethanu",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17815,6 +15214,94 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy wykonasz pełny manewr, możesz otrzymać 1 żeton stresu, aby obrócić statek o 90 stopni.<return> <sabold>Mikroregulacja ciągu:</sabold> Gdy wykonujesz beczkę, <bold>musisz</bold> użyć wzornika <leftbank> albo <rightbank> zamiast wzornika <straight>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6493,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6494,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6495,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6496,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_179",
+            "force_side": null,
+            "id": 179,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Dalan Oberos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 3,
+            "statistics": [
+                {
+                    "id": 7373,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7374,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7375,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7376,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Elitarny łowca nagród",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy się bronisz, po etapie neutralizacji wyników, inny przyjazny statek w twojej strefie rażenia i zasięgu 0–1 może przyjąć 1 uszkodzenie <hit> albo <crit>. Jeżeli tak zrobisz, anuluj 1 analogiczny wynik.<return><sabold>Mikroregulacja ciągu:</sabold> Gdy wykonujesz beczkę, <bold>musisz</bold> użyć wzornika <leftbank> albo <rightbank> zamiast wzornika <straight>.",
             "available_actions": [
                 {
@@ -18078,6 +15565,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy przyjazny statek broni się w zasięgu 0–1, może przerzucić 1 ze swoich kości.<return><shipability><sabold>Punkt podczepienia:</sabold> Możesz się wyposażyć w 1 rozwinięcie <cannon>, <torpedo> albo <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6509,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6510,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6511,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6512,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_183",
+            "force_side": null,
+            "id": 183,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Serissu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7389,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7390,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7391,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7392,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Instruktor pilotażu",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonasz namierzenie, musisz usunąć wszystkie swoje żetony skupienia i uników. Następnie otrzymujesz taką samą liczbę żetonów skupienia i uników, jaką ma namierzony przez ciebie statek.<return><shipability><sabold>Punkt podczepienia:</sabold> Możesz się wyposażyć w 1 rozwinięcie <cannon>, <torpedo> albo <missile>.</shipability>",
             "available_actions": [
                 {
@@ -18331,6 +15904,91 @@
                 }
             ],
             "subtitle": "Poszukiwacz szczęścia",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz albo wykonujesz atak, możesz przyjąć 1 uszkodzenie <hit>, aby przerzucić dowolną liczbę swoich kości.<return><shipability><sabold>Punkt podczepienia:</sabold> Możesz się wyposażyć w 1 rozwinięcie <cannon>, <torpedo> albo <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6525,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6526,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6527,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6528,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 3,
+            "ffg_id": "XW_P_187",
+            "force_side": null,
+            "id": 187,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Inaldra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7405,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7406,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7407,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7408,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Szefowa stacji Tansarii Point",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -18592,6 +16250,88 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy się bronisz w zasięgu ataku 3 albo wykonujesz atak w zasięgu 1, rzucasz 1 dodatkową kością.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6541,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6542,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6543,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_191",
+            "force_side": null,
+            "id": 191,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Talonbane Cobra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7421,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7422,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7423,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7424,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Pogromca z Tansarii",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy się bronisz i znajdujesz się za atakującym, rzucasz 1 dodatkową kością obrony. <return>Gdy wykonujesz atak i znajdujesz się za obrońcą, rzucasz 1 dodatkową kością ataku.",
             "available_actions": [
                 {
@@ -18832,6 +16572,88 @@
                 }
             ],
             "subtitle": "Agresywny oportunista",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Myśliwiec szturmowy Kihraxz został zaprojektowany specjalnie dla syndykatu Czarnego Słońca, którego szczodrze opłacane asy pilotażu domagały się zwinnego, potężnego statku, który pozwoliłby im w pełni wykorzystać umiejętności.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6553,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6554,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6555,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 3,
+            "ffg_id": "XW_P_195",
+            "force_side": null,
+            "id": 195,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "As Czarnego Słońca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7437,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7438,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7439,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7440,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19100,6 +16922,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy wykonasz akcję <boost>, możesz wykonać akcję <evade>.<return><shipability><sabold>Zaawansowany mózg droida:</sabold> Gdy wykonasz akcję <calculate>, otrzymujesz 1 żeton obliczeń.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6567,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6568,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6569,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6570,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 3,
+            "ffg_id": "XW_P_199",
+            "force_side": null,
+            "id": 199,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•IG-88C",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 21,
+            "statistics": [
+                {
+                    "id": 7453,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7454,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7455,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7456,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Podstępna maszyna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz pętlę Segnora (<leftsloop> albo <rightsloop>), zamiast standardowego wzronika możesz użyć wzornika zwrotu (<leftturn> albo <rightturn>) o tej samej prędkości i kierunku albo wzornika na wprost (<straight>) o tej samej prędkości.<return><shipability><sabold>Zaawansowany mózg droida:</sabold> Gdy wykonasz akcję <calculate>, otrzymujesz 1 żeton obliczeń.</shipability>",
             "available_actions": [
                 {
@@ -19355,6 +17268,87 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Legendarni tropiciele z Gand czczą mgły spowijające ich rodzinną planetę. Zwierzynę tropią przy pomocy znaków, wróżb i tajemnych rytuałów.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6581,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6582,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6583,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_203",
+            "force_side": null,
+            "id": 203,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Gandyjski tropiciel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 22,
+            "statistics": [
+                {
+                    "id": 7469,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7470,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7471,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7472,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Zanim wybuchnie przyjazna bomba albo mina, możesz wydać 1 <standardcharge>, aby temu zapobiec. <return>Gdy się bronisz przed atakiem, który jest przesłonięty przez bombę albo minę, rzucasz 1 dodatkową kością obrony.",
             "available_actions": [
                 {
@@ -19604,6 +17598,95 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz atak, każdy wrogi statek w twojej <bullseye> przyjmuje 1 uszkodzenie <hit>, chyba że usunie 1 zielony żeton.<return><sabold>Na gorącym uczynku: </sabold>Gdy wykonujesz atak, a obrońca znajduje się w twojej <bullseye>, nie można modyfikować kości obrony za pomocą zielonych żetonów.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6593,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6594,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6595,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6596,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                10,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_207",
+            "force_side": null,
+            "id": 207,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Torani Kulda",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 39,
+            "statistics": [
+                {
+                    "id": 7486,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7487,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7488,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "7"
+                },
+                {
+                    "id": 7489,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Rodiański wolny strzelec",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19878,6 +17961,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Jeżeli masz uciec, możesz wydać 1 <standardcharge>. Jeżeli tak zrobisz, zamiast uciec, umieść się w rezerwie. Na początku następnej fazy planowania umieść się w zasięgu 1 od krawędzi obszaru gry, przez którą uciekłeś.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6608,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6609,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6610,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                8,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 3,
+            "ffg_id": "XW_P_211",
+            "force_side": null,
+            "id": 211,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Moralo Eval",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 24,
+            "statistics": [
+                {
+                    "id": 7503,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 7504,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7505,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "9"
+                },
+                {
+                    "id": 7506,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                },
+                {
+                    "id": 7507,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Geniusz przestępczy",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Na początku fazy walki możesz wskazać 1 statek w zasięgu 1 i wydać twoje namierzenie ze wskazanego statku. Jeżeli tak zrobisz, wskazny statek otrzymuje 1 żeton wiązki ściągającej.",
             "available_actions": [
                 {
@@ -20130,6 +18304,88 @@
                 }
             ],
             "subtitle": "Mściwy Corellianin",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki możesz wskazać 1 przyjazny statek w zasięgu 0–1. Jeżeli tak zrobisz, przenieś na wskazany statek wszystkie zielone żetony przypisane do twojego statku.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6620,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6621,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6622,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_215",
+            "force_side": null,
+            "id": 215,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Manaroo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 45,
+            "statistics": [
+                {
+                    "id": 7521,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7522,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7523,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7524,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Urokliwa Aruzanka",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20689,38 +18945,39 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Wiele osób żyje, przemierzając Zewnętrzne Rubieże, gdzie czasami trudno jest odróżnić przemytnika od uczciwego handlarza.Na pograniczu cywilizowanego świata kupujący rzadko pytają o pochodzenie towarów, o ile cena jest odpowiednio niska.</flavor>",
+            "ability_text": "Gdy się bronisz albo wykonujesz atak podstawowy, jeśli atak jest przesłonięty przez przeszkodę, możesz rzucić 1 dodatkową kością.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 6645,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 6646,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 6647,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 6648,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
+                1,
                 6,
                 8,
                 8,
@@ -20729,51 +18986,142 @@
                 15,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "54",
             "faction_id": 3,
-            "ffg_id": "XW_P_225",
+            "ffg_id": "XW_P_222",
             "force_side": null,
-            "id": 225,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Kapitan frachtowca",
+            "id": 222,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 7555,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 7556,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 7557,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 7558,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Dzieciak z Korelii",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz rzut kośćmi, jeśli nie posiadasz żetonu stresu, możesz otrzymać 1 żeton stresu, aby przerzucić wszystkie puste wyniki.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6649,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6650,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6651,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6652,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 3,
+            "ffg_id": "XW_P_223",
+            "force_side": null,
+            "id": 223,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7559,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7560,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7561,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7562,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Wygadany hazardzista",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20869,6 +19217,96 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Wiele osób żyje, przemierzając Zewnętrzne Rubieże, gdzie czasami trudno jest odróżnić przemytnika od uczciwego handlarza.Na pograniczu cywilizowanego świata kupujący rzadko pytają o pochodzenie towarów, o ile cena jest odpowiednio niska.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6657,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6658,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6659,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6660,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 3,
+            "ffg_id": "XW_P_225",
+            "force_side": null,
+            "id": 225,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Kapitan frachtowca",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7567,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7568,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7569,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7570,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonasz rzut kośćmi, jeśli nie posiadasz żetonu stresu, możesz otrzymać 1 żeton stresu, aby przerzucić wszystkie puste wyniki.<return><shipability><sabold>Drugi pilot:</sabold> Gdy jesteś zadokowany, statek, który cię przewozi, zyskuje dodatkowo twoją zdolność pilota.</shipability>",
             "available_actions": [
                 {
@@ -20948,42 +19386,160 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonujesz atak podstawowy i obrońca znajduje się w twojej <bullseye>, przed etapem neutralizacji wyników możesz wydać 1 <standardcharge>, aby anulować 1 wynik <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                9
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_1",
-            "force_side": null,
-            "id": 230,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Celny strzał",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
+            "ability_text": "Przyjazne statki w zasięgu 0–1 mogą wykonywać ataki, będąc w zasięgu 0 od przeszkód.<return><shipability><sabold>Drugi pilot:</sabold> Gdy jesteś zadokowany, statek, który cię przewozi, zyskuje dodatkowo twoją zdolność pilota.</shipability>",
+            "available_actions": [
                 {
-                    "id": 6632,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6664,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6665,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6666,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
                 }
             ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+            "available_upgrades": [
+                1,
+                8,
+                14
             ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "24",
+            "faction_id": 3,
+            "ffg_id": "XW_P_227",
+            "force_side": null,
+            "id": 227,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Pionier z Zewnętrznych Rubieży",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7575,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7576,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7577,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7578,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Zaradny banita",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Jeżeli nie masz aktywnych osłon, zmniejsz poziom trudności twoich manewrów skrętu (<leftbank> oraz <rightbank>).<return><shipability><sabold>Drugi pilot: </sabold>Gdy jesteś zadokowany, statek, który cię przewozi, zyskuje dodatkowo twoją zdolność pilota.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6667,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6668,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6669,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "22",
+            "faction_id": 3,
+            "ffg_id": "XW_P_228",
+            "force_side": null,
+            "id": 228,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•L3-37",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7579,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7580,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7581,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7582,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Droid-rewolucjonista",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21069,81 +19625,94 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Jeżeli nie masz aktywnych osłon, zmniejsz poziom trudności twoich manewrów skrętu (<leftbank> oraz <rightbank>).<return><shipability><sabold>Drugi pilot: </sabold>Gdy jesteś zadokowany, statek, który cię przewozi, zyskuje dodatkowo twoją zdolność pilota.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6667,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6668,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6669,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "ability_text": "Gdy wykonujesz atak podstawowy i obrońca znajduje się w twojej <bullseye>, przed etapem neutralizacji wyników możesz wydać 1 <standardcharge>, aby anulować 1 wynik <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
             "card_set_ids": [
-                13
+                4,
+                5,
+                6,
+                9
             ],
-            "card_type_id": 1,
-            "cost": "22",
-            "faction_id": 3,
-            "ffg_id": "XW_P_228",
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_1",
             "force_side": null,
-            "id": 228,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•L3-37",
+            "id": 230,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Celny strzał",
             "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 6632,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7580,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7581,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7582,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
+                    "statistic_id": 7,
+                    "value": "1"
                 }
             ],
-            "subtitle": "Droid-rewolucjonista",
-            "upgrade_types": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz białą akcję <boost>, możesz ją traktować jak czerwoną, aby zamiasttego wykonać ją z użyciem wzornika [1 <leftturn>] albo [1 <rightturn>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                12
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_2",
+            "force_side": null,
+            "id": 231,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Śmiałek",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Boost",
+                            "pk": 1,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21351,6 +19920,39 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy wrogi statek w zasięgu 0 broni się, rzuca 1 kością obrony mniej.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_7",
+            "force_side": null,
+            "id": 236,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Zastraszanie",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz atak i posiadasz żeton uniku, możesz zmienić 1 z wyników <evade> obrońcy na wynik <focus>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21400,6 +20002,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy się bronisz albo wykonujesz atak, jeżeli w zasięgu 0–2 nie ma innych przyjaznych statków, możesz wydać 1 <standardcharge>, aby przerzucić 1 ze swoich kości.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_9",
+            "force_side": null,
+            "id": 238,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Samotny wilk",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6606,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz atak i obrońca znajduje się w twojej <bullseye>, możesz zmienić 1 wynik <hit> na wynik <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21420,6 +20062,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Strzelec wyborowy",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak <frontarc> i nie znajdujesz się w strefie rażenia obrońcy, obrońca rzuca 1 kością obrony mniej.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_11",
+            "force_side": null,
+            "id": 240,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Wymanewrowanie",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21558,37 +20233,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Na początku fazy walki możesz wydać 1 <forcecharge>. Jeżeli tak zrobisz, w tej fazie walczysz z inicjatywą 7 zamiast twojej normalnej wartości inicjatywy.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-            "card_set_ids": [
-                1,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_19",
-            "force_side": null,
-            "id": 248,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Wyczulone zmysły",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                17
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Gdy inny przyjazny statek broni się w zasięgu 0–1, jeżeli znajdujesz<nonbreak>się w strefie ataku atakującego, to przed etapem neutralizacji wyników możesz przyjąć 1 uszkodzenie <crit>, aby anulować 1 wynik <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21630,6 +20274,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy wykonujesz koordynację, wskazany przez ciebie statek może wykonać akcję tylko wtedy, gdy znajduje się ona także na twoim pasku akcji.",
+            "available_actions": [
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 5830,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_16",
+            "force_side": null,
+            "id": 245,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Dowódca eskadry",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Na początku fazy walki możesz wskazać 1 przyjazny statek w zasięgu 1. Jeżeli tak zrobisz, do końca rundy jego inicjatywa jest taka jak twoja.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21658,6 +20343,70 @@
             "subtitle": null,
             "upgrade_types": [
                 1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak przesłonięty przez przeszkodę, rzuć 1 dodatkową kością ataku.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_18",
+            "force_side": null,
+            "id": 247,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Popisowy  strzał",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki możesz wydać 1 <forcecharge>. Jeżeli tak zrobisz, w tej fazie walczysz z inicjatywą 7 zamiast twojej normalnej wartości inicjatywy.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+            "card_set_ids": [
+                1,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_19",
+            "force_side": null,
+            "id": 248,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Wyczulone zmysły",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                17
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -21763,6 +20512,78 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy odsłonisz swoją tarczę manewrów, możesz wykonać 1 akcję. <return>Jeżeli tak zrobisz, nie możesz już wykonać kolejnej akcji podczas twojej aktywacji.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_23",
+            "force_side": null,
+            "id": 252,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Zaawansowane czujniki",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz beczkę albo przyspieszenie, możesz ruszać się przez i nachodzić na przeszkody.<return>Gdy ruszasz się przez lub nachodzisz na przeszkodę, możesz wydać 1 <standardcharge>, aby do końca tej rundy ignorować efekty tej przeszkody.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_24",
+            "force_side": null,
+            "id": 253,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Wykrywacz kolizji",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6626,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz atak przeciwko obrońcy, którego namierzyłeś, możesz przerzucić 1 kość ataku. Jeżeli tak zrobisz, nie możesz wydać swojego namierzenia podczas tego ataku.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21783,6 +20604,37 @@
             "initiative": null,
             "is_unique": false,
             "name": "System kierowania ogniem",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Jeżeli w fazie systemowej masz zrzucić albo wystrzelić bombę, zamiast tego możesz ją wystrzelić, korzystając z wzornika [5<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_set_ids": [
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_26",
+            "force_side": null,
+            "id": 255,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Symulator trajektorii",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21836,83 +20688,43 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Jeżeli w fazie systemowej masz zrzucić albo wystrzelić bombę, zamiast tego możesz ją wystrzelić, korzystając z wzornika [5<nonbreak><straight>].",
+            "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
             "card_set_ids": [
+                4,
                 5,
                 6
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "5",
             "faction_id": null,
-            "ffg_id": "XW_U_26",
+            "ffg_id": "XW_U_28",
             "force_side": null,
-            "id": 255,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "id": 257,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Symulator trajektorii",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5835,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_32",
-            "force_side": null,
-            "id": 261,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Wieżyczka z działem jonowym",
+            "name": "Działo jonowe",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6645,
+                    "id": 6643,
                     "recurring": false,
-                    "statistic_id": 12,
+                    "statistic_id": 10,
                     "value": "3"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
-                4
+                3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 - 3"
         },
         {
             "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wszystkie wyniki <hit>/<crit> przydzielają żetony zakłócania zamiast uszkodzeń.",
@@ -21993,48 +20805,144 @@
             "weapon_range": "1 - 3"
         },
         {
-            "ability_text": "<smallcaps>Atak (</smallcaps><focus><smallcaps>):</smallcaps> Wydaj 1<nonbreak><standardcharge>. Jeżeli obrońca znajduje się w twojej <bullseye>, możesz wydać 1 albo więcej <standardcharge>, aby przerzucić tyle samo kości ataku.",
-            "available_actions": [],
+            "ability_text": "<smallcaps>Atak</smallcaps>",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5832,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
             "card_set_ids": [
-                5
+                4,
+                5,
+                6
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_36",
+            "ffg_id": "XW_U_31",
             "force_side": null,
-            "id": 265,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "id": 260,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Rakiety zaporowe",
+            "name": "Górna wieżyczka",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6619,
+                    "id": 6633,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6621,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "5"
+                    "statistic_id": 12,
+                    "value": "2"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5835,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+            "card_set_ids": [
+                4,
+                5,
                 6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_32",
+            "force_side": null,
+            "id": 261,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Wieżyczka z działem jonowym",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6645,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>): </smallcaps>Wydaj 1 <standardcharge>. Zmień 1 wynik <hit> na wynik <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+            "card_set_ids": [
+                4,
+                5,
                 6
             ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_33",
+            "force_side": null,
+            "id": 262,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Zaaw. torpedy protonowe",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6615,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "5"
+                },
+                {
+                    "id": 6617,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                5
+            ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "1"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>): </smallcaps>Wydaj 1 <standardcharge>. Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
@@ -22129,6 +21037,96 @@
             ],
             "weapon_no_bonus": true,
             "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Atak (</smallcaps><focus><smallcaps>):</smallcaps> Wydaj 1<nonbreak><standardcharge>. Jeżeli obrońca znajduje się w twojej <bullseye>, możesz wydać 1 albo więcej <standardcharge>, aby przerzucić tyle samo kości ataku.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_36",
+            "force_side": null,
+            "id": 265,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Rakiety zaporowe",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6619,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6621,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "5"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6,
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Po wykonaniu tego ataku możesz wykonać go raz jeszcze jako dodatkowy atak przeciwko innemu celowi w zasięgu 0–1 od obrońcy, ignorując wymaganie <targetlock>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_37",
+            "force_side": null,
+            "id": 266,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Rakiety kasetowe",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6623,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6625,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "4"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "1 - 2"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Gdy ten atak trafi, każdy statek w zasięgu 0–1 od obrońcy odkrywa 1 ze swoich kart uszkodzeń.",
@@ -22267,38 +21265,6 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Gdy się bronisz, przed rzutami ataku możesz wydać twoje namierzenie z atakującego statku, aby rzucić 1 kością ataku. Jeżeli tak zrobisz, atakujący otrzymuje 1 żeton zakłócania. Następnie, jeżeli wypadnie <hit> albo <crit>, otrzymujesz 1 żeton zakłócania.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_42",
-            "force_side": null,
-            "id": 271,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Niezależny slicer",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Atak (</smallcaps><focus><smallcaps>):</smallcaps> Wydaj 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22344,6 +21310,109 @@
             "weapon_range": "1 - 2"
         },
         {
+            "ability_text": "Gdy się bronisz, przed rzutami ataku możesz wydać twoje namierzenie z atakującego statku, aby rzucić 1 kością ataku. Jeżeli tak zrobisz, atakujący otrzymuje 1 żeton zakłócania. Następnie, jeżeli wypadnie <hit> albo <crit>, otrzymujesz 1 żeton zakłócania.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_42",
+            "force_side": null,
+            "id": 271,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Niezależny slicer",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Przygotowanie gry:</smallcaps> Tracisz 1<nonbreak><standardcharge>.<return><smallcaps>Akcja:</smallcaps> Odzyskaj 1<nonbreak><standardcharge>.<return><smallcaps>Akcja:</smallcaps> Wydaj 1<nonbreak><standardcharge>, aby odzyskać 1 osłonę.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_43",
+            "force_side": null,
+            "id": 272,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Droid GNK „Gonk”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6636,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Przygotowanie gry:</smallcaps> Po rozmieszczeniu sił wybierz 1 statek wroga i przypisz mu stan <smallcaps>Urządzenie nasłuchowe</smallcaps>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_44",
+            "force_side": null,
+            "id": 273,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Informator",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Na końcu rundy możesz rzucić 1 kością ataku, aby naprawić 1 odkrytą kartę uszkodzeń. Jeżeli wypadnie <hit>, odkryj 1 kartę uszkodzeń.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22363,6 +21432,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Początkujący technik",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz akcję <focus>, otrzymujesz 1 żeton skupienia.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_46",
+            "force_side": null,
+            "id": 275,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Spostrzegawczy pilot",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -22456,6 +21558,38 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak <turretarc>, po etapie modyfikowania rzutów obrony, obrońca usuwa 1 żeton skupienia albo obliczeń.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_49",
+            "force_side": null,
+            "id": 278,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Narwany strzelec",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -22587,6 +21721,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy odsłonisz swoją tarczę menwrów, możesz wydać 1<nonbreak><standardcharge>, aby otrzymać 1 żeton rozbrojenia i odzyskać 1 osłonę.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+            "card_set_ids": [
+                1,
+                4,
+                6,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_53",
+            "force_side": null,
+            "id": 282,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Astromech R2",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6663,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Możesz utrzymywać maksymlanie 2 namierzenia. Każde namierzenie musi być na innym obiekcie.<return>Gdy wykonasz akcję <targetlock>, możesz wykonać namierzenie.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22702,6 +21876,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallcaps>Akcja:</smallcaps> Wydaj 1<nonbreak><standardcharge> aby wykonać akcję <cloak>.<return>Na początku fazy planowania rzuć 1 kością ataku. Jeżeli wypadnie <focus>, wyłącz maskowanie albo odrzuć swój żeton maskowania.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_57",
+            "force_side": null,
+            "id": 286,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•System maskowania",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6594,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim się aktywujesz, możesz wydać 1<nonbreak><standardcharge>. Jeżeli tak zrobisz, do końca rundy możesz wykonywać akcje i czerwone manewry nawet wtedy, gdy posiadasz żeton strasu.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_58",
+            "force_side": null,
+            "id": 287,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cybernetyka z kontrabandy",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6631,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy zostaniesz zniszczony, każdy statek w zasięgu (0–1) przyjmuje 1 uszkodzenie<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22797,45 +22062,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>W fazie systemowej możesz wydać 1 <standardcharge>, aby zrzucić sieć Connera, korzystając z wzornika [1 <straight>].<return>Nie można odzyskać <standardcharge> tej karty.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_64",
-            "force_side": null,
-            "id": 393,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Sieć Connera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6630,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Akcja:</smallcaps> Wydaj 1<nonbreak><standardcharge>. Wyrzuć 1 zbędny towar za pomocą wzornika [1<nonbreak><straight>].",
             "available_actions": [],
             "available_upgrades": [],
@@ -22890,18 +22116,10 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Atak</smallcaps>",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5832,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
+            "ability_text": "Zanim przyjmiesz uszkodzenia od przeszkody albo wybuchu przyjaznej bomby, możesz wydać 1<nonbreak><standardcharge>. Jeżeli tak zrobisz, zapobiegasz 1 uszkodzeniu.",
+            "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
             "card_set_ids": [
                 4,
                 5,
@@ -22910,60 +22128,35 @@
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_31",
+            "ffg_id": "XW_U_68",
             "force_side": null,
-            "id": 260,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+            "id": 292,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Górna wieżyczka",
-            "restrictions": [],
+            "name": "Poszycie ablacyjne",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "LARGE"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6633,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                4
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>W fazie systemowej możesz wydać 1<nonbreak><standardcharge>, aby zrzucić bombę protonową, korzystając z wzornika [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_65",
-            "force_side": null,
-            "id": 394,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Bomby protonowe",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6655,
+                    "id": 6614,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -22971,88 +22164,50 @@
             ],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>W fazie systemowej możesz wydać 1 <standardcharge>, aby zrzucić minę zbliżeniową, korzystając z wzornika [1 <straight>].<return>Nie można odzyskać <standardcharge> tej karty.",
+            "ability_text": "Gdy wykonasz akcję <slam>, jeśli wykonałeś pełny manewr, możesz wykonać białą akcję z twojego paska akcji, traktując ją tak, jak gdyby była czerwona.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
             "card_set_ids": [
                 4,
                 5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_66",
-            "force_side": null,
-            "id": 395,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Miny zbliżeniowe",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6662,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>W fazie systemowej możesz wydać 1<nonbreak><standardcharge>, aby zrzucić ładunek sejsmiczny, korzystając z wzornika [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8,
-                11
+                6
             ],
             "card_type_id": 2,
             "cost": "3",
             "faction_id": null,
-            "ffg_id": "XW_U_67",
+            "ffg_id": "XW_U_69",
             "force_side": null,
-            "id": 396,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "id": 293,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Ładunki sejsmiczne",
-            "restrictions": [],
+            "name": "Zaawansowany SLAM",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Slam",
+                            "pk": 13,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6666,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23187,6 +22342,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Gdy kogoś nie stać na zaawansowany generator osłon, zawsze może zamontować na kadłubie dodatkowe płyty pancerza.</flavor>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "*",
+            "faction_id": null,
+            "ffg_id": "XW_U_73",
+            "force_side": null,
+            "id": 297,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ulepszenie kadłuba",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6642,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "+1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz atak <torpedo> albo <missile>, po wykonaniu rzutu ataku możesz anulować wszystkie wyniki, aby odzyskać 1<nonbreak><standardcharge> wydany jako koszt ataku.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23291,54 +22486,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Zanim rzucisz kośćmi obrony, możesz wydać 1 żeton obliczeń, aby zadeklarować na głos liczbę większą od 0. Jeżeli tak zrobisz i rzucisz dokładnie tyle wyników <evade>, dodaj 1 wynik <evade>.<return>Gdy wykonasz akcję <calculate>, otrzymujesz 1 żeton obliczeń.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5827,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_80",
-            "force_side": null,
-            "id": 304,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•C-3PO",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Gdy się bronisz i twój <standardcharge> jest aktywny, rzucasz dodatkową kością obrony.<return>Gdy przyjmiesz uszkodzenie, tracisz 1 <standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23422,6 +22569,94 @@
             "subtitle": null,
             "upgrade_types": [
                 14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz akcję <focus>, możesz ją traktować jak czerwoną. Jeżeli tak zrobisz, otrzymujesz 1 dodatkowy żeton skupienia za każdy wrogi statek w zasięgu 0–1, ale nie więcej niż 2 żetony.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_79",
+            "force_side": null,
+            "id": 303,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Baze Malbus",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim rzucisz kośćmi obrony, możesz wydać 1 żeton obliczeń, aby zadeklarować na głos liczbę większą od 0. Jeżeli tak zrobisz i rzucisz dokładnie tyle wyników <evade>, dodaj 1 wynik <evade>.<return>Gdy wykonasz akcję <calculate>, otrzymujesz 1 żeton obliczeń.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5827,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "12",
+            "faction_id": null,
+            "ffg_id": "XW_U_80",
+            "force_side": null,
+            "id": 304,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•C-3PO",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23514,6 +22749,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "W trakcie etapu wykonywania akcji możesz wykonać 1 akcję nawet wtedy, gdy posiadasz żeton stresu. Gdy wykonasz akcję, posiadając żeton stresu, przyjmujesz 1 uszkodzenie<nonbreak><hit>, chyba że odkryjesz 1 ze swoich kart uszkodzeń.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_83",
+            "force_side": null,
+            "id": 307,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Możesz wykonywać czerwone manewry nawet wtedy, gdy posiadasz żeton stresu. Gdy wykonasz pełny czerwony manewr i posiadasz 3 lub więcej żetonów stresu, usuwasz 1 żeton stresu i przyjmujesz 1 uszkodzenie<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23531,6 +22806,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Hera Syndulla",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Jeżeli przyjazny statek w zasięgu 0–3 ma otrzymać żeton skupienia, może zamiast tego otrzymać 1 żeton uników.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_85",
+            "force_side": null,
+            "id": 309,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Jyn Erso",
             "restrictions": [
                 [
                     {
@@ -23688,6 +23003,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy zakończysz obronę, jeżeli atak trafił, możesz namierzyć atakującego.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_89",
+            "force_side": null,
+            "id": 313,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Zmniejsz poziom trudności twoich manewrów skrętu (<leftbank> oraz <rightbank>).",
             "available_actions": [],
             "available_upgrades": [],
@@ -23705,6 +23060,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Nien Nunb",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Jeżeli w fazie końcowej jesteś uszkodzony i nie masz aktywnych osłon, możesz rzucić 1 kością ataku, aby odzyskać 1 osłonę. Jeżeli wypadnie <hit>, odkryj 1 ze swoich kart uszkodzeń.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_91",
+            "force_side": null,
+            "id": 315,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R2-D2",
             "restrictions": [
                 [
                     {
@@ -23768,23 +23163,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Jeżeli w fazie końcowej jesteś uszkodzony i nie masz aktywnych osłon, możesz rzucić 1 kością ataku, aby odzyskać 1 osłonę. Jeżeli wypadnie <hit>, odkryj 1 ze swoich kart uszkodzeń.",
+            "ability_text": "Gdy wykonujesz atak, możesz przyjąć 1 uszkodzenie <hit>, aby zmienić wszystkie twoje wyniki <focus> na wyniki <crit>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
             "card_set_ids": [
-                4
+                2
             ],
             "card_type_id": 2,
             "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_91",
+            "ffg_id": "XW_U_93",
             "force_side": null,
-            "id": 315,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "id": 317,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R2-D2",
+            "name": "•Saw Gerrera",
             "restrictions": [
                 [
                     {
@@ -23803,6 +23198,86 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Możesz wykonywać ataki podstawowe w zasięgu 0. Wrogie statki w zasięgu 0 mogą wykonywać przeciwko tobie ataki podstawowe.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_94",
+            "force_side": null,
+            "id": 318,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Zeb” Orrelios",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz atak podstawowy i posiadasz żeton skupienia, możesz wykonać dodatkowy atak <turretarc> przeciwko statkowi, którego jeszcze w tej rundzie nie atakowałeś.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "14",
+            "faction_id": null,
+            "ffg_id": "XW_U_95",
+            "force_side": null,
+            "id": 319,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bistan",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23895,46 +23370,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonujesz atak, możesz przyjąć 1 uszkodzenie <hit>, aby zmienić wszystkie twoje wyniki <focus> na wyniki <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_93",
-            "force_side": null,
-            "id": 317,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Na początku fazy walki możesz wydać 1 <forcecharge>, aby obrócić wskaźnik <turretarc>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23977,6 +23412,46 @@
             "subtitle": null,
             "upgrade_types": [
                 16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Akcja:</smallcaps> Wydaj 1 nieodnawialny <standardcharge> z innego rozwinięcia, w które jesteś wyposażony, aby odzyskać 1 osłonę.<return><smallcaps>Akcja:</smallcaps> Wydaj 2 osłony, aby odzyskać 1 nieodnawialny <standardcharge> na rozwinięciu, w które jesteś wyposażony.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_99",
+            "force_side": null,
+            "id": 323,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24076,23 +23551,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Możesz wykonywać ataki podstawowe w zasięgu 0. Wrogie statki w zasięgu 0 mogą wykonywać przeciwko tobie ataki podstawowe.",
+            "ability_text": "Może do ciebie dokować 1 prom sztumowy albo prom klasy Sheathipede. <return>Zadokowane do ciebie statki mogą startować tylko z tylnych wypustek.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 2,
-            "cost": "1",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_94",
+            "ffg_id": "XW_U_102",
             "force_side": null,
-            "id": 318,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "id": 326,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•„Zeb” Orrelios",
+            "name": "•<italic>Duch</italic>",
             "restrictions": [
                 [
                     {
@@ -24102,6 +23577,15 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 23,
+                            "raw_name": "VCX-100 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
@@ -24110,40 +23594,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz atak przesłonięty przez przeszkodę, rzuć 1 dodatkową kością ataku.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_18",
-            "force_side": null,
-            "id": 247,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Popisowy  strzał",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24311,6 +23762,103 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Możesz dokować w zasięgu 0–1.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_106",
+            "force_side": null,
+            "id": 330,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Upiór</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 32,
+                            "raw_name": "Attack Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    },
+                    {
+                        "kwargs": {
+                            "pk": 8,
+                            "raw_name": "Sheathipede-class Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim się aktywujesz, możesz odwrócić tę kartę.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+            "card_set_ids": [
+                2,
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_107",
+            "force_side": null,
+            "id": 331,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Obracane skrzydła (otwarte)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 15,
+                            "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy się bronisz, rzucasz 1 kością obrony mniej.<return>Gdy wykonasz manewr [0<nonbreak><stop>], możesz obrócić statek o 90° albo 180°.<return>Zanim się aktywujesz, możesz odwrócić tę kartę.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24332,6 +23880,49 @@
                         "kwargs": {
                             "pk": 15,
                             "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Zanim się aktywujesz, możesz odwrócić tę kartę.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_set_ids": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_108",
+            "force_side": null,
+            "id": 333,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Serwomotory stabilizatorów (otwarte)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 33,
+                            "raw_name": "T-65 X-wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -24402,34 +23993,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Zanim się aktywujesz, możesz odwrócić tę kartę.",
+            "ability_text": "Gdy inny przyjazny statek w zasięgu 0–3 się broni i zostanie zniszczony, atakujący otrzymuje 2 żetony stresu.<return>Gdy przyjazny statek w zasięgu 0–3 wykonuje atak na statek z żetonem stresu, może przerzucić 1 kość ataku.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
             "card_set_ids": [
-                1,
-                2,
-                4,
-                7
+                5
             ],
             "card_type_id": 2,
-            "cost": "0",
+            "cost": "10",
             "faction_id": null,
-            "ffg_id": "XW_U_108",
+            "ffg_id": "XW_U_109",
             "force_side": null,
-            "id": 333,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "id": 335,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Serwomotory stabilizatorów (otwarte)",
+            "is_unique": true,
+            "name": "•Admirał Sloane",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "pk": 33,
-                            "raw_name": "T-65 X-wing"
+                            "name": "Galactic Empire",
+                            "pk": 2
                         },
-                        "type": "SHIP_TYPE"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -24439,7 +24027,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                18
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24590,6 +24178,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "W fazie aktywacji wrogie statki w zasięgu 0–1 nie mogą usuwać żetonów stresu.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_113",
+            "force_side": null,
+            "id": 339,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Szturmowcy śmierci",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8,
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallcaps>Przygotowanie gry: </smallcaps>Przed rozmieszczeniem sił przypisz stan <smallcaps>Zoptymalizowany prototyp</smallcaps> innemu przyjaznemu statkowi.",
             "available_actions": [
                 {
@@ -24733,6 +24362,111 @@
             "weapon_range": null
         },
         {
+            "ability_text": "W fazie systemowej możesz wydać 2 <standardcharge>. Jeżeli tak zrobisz, każdy przyjazny statek może namierzyć statek, który namierzyłeś.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_117",
+            "force_side": null,
+            "id": 343,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Wielki Moff Tarkin",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6601,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "W fazie końcowej wrogie statki w zasięgu 1–2 nie mogą usuwać żetonów zakłócania.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_118",
+            "force_side": null,
+            "id": 344,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Slicer IBB",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Na początku fazy walki, jeżeli twój statek jest uszkodzony, możesz wykonać czerwoną akcję <reinforce>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24838,23 +24572,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "W fazie końcowej wrogie statki w zasięgu 1–2 nie mogą usuwać żetonów zakłócania.",
+            "ability_text": "Jeżeli wrogi statek w zasięgu 0–1 ma otrzymać żeton stresu, możesz wydać 1 <forcecharge>, aby zamiast tego otrzymał 1 żeton zakłócania albo wiązki ściągającej.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
             "card_set_ids": [
-                3
+                5
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "12",
             "faction_id": null,
-            "ffg_id": "XW_U_118",
+            "ffg_id": "XW_U_121",
             "force_side": null,
-            "id": 344,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "id": 347,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Slicer IBB",
+            "is_unique": true,
+            "name": "•Siódma Siostra",
             "restrictions": [
                 [
                     {
@@ -24869,7 +24603,14 @@
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [],
+            "statistics": [
+                {
+                    "id": 6613,
+                    "recurring": false,
+                    "statistic_id": 4,
+                    "value": "+1"
+                }
+            ],
             "subtitle": null,
             "upgrade_types": [
                 8
@@ -24925,94 +24666,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Jeżeli wrogi statek w zasięgu 0–1 ma otrzymać żeton stresu, możesz wydać 1 <forcecharge>, aby zamiast tego otrzymał 1 żeton zakłócania albo wiązki ściągającej.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_121",
-            "force_side": null,
-            "id": 347,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Siódma Siostra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6613,
-                    "recurring": false,
-                    "statistic_id": 4,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Zanim się aktywujesz, możesz odwrócić tę kartę.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
-            "card_set_ids": [
-                2,
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_107",
-            "force_side": null,
-            "id": 331,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Obracane skrzydła (otwarte)",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 15,
-                            "raw_name": "UT-60D U-wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Gdy wykonasz manewr częściowy, możesz wykonać 1 białą akcję, traktując ją tak, jak gdyby była czerwona.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25062,38 +24715,29 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonasz akcję <coordinate>, możesz wskazać wrogi statek w zasięgu 0–3 od koordynowanego przez ciebie statku. Jeżeli tak zrobisz, namierzasz wskazany wrogi statek, ignorując ograniczenia zasięgu.",
+            "ability_text": "Gdy masz dokładnie 1 żeton rozbrojenia, wciąż możesz wykonywać ataki <torpedo> oraz <missile> przeciwko celom, które masz namierzone. Jeżeli tak zrobisz, podczas tego ataku nie możesz wydać swojego namierzenia.<return>Dodaj gniazda <torpedo> oraz <missile>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_124",
+            "ffg_id": "XW_U_125",
             "force_side": null,
-            "id": 391,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "id": 350,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
             "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>ST-321</italic>",
+            "is_unique": false,
+            "name": "Wyposażenie z arsenału Os-1",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 26,
-                            "raw_name": "Lambda-class T-4a Shuttle"
+                            "pk": 14,
+                            "raw_name": "Alpha-class Star Wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -25105,7 +24749,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                15
+                18
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25146,6 +24790,60 @@
             "subtitle": null,
             "upgrade_types": [
                 18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy walki możesz wskazać 1 wrogi statek w zasięgu 0–1. Jeżeli tak zrobisz, otrzymujesz 1 żeton obliczeń, chyba że wskazany statek postanowi przyjąć 1 żeton stresu.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_127",
+            "force_side": null,
+            "id": 352,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•0-0-0",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 338
+                        },
+                        "type": "CARD_INCLUDED"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 93
+                        },
+                        "type": "CARD_INCLUDED"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25249,6 +24947,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Cad Bane",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "W fazie końcowej możesz wybrać 2 rozwinięcia <illicit>, w które wyposażone są przyjazne statki w zasięgu 0–1. Jeżeli tak zrobisz, możesz zamienić miejscami te rozwinięcia.<return><smallcaps>Zakończenie gry:</smallcaps> Odłóż wszystkie rozwinięcia <illicit> na statki, z których pochodzą.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_131",
+            "force_side": null,
+            "id": 356,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Cikatro Vizago",
             "restrictions": [
                 [
                     {
@@ -25385,6 +25123,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Ketsu Onyo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy się bronisz i atakujący posiada żeton stresu, możesz usunąć z niego 1 żeton stresu i zmienić 1 ze swoich pustych/<focus> wyników na wynik <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_135",
+            "force_side": null,
+            "id": 360,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Latts Razzi",
             "restrictions": [
                 [
                     {
@@ -25563,6 +25341,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy wykonasz atak podstawowy, który nie trafi, i nie posiadasz żetonu stresu, musisz otrzymać 1 żeton stresu i wykonać dodatkowy atak podstawowy przeciwko temu samemu celowi.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_139",
+            "force_side": null,
+            "id": 364,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bossk",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Gdy wykonujesz atak, możesz zmienić 1 wynik <hit> na wynik <crit> za każdy żeton stresu, który ma obrońca.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25711,6 +25529,133 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Gdy wykonasz pełny manewr i nie zrzuciłeś ani nie wystrzeliłeś żadnego urzadzenia w tej rundzie, możesz zrzucić 1 bombę.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_143",
+            "force_side": null,
+            "id": 368,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•„Geniusz”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz atak przeciwko obrońcy w twojej strefie <frontarc>, możesz wydać 1 <standardcharge>, aby przerzucić 1 kość ataku. Jeżeli na przerzuconej kości wypadnie <crit>, przyjmujesz 1 uszkodzenie <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_144",
+            "force_side": null,
+            "id": 369,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-P8",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6612,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Możesz atakować przyjazne statki.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_145",
+            "force_side": null,
+            "id": 370,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-TK",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Dodaj gniazdo <bomb>.",
             "available_actions": [
                 {
@@ -25818,23 +25763,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonujesz atak przeciwko obrońcy w twojej strefie <frontarc>, możesz wydać 1 <standardcharge>, aby przerzucić 1 kość ataku. Jeżeli na przerzuconej kości wypadnie <crit>, przyjmujesz 1 uszkodzenie <crit>.",
+            "ability_text": "Może do ciebie dokować 1 Z-95-AF4 Łowca Głów.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "4",
+            "cost": "1",
             "faction_id": null,
-            "ffg_id": "XW_U_144",
+            "ffg_id": "XW_U_148",
             "force_side": null,
-            "id": 369,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "id": 373,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R5-P8",
+            "name": "•<italic>Wściekły Pies</italic>",
             "restrictions": [
                 [
                     {
@@ -25844,22 +25789,73 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 24,
+                            "raw_name": "YV-666 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6612,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "3"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                10
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Posiadasz zdolności pilota każdego sojuszniczego statku z rozwinięciem <sabold>IG-2000</sabold>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_149",
+            "force_side": null,
+            "id": 374,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "<italic>IG-2000</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 21,
+                            "raw_name": "Aggressor Assault Fighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25971,23 +25967,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Posiadasz zdolności pilota każdego sojuszniczego statku z rozwinięciem <sabold>IG-2000</sabold>.",
+            "ability_text": "Gdy wykonujesz atak podstawowy i obrońca znajduje się w twojej <frontarc>, rzuć 1 dodatkową kością ataku.<return>Usuń gniazdo <crew>. Dodaj gniazdo <astro>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_149",
+            "ffg_id": "XW_U_152",
             "force_side": null,
-            "id": 374,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "id": 377,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "<italic>IG-2000</italic>",
+            "is_unique": true,
+            "name": "•<italic>Karząca Ręka</italic>",
             "restrictions": [
                 [
                     {
@@ -26001,8 +25997,8 @@
                 [
                     {
                         "kwargs": {
-                            "pk": 21,
-                            "raw_name": "Aggressor Assault Fighter"
+                            "pk": 45,
+                            "raw_name": "JumpMaster 5000"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -26172,23 +26168,72 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Przygotowanie gry:</smallcaps>Wyposaż tą stroną do góry.<return>Gdy się bronisz, możesz odwrócić tę kartę. Jeżeli tak zrobisz, atakujący musi przerzucić wszystkie kości ataku.",
+            "ability_text": "Gdy nie uda ci się jakaś akcja i nie masz zielonych żetonów, możesz wykonać akcję <focus>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_156",
+            "force_side": null,
+            "id": 381,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Opanowanie",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Na początku fazy końcowej możesz wydać 1 żeton skupienia, aby naprawić 1 z twoich odkrytych kart uszkodzeń.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_158",
+            "ffg_id": "XW_U_157",
             "force_side": null,
-            "id": 384,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+            "id": 382,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•L3-37",
+            "name": "•Chewbacca",
             "restrictions": [
                 [
                     {
@@ -26250,40 +26295,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy nie uda ci się jakaś akcja i nie masz zielonych żetonów, możesz wykonać akcję <focus>.",
+            "ability_text": "<smallcaps>Przygotowanie gry:</smallcaps>Wyposaż tą stroną do góry.<return>Gdy się bronisz, możesz odwrócić tę kartę. Jeżeli tak zrobisz, atakujący musi przerzucić wszystkie kości ataku.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_156",
+            "ffg_id": "XW_U_158",
             "force_side": null,
-            "id": 381,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "id": 384,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Opanowanie",
+            "is_unique": true,
+            "name": "•L3-37",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "STRESS"
+                            "name": "Scum and Villainy",
+                            "pk": 3
                         },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -26293,7 +26329,47 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                1
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz rzut kośćmi, możesz wydać 1 zielony żeton, aby przerzucić maksymalnie 2 wyniki.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_159",
+            "force_side": null,
+            "id": 385,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26316,6 +26392,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Tobias Beckett",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonujesz ruch lub atakujesz, ignorujesz namierzone przez ciebie przeszkody.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_161",
+            "force_side": null,
+            "id": 387,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Qi’ra",
             "restrictions": [
                 [
                     {
@@ -26369,46 +26485,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Gdy wykonasz rzut kośćmi, możesz wydać 1 zielony żeton, aby przerzucić maksymalnie 2 wyniki.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_159",
-            "force_side": null,
-            "id": 385,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Zanim zaczniesz walkę, możesz wykonać czerwoną akcję <focus>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -26444,331 +26520,6 @@
             "subtitle": null,
             "upgrade_types": [
                 16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonujesz ruch lub atakujesz, ignorujesz namierzone przez ciebie przeszkody.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_161",
-            "force_side": null,
-            "id": 387,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Qi’ra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy otrzymasz żeton stresu, możesz rzucić 1 kością ataku, aby go usunąć. Jeżeli wypadnie <hit>, przyjmujesz 1 uszkodzenie <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5851,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5852,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5853,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_5",
-            "force_side": null,
-            "id": 5,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Jek Porkins",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6688,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6689,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6690,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6691,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Czerwony Sześć",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Możesz wykonywać ataki podstawowe w zasięgu 0.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6363,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6364,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6365,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6366,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6367,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_146",
-            "force_side": null,
-            "id": 146,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kapitan Oicunn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7244,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7245,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7246,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7247,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Genialny taktyk",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wrogi statek w zasięgu 0 broni się, rzuca 1 kością obrony mniej.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_7",
-            "force_side": null,
-            "id": 236,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Zastraszanie",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Gdy wykonasz akcję <focus>, otrzymujesz 1 żeton skupienia.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_46",
-            "force_side": null,
-            "id": 275,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Spostrzegawczy pilot",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Możesz atakować przyjazne statki.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_145",
-            "force_side": null,
-            "id": 370,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•R5-TK",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26818,6 +26569,255 @@
             "subtitle": null,
             "upgrade_types": [
                 15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Gdy wykonasz akcję <coordinate>, możesz wskazać wrogi statek w zasięgu 0–3 od koordynowanego przez ciebie statku. Jeżeli tak zrobisz, namierzasz wskazany wrogi statek, ignorując ograniczenia zasięgu.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_124",
+            "force_side": null,
+            "id": 391,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>ST-321</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 26,
+                            "raw_name": "Lambda-class T-4a Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>W fazie systemowej możesz wydać 1 <standardcharge>, aby zrzucić bombę kasetową, korzystając z wzornika [1 <straight>].<return>Na początku fazy aktywacji możesz wydać 1 osłonę, aby odzyskać 2 <standardcharge>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_63",
+            "force_side": null,
+            "id": 392,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Wytwornica bomb kasetowych",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6622,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12,
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>W fazie systemowej możesz wydać 1 <standardcharge>, aby zrzucić sieć Connera, korzystając z wzornika [1 <straight>].<return>Nie można odzyskać <standardcharge> tej karty.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_64",
+            "force_side": null,
+            "id": 393,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Sieć Connera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6630,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>W fazie systemowej możesz wydać 1<nonbreak><standardcharge>, aby zrzucić bombę protonową, korzystając z wzornika [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_65",
+            "force_side": null,
+            "id": 394,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Bomby protonowe",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6655,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>W fazie systemowej możesz wydać 1 <standardcharge>, aby zrzucić minę zbliżeniową, korzystając z wzornika [1 <straight>].<return>Nie można odzyskać <standardcharge> tej karty.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_66",
+            "force_side": null,
+            "id": 395,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Miny zbliżeniowe",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6662,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>W fazie systemowej możesz wydać 1<nonbreak><standardcharge>, aby zrzucić ładunek sejsmiczny, korzystając z wzornika [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_67",
+            "force_side": null,
+            "id": 396,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Ładunki sejsmiczne",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6666,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
             ],
             "weapon_no_bonus": false,
             "weapon_range": null

--- a/translation_helper/api_export_pl.json
+++ b/translation_helper/api_export_pl.json
@@ -6,21 +6,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 6673,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 6674,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 6675,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -53,25 +53,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 7588,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 7589,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 7590,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 7591,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -88,21 +88,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5842,
+                    "id": 6676,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5843,
+                    "id": 6677,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5844,
+                    "id": 6678,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -134,31 +134,31 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6675,
+                    "id": 7592,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6676,
+                    "id": 7593,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6677,
+                    "id": 7594,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6678,
+                    "id": 7595,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 6679,
+                    "id": 7596,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -175,21 +175,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 6679,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 6680,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 6681,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -221,25 +221,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 7597,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 7598,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 7599,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 7600,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -256,21 +256,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5848,
+                    "id": 6682,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5849,
+                    "id": 6683,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5850,
+                    "id": 6684,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -303,25 +303,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6684,
+                    "id": 7601,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6685,
+                    "id": 7602,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6686,
+                    "id": 7603,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6687,
+                    "id": 7604,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -338,21 +338,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5851,
+                    "id": 6685,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5852,
+                    "id": 6686,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5853,
+                    "id": 6687,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -384,25 +384,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6688,
+                    "id": 7605,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6689,
+                    "id": 7606,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6690,
+                    "id": 7607,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6691,
+                    "id": 7608,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -419,21 +419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5854,
+                    "id": 6688,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5855,
+                    "id": 6689,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5856,
+                    "id": 6690,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -466,25 +466,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6692,
+                    "id": 7609,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6693,
+                    "id": 7610,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6694,
+                    "id": 7611,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6695,
+                    "id": 7612,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -501,21 +501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5857,
+                    "id": 6691,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5858,
+                    "id": 6692,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5859,
+                    "id": 6693,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -547,25 +547,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6696,
+                    "id": 7613,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6697,
+                    "id": 7614,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6698,
+                    "id": 7615,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6699,
+                    "id": 7616,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -582,21 +582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 6694,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 6695,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 6696,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -629,25 +629,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 7617,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6701,
+                    "id": 7618,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 7619,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6703,
+                    "id": 7620,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -664,21 +664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5863,
+                    "id": 6697,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5864,
+                    "id": 6698,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5865,
+                    "id": 6699,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -710,25 +710,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6704,
+                    "id": 7621,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6705,
+                    "id": 7622,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6706,
+                    "id": 7623,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6707,
+                    "id": 7624,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -745,21 +745,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5866,
+                    "id": 6700,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5867,
+                    "id": 6701,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5868,
+                    "id": 6702,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -793,25 +793,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6708,
+                    "id": 7625,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6709,
+                    "id": 7626,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6710,
+                    "id": 7627,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6711,
+                    "id": 7628,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -828,21 +828,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5869,
+                    "id": 6703,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5870,
+                    "id": 6704,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5871,
+                    "id": 6705,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -875,25 +875,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6712,
+                    "id": 7629,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6713,
+                    "id": 7630,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6714,
+                    "id": 7631,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6715,
+                    "id": 7632,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -910,21 +910,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5872,
+                    "id": 6706,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5873,
+                    "id": 6707,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5874,
+                    "id": 6708,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -956,25 +956,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6716,
+                    "id": 7633,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6717,
+                    "id": 7634,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6718,
+                    "id": 7635,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6719,
+                    "id": 7636,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -991,28 +991,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5875,
+                    "id": 6709,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5876,
+                    "id": 6710,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5877,
+                    "id": 6711,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5878,
+                    "id": 6712,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1046,25 +1046,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6720,
+                    "id": 7637,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6721,
+                    "id": 7638,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6722,
+                    "id": 7639,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6723,
+                    "id": 7640,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1081,28 +1081,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5879,
+                    "id": 6713,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5880,
+                    "id": 6714,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5881,
+                    "id": 6715,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5882,
+                    "id": 6716,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1137,25 +1137,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6724,
+                    "id": 7641,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6725,
+                    "id": 7642,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6726,
+                    "id": 7643,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6727,
+                    "id": 7644,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1172,28 +1172,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5883,
+                    "id": 6717,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5884,
+                    "id": 6718,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5885,
+                    "id": 6719,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5886,
+                    "id": 6720,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1228,25 +1228,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6728,
+                    "id": 7645,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6729,
+                    "id": 7646,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6730,
+                    "id": 7647,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6731,
+                    "id": 7648,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1263,28 +1263,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 6721,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 6722,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 6723,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 6724,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1318,25 +1318,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 7649,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 7650,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 7651,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 7652,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1353,28 +1353,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5891,
+                    "id": 6725,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5892,
+                    "id": 6726,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5893,
+                    "id": 6727,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5894,
+                    "id": 6728,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1409,25 +1409,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6736,
+                    "id": 7653,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6737,
+                    "id": 7654,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6738,
+                    "id": 7655,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6739,
+                    "id": 7656,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1444,28 +1444,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 6729,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 6730,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "id": 6731,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "id": 6732,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1499,25 +1499,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 7657,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 7658,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6742,
+                    "id": 7659,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6743,
+                    "id": 7660,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1534,35 +1534,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5899,
+                    "id": 6733,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5900,
+                    "id": 6734,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5901,
+                    "id": 6735,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5902,
+                    "id": 6736,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5903,
+                    "id": 6737,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1591,25 +1591,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6744,
+                    "id": 7661,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6745,
+                    "id": 7662,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6746,
+                    "id": 7663,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6747,
+                    "id": 7664,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1626,35 +1626,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
+                    "id": 6738,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5905,
+                    "id": 6739,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 6740,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
+                    "id": 6741,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 6742,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1683,25 +1683,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 7665,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 7666,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6750,
+                    "id": 7667,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 7668,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1718,35 +1718,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5909,
+                    "id": 6743,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5910,
+                    "id": 6744,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5911,
+                    "id": 6745,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5912,
+                    "id": 6746,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5913,
+                    "id": 6747,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1775,25 +1775,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6752,
+                    "id": 7669,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6753,
+                    "id": 7670,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6754,
+                    "id": 7671,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6755,
+                    "id": 7672,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1810,35 +1810,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5914,
+                    "id": 6748,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5915,
+                    "id": 6749,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5916,
+                    "id": 6750,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5917,
+                    "id": 6751,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5918,
+                    "id": 6752,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1866,25 +1866,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6756,
+                    "id": 7673,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6757,
+                    "id": 7674,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6758,
+                    "id": 7675,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6759,
+                    "id": 7676,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1901,21 +1901,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5919,
+                    "id": 6753,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5920,
+                    "id": 6754,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5921,
+                    "id": 6755,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1948,25 +1948,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6760,
+                    "id": 7677,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6761,
+                    "id": 7678,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6762,
+                    "id": 7679,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6763,
+                    "id": 7680,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -1983,21 +1983,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5922,
+                    "id": 6756,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5923,
+                    "id": 6757,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5924,
+                    "id": 6758,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2030,25 +2030,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6764,
+                    "id": 7681,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6765,
+                    "id": 7682,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6766,
+                    "id": 7683,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6767,
+                    "id": 7684,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2065,21 +2065,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5925,
+                    "id": 6759,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5926,
+                    "id": 6760,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5927,
+                    "id": 6761,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2112,25 +2112,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6768,
+                    "id": 7685,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6769,
+                    "id": 7686,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6770,
+                    "id": 7687,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6771,
+                    "id": 7688,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2147,21 +2147,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5928,
+                    "id": 6762,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5929,
+                    "id": 6763,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5930,
+                    "id": 6764,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2193,25 +2193,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6772,
+                    "id": 7689,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6773,
+                    "id": 7690,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6774,
+                    "id": 7691,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6775,
+                    "id": 7692,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2228,21 +2228,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5931,
+                    "id": 6765,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5932,
+                    "id": 6766,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5933,
+                    "id": 6767,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2272,25 +2272,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6776,
+                    "id": 7693,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6777,
+                    "id": 7694,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6778,
+                    "id": 7695,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6779,
+                    "id": 7696,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2307,21 +2307,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5934,
+                    "id": 6768,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5935,
+                    "id": 6769,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5936,
+                    "id": 6770,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2351,25 +2351,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6780,
+                    "id": 7697,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6781,
+                    "id": 7698,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6782,
+                    "id": 7699,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6783,
+                    "id": 7700,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2386,21 +2386,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5937,
+                    "id": 6771,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5938,
+                    "id": 6772,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5939,
+                    "id": 6773,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2430,25 +2430,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6784,
+                    "id": 7701,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6785,
+                    "id": 7702,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6786,
+                    "id": 7703,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6787,
+                    "id": 7704,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2465,21 +2465,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5940,
+                    "id": 6774,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5941,
+                    "id": 6775,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5942,
+                    "id": 6776,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2508,25 +2508,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6788,
+                    "id": 7705,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6789,
+                    "id": 7706,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6790,
+                    "id": 7707,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6791,
+                    "id": 7708,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2543,21 +2543,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5943,
+                    "id": 6777,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5944,
+                    "id": 6778,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5945,
+                    "id": 6779,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2588,25 +2588,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6792,
+                    "id": 7709,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6793,
+                    "id": 7710,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6794,
+                    "id": 7711,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6795,
+                    "id": 7712,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2623,21 +2623,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5946,
+                    "id": 6780,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5947,
+                    "id": 6781,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5948,
+                    "id": 6782,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2668,25 +2668,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6796,
+                    "id": 7713,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6797,
+                    "id": 7714,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6798,
+                    "id": 7715,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6799,
+                    "id": 7716,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2703,21 +2703,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5949,
+                    "id": 6783,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5950,
+                    "id": 6784,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5951,
+                    "id": 6785,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2747,25 +2747,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6800,
+                    "id": 7717,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6801,
+                    "id": 7718,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6802,
+                    "id": 7719,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6803,
+                    "id": 7720,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2782,21 +2782,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5952,
+                    "id": 6786,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5953,
+                    "id": 6787,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5954,
+                    "id": 6788,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2828,25 +2828,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6804,
+                    "id": 7721,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6805,
+                    "id": 7722,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6806,
+                    "id": 7723,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6807,
+                    "id": 7724,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2863,21 +2863,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5955,
+                    "id": 6789,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5956,
+                    "id": 6790,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5957,
+                    "id": 6791,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2909,25 +2909,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6808,
+                    "id": 7725,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6809,
+                    "id": 7726,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6810,
+                    "id": 7727,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6811,
+                    "id": 7728,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2944,21 +2944,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5958,
+                    "id": 6792,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5959,
+                    "id": 6793,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5960,
+                    "id": 6794,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2990,31 +2990,31 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6812,
+                    "id": 7729,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6813,
+                    "id": 7730,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6814,
+                    "id": 7731,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6815,
+                    "id": 7732,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6816,
+                    "id": 7733,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3031,21 +3031,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5961,
+                    "id": 6795,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5962,
+                    "id": 6796,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5963,
+                    "id": 6797,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -3076,25 +3076,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6817,
+                    "id": 7734,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6818,
+                    "id": 7735,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6819,
+                    "id": 7736,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6820,
+                    "id": 7737,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3111,14 +3111,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5964,
+                    "id": 6798,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5965,
+                    "id": 6799,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3150,31 +3150,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6821,
+                    "id": 7738,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6822,
+                    "id": 7739,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6823,
+                    "id": 7740,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6824,
+                    "id": 7741,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6825,
+                    "id": 7742,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3191,14 +3191,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5966,
+                    "id": 6800,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5967,
+                    "id": 6801,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3230,37 +3230,37 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6826,
+                    "id": 7743,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6827,
+                    "id": 7744,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6828,
+                    "id": 7745,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6829,
+                    "id": 7746,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6830,
+                    "id": 7747,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6831,
+                    "id": 7748,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3277,14 +3277,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5968,
+                    "id": 6802,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5969,
+                    "id": 6803,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3316,31 +3316,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6832,
+                    "id": 7749,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6833,
+                    "id": 7750,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6834,
+                    "id": 7751,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6835,
+                    "id": 7752,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6836,
+                    "id": 7753,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3357,14 +3357,14 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 5970,
+                    "id": 6804,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5971,
+                    "id": 6805,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3396,31 +3396,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6837,
+                    "id": 7754,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6838,
+                    "id": 7755,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6839,
+                    "id": 7756,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6840,
+                    "id": 7757,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6841,
+                    "id": 7758,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3437,35 +3437,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5972,
+                    "id": 6806,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5973,
+                    "id": 6807,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5974,
+                    "id": 6808,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5975,
+                    "id": 6809,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5976,
+                    "id": 6810,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3498,25 +3498,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6842,
+                    "id": 7759,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6843,
+                    "id": 7760,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6844,
+                    "id": 7761,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6845,
+                    "id": 7762,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3533,35 +3533,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5977,
+                    "id": 6811,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5978,
+                    "id": 6812,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5979,
+                    "id": 6813,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5980,
+                    "id": 6814,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5981,
+                    "id": 6815,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3594,25 +3594,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6846,
+                    "id": 7763,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6847,
+                    "id": 7764,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6848,
+                    "id": 7765,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6849,
+                    "id": 7766,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3629,35 +3629,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5982,
+                    "id": 6816,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5983,
+                    "id": 6817,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5984,
+                    "id": 6818,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5985,
+                    "id": 6819,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5986,
+                    "id": 6820,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3690,25 +3690,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6850,
+                    "id": 7767,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6851,
+                    "id": 7768,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6852,
+                    "id": 7769,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6853,
+                    "id": 7770,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3725,35 +3725,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5987,
+                    "id": 6821,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5988,
+                    "id": 6822,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5989,
+                    "id": 6823,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5990,
+                    "id": 6824,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5991,
+                    "id": 6825,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3785,25 +3785,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6854,
+                    "id": 7771,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6855,
+                    "id": 7772,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6856,
+                    "id": 7773,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6857,
+                    "id": 7774,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3820,21 +3820,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5992,
+                    "id": 6826,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5993,
+                    "id": 6827,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5994,
+                    "id": 6828,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3863,25 +3863,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6858,
+                    "id": 7775,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6859,
+                    "id": 7776,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6860,
+                    "id": 7777,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6861,
+                    "id": 7778,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3898,21 +3898,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5995,
+                    "id": 6829,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5996,
+                    "id": 6830,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5997,
+                    "id": 6831,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3941,19 +3941,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6862,
+                    "id": 7779,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6863,
+                    "id": 7780,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6864,
+                    "id": 7781,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -3970,21 +3970,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5998,
+                    "id": 6832,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5999,
+                    "id": 6833,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6000,
+                    "id": 6834,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4012,19 +4012,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6865,
+                    "id": 7782,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6866,
+                    "id": 7783,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6867,
+                    "id": 7784,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4041,21 +4041,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6001,
+                    "id": 6835,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6002,
+                    "id": 6836,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6003,
+                    "id": 6837,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4083,19 +4083,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6868,
+                    "id": 7785,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6869,
+                    "id": 7786,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6870,
+                    "id": 7787,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4112,35 +4112,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6004,
+                    "id": 6838,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6005,
+                    "id": 6839,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6006,
+                    "id": 6840,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6007,
+                    "id": 6841,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6008,
+                    "id": 6842,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4172,25 +4172,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6871,
+                    "id": 7788,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6872,
+                    "id": 7789,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6873,
+                    "id": 7790,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6874,
+                    "id": 7791,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4207,35 +4207,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6009,
+                    "id": 6843,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6010,
+                    "id": 6844,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6011,
+                    "id": 6845,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6012,
+                    "id": 6846,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6013,
+                    "id": 6847,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4267,25 +4267,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6875,
+                    "id": 7792,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6876,
+                    "id": 7793,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6877,
+                    "id": 7794,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6878,
+                    "id": 7795,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4302,35 +4302,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6014,
+                    "id": 6848,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6015,
+                    "id": 6849,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6016,
+                    "id": 6850,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6017,
+                    "id": 6851,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6018,
+                    "id": 6852,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4362,25 +4362,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6879,
+                    "id": 7796,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6880,
+                    "id": 7797,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6881,
+                    "id": 7798,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6882,
+                    "id": 7799,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4397,35 +4397,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6019,
+                    "id": 6853,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6020,
+                    "id": 6854,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6021,
+                    "id": 6855,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6022,
+                    "id": 6856,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6023,
+                    "id": 6857,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4456,25 +4456,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6883,
+                    "id": 7800,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6884,
+                    "id": 7801,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6885,
+                    "id": 7802,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6886,
+                    "id": 7803,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4491,21 +4491,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6024,
+                    "id": 6858,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6025,
+                    "id": 6859,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6026,
+                    "id": 6860,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4538,25 +4538,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6887,
+                    "id": 7804,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6888,
+                    "id": 7805,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6889,
+                    "id": 7806,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6890,
+                    "id": 7807,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4573,21 +4573,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6861,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6862,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "id": 6863,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4621,25 +4621,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6891,
+                    "id": 7808,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6892,
+                    "id": 7809,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6893,
+                    "id": 7810,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6894,
+                    "id": 7811,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4656,21 +4656,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6030,
+                    "id": 6864,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6031,
+                    "id": 6865,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6032,
+                    "id": 6866,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4703,25 +4703,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6895,
+                    "id": 7812,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6896,
+                    "id": 7813,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6897,
+                    "id": 7814,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6898,
+                    "id": 7815,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4738,21 +4738,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6033,
+                    "id": 6867,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6034,
+                    "id": 6868,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6035,
+                    "id": 6869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4786,25 +4786,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6899,
+                    "id": 7816,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6900,
+                    "id": 7817,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6901,
+                    "id": 7818,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6902,
+                    "id": 7819,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4821,21 +4821,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6036,
+                    "id": 6870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6037,
+                    "id": 6871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6038,
+                    "id": 6872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4868,25 +4868,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6903,
+                    "id": 7820,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6904,
+                    "id": 7821,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6905,
+                    "id": 7822,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6906,
+                    "id": 7823,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4903,21 +4903,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6039,
+                    "id": 6873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6040,
+                    "id": 6874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6041,
+                    "id": 6875,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4950,25 +4950,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6907,
+                    "id": 7824,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6908,
+                    "id": 7825,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6909,
+                    "id": 7826,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6910,
+                    "id": 7827,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4985,21 +4985,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6042,
+                    "id": 6876,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6043,
+                    "id": 6877,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6044,
+                    "id": 6878,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5031,25 +5031,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6911,
+                    "id": 7828,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6912,
+                    "id": 7829,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6913,
+                    "id": 7830,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6914,
+                    "id": 7831,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5066,21 +5066,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6045,
+                    "id": 6879,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6046,
+                    "id": 6880,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6047,
+                    "id": 6881,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5113,25 +5113,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6915,
+                    "id": 7832,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6916,
+                    "id": 7833,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6917,
+                    "id": 7834,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6918,
+                    "id": 7835,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5148,35 +5148,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6048,
+                    "id": 6882,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6049,
+                    "id": 6883,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6050,
+                    "id": 6884,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6051,
+                    "id": 6885,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6052,
+                    "id": 6886,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5211,25 +5211,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6919,
+                    "id": 7836,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6920,
+                    "id": 7837,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6921,
+                    "id": 7838,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6922,
+                    "id": 7839,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5246,35 +5246,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6053,
+                    "id": 6887,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6054,
+                    "id": 6888,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6055,
+                    "id": 6889,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6056,
+                    "id": 6890,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6057,
+                    "id": 6891,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5309,25 +5309,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6923,
+                    "id": 7840,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6924,
+                    "id": 7841,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6925,
+                    "id": 7842,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6926,
+                    "id": 7843,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5344,35 +5344,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6058,
+                    "id": 6892,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6059,
+                    "id": 6893,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6060,
+                    "id": 6894,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6061,
+                    "id": 6895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6062,
+                    "id": 6896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5407,25 +5407,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6927,
+                    "id": 7844,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6928,
+                    "id": 7845,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6929,
+                    "id": 7846,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6930,
+                    "id": 7847,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5442,21 +5442,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6063,
+                    "id": 6897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6064,
+                    "id": 6898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6065,
+                    "id": 6899,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5489,31 +5489,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6931,
+                    "id": 7848,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6932,
+                    "id": 7849,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6933,
+                    "id": 7850,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6934,
+                    "id": 7851,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6935,
+                    "id": 7852,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5530,21 +5530,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6066,
+                    "id": 6900,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6067,
+                    "id": 6901,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6068,
+                    "id": 6902,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5577,31 +5577,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6936,
+                    "id": 7853,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6937,
+                    "id": 7854,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6938,
+                    "id": 7855,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6939,
+                    "id": 7856,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6940,
+                    "id": 7857,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5618,21 +5618,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6069,
+                    "id": 6903,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6070,
+                    "id": 6904,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6071,
+                    "id": 6905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5665,31 +5665,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6941,
+                    "id": 7858,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6942,
+                    "id": 7859,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6943,
+                    "id": 7860,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6944,
+                    "id": 7861,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6945,
+                    "id": 7862,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5706,21 +5706,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6072,
+                    "id": 6906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6073,
+                    "id": 6907,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6074,
+                    "id": 6908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5753,31 +5753,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6946,
+                    "id": 7863,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6947,
+                    "id": 7864,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6948,
+                    "id": 7865,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6949,
+                    "id": 7866,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6950,
+                    "id": 7867,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5794,28 +5794,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6075,
+                    "id": 6909,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6076,
+                    "id": 6910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6077,
+                    "id": 6911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6078,
+                    "id": 6912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5850,25 +5850,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6951,
+                    "id": 7868,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6952,
+                    "id": 7869,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6953,
+                    "id": 7870,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6954,
+                    "id": 7871,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5885,28 +5885,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6079,
+                    "id": 6913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6080,
+                    "id": 6914,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6081,
+                    "id": 6915,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6082,
+                    "id": 6916,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5941,25 +5941,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6955,
+                    "id": 7872,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6956,
+                    "id": 7873,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6957,
+                    "id": 7874,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6958,
+                    "id": 7875,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5976,28 +5976,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6083,
+                    "id": 6917,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6084,
+                    "id": 6918,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6085,
+                    "id": 6919,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6086,
+                    "id": 6920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6032,31 +6032,31 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6959,
+                    "id": 7876,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6960,
+                    "id": 7877,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6961,
+                    "id": 7878,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6962,
+                    "id": 7879,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
                 },
                 {
-                    "id": 6963,
+                    "id": 7880,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -6073,28 +6073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6087,
+                    "id": 6921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6088,
+                    "id": 6922,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6089,
+                    "id": 6923,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6090,
+                    "id": 6924,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6128,25 +6128,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6964,
+                    "id": 7881,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6965,
+                    "id": 7882,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6966,
+                    "id": 7883,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6967,
+                    "id": 7884,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -6163,21 +6163,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6091,
+                    "id": 6925,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6092,
+                    "id": 6926,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6093,
+                    "id": 6927,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6212,25 +6212,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6968,
+                    "id": 7885,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6969,
+                    "id": 7886,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6970,
+                    "id": 7887,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6971,
+                    "id": 7888,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6247,21 +6247,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6094,
+                    "id": 6928,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6095,
+                    "id": 6929,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6096,
+                    "id": 6930,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6296,31 +6296,31 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6972,
+                    "id": 7889,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6973,
+                    "id": 7890,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6974,
+                    "id": 7891,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6975,
+                    "id": 7892,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 6976,
+                    "id": 7893,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -6337,21 +6337,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6097,
+                    "id": 6931,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6098,
+                    "id": 6932,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6099,
+                    "id": 6933,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6385,25 +6385,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6977,
+                    "id": 7894,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6978,
+                    "id": 7895,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6979,
+                    "id": 7896,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6980,
+                    "id": 7897,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6420,21 +6420,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6100,
+                    "id": 6934,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6101,
+                    "id": 6935,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6102,
+                    "id": 6936,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6468,25 +6468,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6981,
+                    "id": 7898,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6982,
+                    "id": 7899,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6983,
+                    "id": 7900,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6984,
+                    "id": 7901,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6503,28 +6503,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6103,
+                    "id": 6937,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6104,
+                    "id": 6938,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6105,
+                    "id": 6939,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6106,
+                    "id": 6940,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6558,25 +6558,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6985,
+                    "id": 7902,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6986,
+                    "id": 7903,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6987,
+                    "id": 7904,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6988,
+                    "id": 7905,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6593,28 +6593,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6107,
+                    "id": 6941,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6108,
+                    "id": 6942,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6109,
+                    "id": 6943,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6110,
+                    "id": 6944,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6647,25 +6647,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6989,
+                    "id": 7906,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6990,
+                    "id": 7907,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6991,
+                    "id": 7908,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6992,
+                    "id": 7909,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6682,28 +6682,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6111,
+                    "id": 6945,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6112,
+                    "id": 6946,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6113,
+                    "id": 6947,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6114,
+                    "id": 6948,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6736,25 +6736,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6993,
+                    "id": 7910,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6994,
+                    "id": 7911,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6995,
+                    "id": 7912,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6996,
+                    "id": 7913,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6771,21 +6771,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6115,
+                    "id": 6949,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6116,
+                    "id": 6950,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6117,
+                    "id": 6951,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6815,19 +6815,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6997,
+                    "id": 7914,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6998,
+                    "id": 7915,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6999,
+                    "id": 7916,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6844,21 +6844,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6118,
+                    "id": 6952,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6119,
+                    "id": 6953,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6120,
+                    "id": 6954,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6888,19 +6888,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7000,
+                    "id": 7917,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7001,
+                    "id": 7918,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7002,
+                    "id": 7919,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6917,21 +6917,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6121,
+                    "id": 6955,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6122,
+                    "id": 6956,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6123,
+                    "id": 6957,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6961,19 +6961,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7003,
+                    "id": 7920,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7004,
+                    "id": 7921,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7005,
+                    "id": 7922,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6990,21 +6990,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6124,
+                    "id": 6958,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6125,
+                    "id": 6959,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6126,
+                    "id": 6960,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7033,25 +7033,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7006,
+                    "id": 7923,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7007,
+                    "id": 7924,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7008,
+                    "id": 7925,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7009,
+                    "id": 7926,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -7068,21 +7068,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6127,
+                    "id": 6961,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6128,
+                    "id": 6962,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6129,
+                    "id": 6963,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7111,19 +7111,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7010,
+                    "id": 7927,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7011,
+                    "id": 7928,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7012,
+                    "id": 7929,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7140,21 +7140,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6130,
+                    "id": 6964,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6131,
+                    "id": 6965,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6132,
+                    "id": 6966,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7183,19 +7183,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7013,
+                    "id": 7930,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7014,
+                    "id": 7931,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7015,
+                    "id": 7932,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7212,21 +7212,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6133,
+                    "id": 6967,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6134,
+                    "id": 6968,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6135,
+                    "id": 6969,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7255,19 +7255,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7016,
+                    "id": 7933,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7017,
+                    "id": 7934,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7018,
+                    "id": 7935,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7284,21 +7284,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6136,
+                    "id": 6970,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6137,
+                    "id": 6971,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6138,
+                    "id": 6972,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7327,19 +7327,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7019,
+                    "id": 7936,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7020,
+                    "id": 7937,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7021,
+                    "id": 7938,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7356,21 +7356,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6139,
+                    "id": 6973,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6140,
+                    "id": 6974,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6141,
+                    "id": 6975,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7398,19 +7398,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7022,
+                    "id": 7939,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7023,
+                    "id": 7940,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7024,
+                    "id": 7941,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7427,21 +7427,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6142,
+                    "id": 6976,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6143,
+                    "id": 6977,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6144,
+                    "id": 6978,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7470,25 +7470,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7025,
+                    "id": 7942,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7026,
+                    "id": 7943,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7027,
+                    "id": 7944,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7028,
+                    "id": 7945,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -7505,21 +7505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6145,
+                    "id": 6979,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6146,
+                    "id": 6980,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6147,
+                    "id": 6981,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7550,19 +7550,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7029,
+                    "id": 7946,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7030,
+                    "id": 7947,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7031,
+                    "id": 7948,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7579,21 +7579,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6148,
+                    "id": 6982,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6149,
+                    "id": 6983,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6150,
+                    "id": 6984,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7623,19 +7623,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7032,
+                    "id": 7949,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7033,
+                    "id": 7950,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7034,
+                    "id": 7951,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7652,21 +7652,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6151,
+                    "id": 6985,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6152,
+                    "id": 6986,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6153,
+                    "id": 6987,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7696,19 +7696,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7035,
+                    "id": 7952,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7036,
+                    "id": 7953,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7037,
+                    "id": 7954,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7725,21 +7725,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6154,
+                    "id": 6988,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6155,
+                    "id": 6989,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6156,
+                    "id": 6990,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7771,31 +7771,31 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7038,
+                    "id": 7955,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7039,
+                    "id": 7956,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7040,
+                    "id": 7957,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7041,
+                    "id": 7958,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7042,
+                    "id": 7959,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "3"
@@ -7812,21 +7812,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6157,
+                    "id": 6991,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6158,
+                    "id": 6992,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6159,
+                    "id": 6993,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7858,25 +7858,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7043,
+                    "id": 7960,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7044,
+                    "id": 7961,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7045,
+                    "id": 7962,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7046,
+                    "id": 7963,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7893,21 +7893,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6160,
+                    "id": 6994,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6161,
+                    "id": 6995,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6162,
+                    "id": 6996,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7938,25 +7938,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7047,
+                    "id": 7964,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7048,
+                    "id": 7965,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7049,
+                    "id": 7966,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7050,
+                    "id": 7967,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7973,21 +7973,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6163,
+                    "id": 6997,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6164,
+                    "id": 6998,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6165,
+                    "id": 6999,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8018,25 +8018,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7051,
+                    "id": 7968,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7052,
+                    "id": 7969,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7053,
+                    "id": 7970,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7054,
+                    "id": 7971,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8053,21 +8053,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6166,
+                    "id": 7000,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6167,
+                    "id": 7001,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6168,
+                    "id": 7002,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8099,25 +8099,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7055,
+                    "id": 7972,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7056,
+                    "id": 7973,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7057,
+                    "id": 7974,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7058,
+                    "id": 7975,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8134,21 +8134,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6169,
+                    "id": 7003,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6170,
+                    "id": 7004,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6171,
+                    "id": 7005,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8179,25 +8179,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7059,
+                    "id": 7976,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7060,
+                    "id": 7977,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7061,
+                    "id": 7978,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7062,
+                    "id": 7979,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8214,35 +8214,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6172,
+                    "id": 7006,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6173,
+                    "id": 7007,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6174,
+                    "id": 7008,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6175,
+                    "id": 7009,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6176,
+                    "id": 7010,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8272,31 +8272,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7063,
+                    "id": 7980,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7064,
+                    "id": 7981,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7065,
+                    "id": 7982,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7066,
+                    "id": 7983,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7067,
+                    "id": 7984,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8313,35 +8313,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6177,
+                    "id": 7011,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6178,
+                    "id": 7012,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6179,
+                    "id": 7013,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6180,
+                    "id": 7014,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6181,
+                    "id": 7015,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8371,31 +8371,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7068,
+                    "id": 7985,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7069,
+                    "id": 7986,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7070,
+                    "id": 7987,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7071,
+                    "id": 7988,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7072,
+                    "id": 7989,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8412,35 +8412,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6182,
+                    "id": 7016,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6183,
+                    "id": 7017,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6184,
+                    "id": 7018,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6185,
+                    "id": 7019,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6186,
+                    "id": 7020,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8470,25 +8470,25 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7073,
+                    "id": 7990,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7074,
+                    "id": 7991,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7075,
+                    "id": 7992,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7076,
+                    "id": 7993,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8505,35 +8505,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6187,
+                    "id": 7021,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6188,
+                    "id": 7022,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6189,
+                    "id": 7023,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6190,
+                    "id": 7024,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6191,
+                    "id": 7025,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8563,31 +8563,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7994,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7078,
+                    "id": 7995,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7996,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7080,
+                    "id": 7997,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7081,
+                    "id": 7998,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -8604,28 +8604,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6192,
+                    "id": 7026,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6193,
+                    "id": 7027,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6194,
+                    "id": 7028,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6195,
+                    "id": 7029,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8655,19 +8655,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7082,
+                    "id": 7999,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7083,
+                    "id": 8000,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7084,
+                    "id": 8001,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8684,28 +8684,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6196,
+                    "id": 7030,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6197,
+                    "id": 7031,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6198,
+                    "id": 7032,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6199,
+                    "id": 7033,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8735,19 +8735,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7085,
+                    "id": 8002,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7086,
+                    "id": 8003,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7087,
+                    "id": 8004,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8764,28 +8764,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6200,
+                    "id": 7034,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6201,
+                    "id": 7035,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6202,
+                    "id": 7036,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6203,
+                    "id": 7037,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8815,19 +8815,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7088,
+                    "id": 8005,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7089,
+                    "id": 8006,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7090,
+                    "id": 8007,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8844,28 +8844,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6204,
+                    "id": 7038,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6205,
+                    "id": 7039,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6206,
+                    "id": 7040,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6207,
+                    "id": 7041,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8894,19 +8894,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7091,
+                    "id": 8008,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7092,
+                    "id": 8009,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7093,
+                    "id": 8010,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8923,28 +8923,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6208,
+                    "id": 7042,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6209,
+                    "id": 7043,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6210,
+                    "id": 7044,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6211,
+                    "id": 7045,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8979,19 +8979,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7094,
+                    "id": 8011,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7095,
+                    "id": 8012,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7096,
+                    "id": 8013,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9008,28 +9008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6212,
+                    "id": 7046,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6213,
+                    "id": 7047,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6214,
+                    "id": 7048,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6215,
+                    "id": 7049,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9064,19 +9064,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7097,
+                    "id": 8014,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7098,
+                    "id": 8015,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7099,
+                    "id": 8016,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9093,28 +9093,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6216,
+                    "id": 7050,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6217,
+                    "id": 7051,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6218,
+                    "id": 7052,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6219,
+                    "id": 7053,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9149,19 +9149,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7100,
+                    "id": 8017,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7101,
+                    "id": 8018,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7102,
+                    "id": 8019,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9178,28 +9178,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6220,
+                    "id": 7054,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6221,
+                    "id": 7055,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6222,
+                    "id": 7056,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6223,
+                    "id": 7057,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9233,19 +9233,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7103,
+                    "id": 8020,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7104,
+                    "id": 8021,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7105,
+                    "id": 8022,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9262,28 +9262,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6224,
+                    "id": 7058,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6225,
+                    "id": 7059,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6226,
+                    "id": 7060,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6227,
+                    "id": 7061,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9318,19 +9318,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7106,
+                    "id": 8023,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7107,
+                    "id": 8024,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7108,
+                    "id": 8025,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9347,28 +9347,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6228,
+                    "id": 7062,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6229,
+                    "id": 7063,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6230,
+                    "id": 7064,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6231,
+                    "id": 7065,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9402,19 +9402,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7109,
+                    "id": 8026,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7110,
+                    "id": 8027,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7111,
+                    "id": 8028,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9431,28 +9431,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6232,
+                    "id": 7066,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6233,
+                    "id": 7067,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6234,
+                    "id": 7068,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6235,
+                    "id": 7069,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9483,25 +9483,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7112,
+                    "id": 8029,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7113,
+                    "id": 8030,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7114,
+                    "id": 8031,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7115,
+                    "id": 8032,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9518,28 +9518,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6236,
+                    "id": 7070,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6237,
+                    "id": 7071,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6238,
+                    "id": 7072,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6239,
+                    "id": 7073,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9570,25 +9570,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7116,
+                    "id": 8033,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7117,
+                    "id": 8034,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7118,
+                    "id": 8035,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7119,
+                    "id": 8036,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9605,28 +9605,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6240,
+                    "id": 7074,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6241,
+                    "id": 7075,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6242,
+                    "id": 7076,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6243,
+                    "id": 7077,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9656,25 +9656,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7120,
+                    "id": 8037,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7121,
+                    "id": 8038,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7122,
+                    "id": 8039,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7123,
+                    "id": 8040,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9691,28 +9691,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6244,
+                    "id": 7078,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6245,
+                    "id": 7079,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6246,
+                    "id": 7080,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6247,
+                    "id": 7081,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9742,25 +9742,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7124,
+                    "id": 8041,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7125,
+                    "id": 8042,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7126,
+                    "id": 8043,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7127,
+                    "id": 8044,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9777,21 +9777,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6248,
+                    "id": 7082,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6249,
+                    "id": 7083,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6250,
+                    "id": 7084,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9822,19 +9822,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7128,
+                    "id": 8045,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7129,
+                    "id": 8046,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7130,
+                    "id": 8047,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9851,21 +9851,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6251,
+                    "id": 7085,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6252,
+                    "id": 7086,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6253,
+                    "id": 7087,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9896,19 +9896,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7131,
+                    "id": 8048,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7132,
+                    "id": 8049,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7133,
+                    "id": 8050,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9925,21 +9925,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6254,
+                    "id": 7088,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6255,
+                    "id": 7089,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6256,
+                    "id": 7090,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9970,19 +9970,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7134,
+                    "id": 8051,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7135,
+                    "id": 8052,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7136,
+                    "id": 8053,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9999,21 +9999,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6257,
+                    "id": 7091,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6258,
+                    "id": 7092,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6259,
+                    "id": 7093,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10044,19 +10044,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7137,
+                    "id": 8054,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7138,
+                    "id": 8055,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7139,
+                    "id": 8056,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10073,21 +10073,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6260,
+                    "id": 7094,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6261,
+                    "id": 7095,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6262,
+                    "id": 7096,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10117,19 +10117,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7140,
+                    "id": 8057,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7141,
+                    "id": 8058,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7142,
+                    "id": 8059,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10146,35 +10146,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6263,
+                    "id": 7097,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6264,
+                    "id": 7098,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6265,
+                    "id": 7099,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6266,
+                    "id": 7100,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6267,
+                    "id": 7101,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10205,25 +10205,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7143,
+                    "id": 8060,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7144,
+                    "id": 8061,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7145,
+                    "id": 8062,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7146,
+                    "id": 8063,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10240,35 +10240,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6268,
+                    "id": 7102,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6269,
+                    "id": 7103,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6270,
+                    "id": 7104,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6271,
+                    "id": 7105,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6272,
+                    "id": 7106,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10299,25 +10299,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7147,
+                    "id": 8064,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7148,
+                    "id": 8065,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7149,
+                    "id": 8066,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7150,
+                    "id": 8067,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10334,35 +10334,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6273,
+                    "id": 7107,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6274,
+                    "id": 7108,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6275,
+                    "id": 7109,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6276,
+                    "id": 7110,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6277,
+                    "id": 7111,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10393,25 +10393,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7151,
+                    "id": 8068,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7152,
+                    "id": 8069,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7153,
+                    "id": 8070,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7154,
+                    "id": 8071,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10428,35 +10428,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6278,
+                    "id": 7112,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6279,
+                    "id": 7113,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6280,
+                    "id": 7114,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6281,
+                    "id": 7115,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6282,
+                    "id": 7116,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10487,25 +10487,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7155,
+                    "id": 8072,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7156,
+                    "id": 8073,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7157,
+                    "id": 8074,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7158,
+                    "id": 8075,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10522,35 +10522,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6283,
+                    "id": 7117,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6284,
+                    "id": 7118,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6285,
+                    "id": 7119,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6286,
+                    "id": 7120,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6287,
+                    "id": 7121,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10580,25 +10580,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7159,
+                    "id": 8076,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7160,
+                    "id": 8077,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7161,
+                    "id": 8078,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7162,
+                    "id": 8079,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10615,21 +10615,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6288,
+                    "id": 7122,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6289,
+                    "id": 7123,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6290,
+                    "id": 7124,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10662,25 +10662,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7163,
+                    "id": 8080,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7164,
+                    "id": 8081,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7165,
+                    "id": 8082,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7166,
+                    "id": 8083,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10697,21 +10697,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6291,
+                    "id": 7125,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6292,
+                    "id": 7126,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6293,
+                    "id": 7127,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10744,25 +10744,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7167,
+                    "id": 8084,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7168,
+                    "id": 8085,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7169,
+                    "id": 8086,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7170,
+                    "id": 8087,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10779,21 +10779,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6294,
+                    "id": 7128,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6295,
+                    "id": 7129,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6296,
+                    "id": 7130,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10826,25 +10826,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7171,
+                    "id": 8088,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7172,
+                    "id": 8089,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7173,
+                    "id": 8090,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7174,
+                    "id": 8091,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10861,21 +10861,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6297,
+                    "id": 7131,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6298,
+                    "id": 7132,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6299,
+                    "id": 7133,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10907,25 +10907,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7175,
+                    "id": 8092,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7176,
+                    "id": 8093,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7177,
+                    "id": 8094,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7178,
+                    "id": 8095,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10942,28 +10942,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6300,
+                    "id": 7134,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6301,
+                    "id": 7135,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6302,
+                    "id": 7136,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6303,
+                    "id": 7137,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10994,25 +10994,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7179,
+                    "id": 8096,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7180,
+                    "id": 8097,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7181,
+                    "id": 8098,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7182,
+                    "id": 8099,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11029,28 +11029,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6304,
+                    "id": 7138,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6305,
+                    "id": 7139,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6306,
+                    "id": 7140,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6307,
+                    "id": 7141,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11081,25 +11081,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7183,
+                    "id": 8100,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7184,
+                    "id": 8101,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7185,
+                    "id": 8102,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7186,
+                    "id": 8103,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11116,28 +11116,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6308,
+                    "id": 7142,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6309,
+                    "id": 7143,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6310,
+                    "id": 7144,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6311,
+                    "id": 7145,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11168,25 +11168,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7187,
+                    "id": 8104,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7188,
+                    "id": 8105,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7189,
+                    "id": 8106,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7190,
+                    "id": 8107,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11203,28 +11203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6312,
+                    "id": 7146,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6313,
+                    "id": 7147,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6314,
+                    "id": 7148,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6315,
+                    "id": 7149,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11254,25 +11254,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7191,
+                    "id": 8108,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7192,
+                    "id": 8109,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7193,
+                    "id": 8110,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7194,
+                    "id": 8111,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11289,28 +11289,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6316,
+                    "id": 7150,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6317,
+                    "id": 7151,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6318,
+                    "id": 7152,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6319,
+                    "id": 7153,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11343,25 +11343,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7195,
+                    "id": 8112,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7196,
+                    "id": 8113,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7197,
+                    "id": 8114,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7198,
+                    "id": 8115,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11378,28 +11378,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6320,
+                    "id": 7154,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6321,
+                    "id": 7155,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6322,
+                    "id": 7156,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6323,
+                    "id": 7157,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11432,25 +11432,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7199,
+                    "id": 8116,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7200,
+                    "id": 8117,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7201,
+                    "id": 8118,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7202,
+                    "id": 8119,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11467,28 +11467,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6324,
+                    "id": 7158,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6325,
+                    "id": 7159,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6326,
+                    "id": 7160,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6327,
+                    "id": 7161,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11521,25 +11521,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7203,
+                    "id": 8120,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7204,
+                    "id": 8121,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7205,
+                    "id": 8122,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7206,
+                    "id": 8123,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11556,28 +11556,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6328,
+                    "id": 7162,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6329,
+                    "id": 7163,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6330,
+                    "id": 7164,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6331,
+                    "id": 7165,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11609,25 +11609,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7207,
+                    "id": 8124,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7208,
+                    "id": 8125,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7209,
+                    "id": 8126,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7210,
+                    "id": 8127,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11644,35 +11644,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6332,
+                    "id": 7166,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6333,
+                    "id": 7167,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6334,
+                    "id": 7168,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6335,
+                    "id": 7169,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6336,
+                    "id": 7170,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11707,25 +11707,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7211,
+                    "id": 8128,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7212,
+                    "id": 8129,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7213,
+                    "id": 8130,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7214,
+                    "id": 8131,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11742,35 +11742,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6337,
+                    "id": 7171,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6338,
+                    "id": 7172,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6339,
+                    "id": 7173,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6340,
+                    "id": 7174,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6341,
+                    "id": 7175,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11805,25 +11805,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7215,
+                    "id": 8132,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7216,
+                    "id": 8133,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7217,
+                    "id": 8134,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7218,
+                    "id": 8135,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11840,35 +11840,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6342,
+                    "id": 7176,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6343,
+                    "id": 7177,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6344,
+                    "id": 7178,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6345,
+                    "id": 7179,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6346,
+                    "id": 7180,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11903,25 +11903,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7219,
+                    "id": 8136,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7220,
+                    "id": 8137,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7221,
+                    "id": 8138,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7222,
+                    "id": 8139,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11938,28 +11938,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6347,
+                    "id": 7181,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6348,
+                    "id": 7182,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6349,
+                    "id": 7183,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6350,
+                    "id": 7184,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11992,31 +11992,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7223,
+                    "id": 8140,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7224,
+                    "id": 8141,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7225,
+                    "id": 8142,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7226,
+                    "id": 8143,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7227,
+                    "id": 8144,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12033,28 +12033,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6351,
+                    "id": 7185,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6352,
+                    "id": 7186,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6353,
+                    "id": 7187,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6354,
+                    "id": 7188,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12087,37 +12087,37 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7228,
+                    "id": 8145,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7229,
+                    "id": 8146,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7230,
+                    "id": 8147,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7231,
+                    "id": 8148,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7232,
+                    "id": 8149,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7233,
+                    "id": 8150,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -12134,28 +12134,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6355,
+                    "id": 7189,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6356,
+                    "id": 7190,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6357,
+                    "id": 7191,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6358,
+                    "id": 7192,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12188,31 +12188,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7234,
+                    "id": 8151,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7235,
+                    "id": 8152,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7236,
+                    "id": 8153,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7237,
+                    "id": 8154,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7238,
+                    "id": 8155,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12229,28 +12229,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6359,
+                    "id": 7193,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6360,
+                    "id": 7194,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6361,
+                    "id": 7195,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6362,
+                    "id": 7196,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12283,31 +12283,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7239,
+                    "id": 8156,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7240,
+                    "id": 8157,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7241,
+                    "id": 8158,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7242,
+                    "id": 8159,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7243,
+                    "id": 8160,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12324,35 +12324,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6363,
+                    "id": 7197,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6364,
+                    "id": 7198,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6365,
+                    "id": 7199,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6366,
+                    "id": 7200,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6367,
+                    "id": 7201,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12387,25 +12387,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7244,
+                    "id": 8161,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7245,
+                    "id": 8162,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7246,
+                    "id": 8163,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7247,
+                    "id": 8164,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12422,35 +12422,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6368,
+                    "id": 7202,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6369,
+                    "id": 7203,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6370,
+                    "id": 7204,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6371,
+                    "id": 7205,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6372,
+                    "id": 7206,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12485,25 +12485,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7248,
+                    "id": 8165,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7249,
+                    "id": 8166,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7250,
+                    "id": 8167,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7251,
+                    "id": 8168,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12520,35 +12520,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6373,
+                    "id": 7207,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6374,
+                    "id": 7208,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6375,
+                    "id": 7209,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6376,
+                    "id": 7210,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6377,
+                    "id": 7211,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12582,25 +12582,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7252,
+                    "id": 8169,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7253,
+                    "id": 8170,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7254,
+                    "id": 8171,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7255,
+                    "id": 8172,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12617,28 +12617,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6378,
+                    "id": 7212,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6379,
+                    "id": 7213,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6380,
+                    "id": 7214,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6381,
+                    "id": 7215,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12674,31 +12674,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7256,
+                    "id": 8173,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7257,
+                    "id": 8174,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7258,
+                    "id": 8175,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7259,
+                    "id": 8176,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7260,
+                    "id": 8177,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12715,28 +12715,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6382,
+                    "id": 7216,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6383,
+                    "id": 7217,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6384,
+                    "id": 7218,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6385,
+                    "id": 7219,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12772,31 +12772,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7261,
+                    "id": 8178,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7262,
+                    "id": 8179,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7263,
+                    "id": 8180,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7264,
+                    "id": 8181,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7265,
+                    "id": 8182,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12813,28 +12813,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6386,
+                    "id": 7220,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6387,
+                    "id": 7221,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6388,
+                    "id": 7222,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6389,
+                    "id": 7223,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12870,31 +12870,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7266,
+                    "id": 8183,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7267,
+                    "id": 8184,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7268,
+                    "id": 8185,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7269,
+                    "id": 8186,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7270,
+                    "id": 8187,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12911,28 +12911,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6390,
+                    "id": 7224,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6391,
+                    "id": 7225,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6392,
+                    "id": 7226,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6393,
+                    "id": 7227,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12967,31 +12967,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7271,
+                    "id": 8188,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7272,
+                    "id": 8189,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7273,
+                    "id": 8190,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7274,
+                    "id": 8191,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7275,
+                    "id": 8192,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13008,28 +13008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6394,
+                    "id": 7228,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6395,
+                    "id": 7229,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6396,
+                    "id": 7230,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6397,
+                    "id": 7231,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13065,31 +13065,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7276,
+                    "id": 8193,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7277,
+                    "id": 8194,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7278,
+                    "id": 8195,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7279,
+                    "id": 8196,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7280,
+                    "id": 8197,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13106,28 +13106,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6398,
+                    "id": 7232,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6399,
+                    "id": 7233,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6400,
+                    "id": 7234,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6401,
+                    "id": 7235,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13162,31 +13162,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7281,
+                    "id": 8198,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7282,
+                    "id": 8199,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7283,
+                    "id": 8200,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7284,
+                    "id": 8201,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7285,
+                    "id": 8202,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13203,28 +13203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6402,
+                    "id": 7236,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6403,
+                    "id": 7237,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6404,
+                    "id": 7238,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6405,
+                    "id": 7239,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13254,19 +13254,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7286,
+                    "id": 8203,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7287,
+                    "id": 8204,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7288,
+                    "id": 8205,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13283,28 +13283,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6406,
+                    "id": 7240,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6407,
+                    "id": 7241,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6408,
+                    "id": 7242,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6409,
+                    "id": 7243,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13334,19 +13334,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7289,
+                    "id": 8206,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7290,
+                    "id": 8207,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7291,
+                    "id": 8208,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13363,28 +13363,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6410,
+                    "id": 7244,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6411,
+                    "id": 7245,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6412,
+                    "id": 7246,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6413,
+                    "id": 7247,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13413,19 +13413,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7292,
+                    "id": 8209,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7293,
+                    "id": 8210,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7294,
+                    "id": 8211,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13442,28 +13442,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6414,
+                    "id": 7248,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6415,
+                    "id": 7249,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6416,
+                    "id": 7250,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6417,
+                    "id": 7251,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13493,19 +13493,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7295,
+                    "id": 8212,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7296,
+                    "id": 8213,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7297,
+                    "id": 8214,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13522,28 +13522,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6418,
+                    "id": 7252,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6419,
+                    "id": 7253,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6420,
+                    "id": 7254,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6421,
+                    "id": 7255,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13573,19 +13573,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7298,
+                    "id": 8215,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7299,
+                    "id": 8216,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7300,
+                    "id": 8217,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13602,28 +13602,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6422,
+                    "id": 7256,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6423,
+                    "id": 7257,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6424,
+                    "id": 7258,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6425,
+                    "id": 7259,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13652,19 +13652,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7301,
+                    "id": 8218,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7302,
+                    "id": 8219,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7303,
+                    "id": 8220,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13681,21 +13681,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6426,
+                    "id": 7260,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6427,
+                    "id": 7261,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6428,
+                    "id": 7262,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13728,19 +13728,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7304,
+                    "id": 8221,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7305,
+                    "id": 8222,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7306,
+                    "id": 8223,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13757,21 +13757,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6429,
+                    "id": 7263,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6430,
+                    "id": 7264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6431,
+                    "id": 7265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13803,19 +13803,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7307,
+                    "id": 8224,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7308,
+                    "id": 8225,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7309,
+                    "id": 8226,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13832,21 +13832,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6432,
+                    "id": 7266,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6433,
+                    "id": 7267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6434,
+                    "id": 7268,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13878,19 +13878,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7310,
+                    "id": 8227,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7311,
+                    "id": 8228,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7312,
+                    "id": 8229,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13907,21 +13907,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6435,
+                    "id": 7269,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6436,
+                    "id": 7270,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6437,
+                    "id": 7271,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13953,19 +13953,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7313,
+                    "id": 8230,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7314,
+                    "id": 8231,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7315,
+                    "id": 8232,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13982,28 +13982,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6438,
+                    "id": 7272,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6439,
+                    "id": 7273,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6440,
+                    "id": 7274,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6441,
+                    "id": 7275,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14038,25 +14038,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7316,
+                    "id": 8233,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7317,
+                    "id": 8234,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7318,
+                    "id": 8235,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7319,
+                    "id": 8236,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14073,28 +14073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6442,
+                    "id": 7276,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6443,
+                    "id": 7277,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6444,
+                    "id": 7278,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6445,
+                    "id": 7279,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14129,25 +14129,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7320,
+                    "id": 8237,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7321,
+                    "id": 8238,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7322,
+                    "id": 8239,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7323,
+                    "id": 8240,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14164,28 +14164,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6446,
+                    "id": 7280,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6447,
+                    "id": 7281,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6448,
+                    "id": 7282,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6449,
+                    "id": 7283,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14220,25 +14220,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7324,
+                    "id": 8241,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7325,
+                    "id": 8242,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7326,
+                    "id": 8243,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7327,
+                    "id": 8244,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14255,28 +14255,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6450,
+                    "id": 7284,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6451,
+                    "id": 7285,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6452,
+                    "id": 7286,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6453,
+                    "id": 7287,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14310,25 +14310,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7328,
+                    "id": 8245,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7329,
+                    "id": 8246,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7330,
+                    "id": 8247,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7331,
+                    "id": 8248,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14345,21 +14345,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6454,
+                    "id": 7288,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6455,
+                    "id": 7289,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6456,
+                    "id": 7290,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14390,25 +14390,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7332,
+                    "id": 8249,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7333,
+                    "id": 8250,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7334,
+                    "id": 8251,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7335,
+                    "id": 8252,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14425,21 +14425,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6457,
+                    "id": 7291,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6458,
+                    "id": 7292,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6459,
+                    "id": 7293,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14470,25 +14470,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7336,
+                    "id": 8253,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7337,
+                    "id": 8254,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7338,
+                    "id": 8255,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7339,
+                    "id": 8256,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14505,21 +14505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6460,
+                    "id": 7294,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6461,
+                    "id": 7295,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6462,
+                    "id": 7296,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14549,25 +14549,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7340,
+                    "id": 8257,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7341,
+                    "id": 8258,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7342,
+                    "id": 8259,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7343,
+                    "id": 8260,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14584,21 +14584,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6463,
+                    "id": 7297,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6464,
+                    "id": 7298,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6465,
+                    "id": 7299,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14629,25 +14629,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7344,
+                    "id": 8261,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7345,
+                    "id": 8262,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7346,
+                    "id": 8263,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7347,
+                    "id": 8264,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14664,21 +14664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6466,
+                    "id": 7300,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6467,
+                    "id": 7301,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6468,
+                    "id": 7302,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14708,25 +14708,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7348,
+                    "id": 8265,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7349,
+                    "id": 8266,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7350,
+                    "id": 8267,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7351,
+                    "id": 8268,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14743,35 +14743,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6469,
+                    "id": 7303,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6470,
+                    "id": 7304,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6471,
+                    "id": 7305,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6472,
+                    "id": 7306,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6473,
+                    "id": 7307,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14804,31 +14804,31 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7352,
+                    "id": 8269,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7353,
+                    "id": 8270,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7354,
+                    "id": 8271,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7355,
+                    "id": 8272,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7356,
+                    "id": 8273,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "3"
@@ -14845,35 +14845,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6474,
+                    "id": 7308,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6475,
+                    "id": 7309,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6476,
+                    "id": 7310,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6477,
+                    "id": 7311,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6478,
+                    "id": 7312,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14906,25 +14906,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7357,
+                    "id": 8274,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7358,
+                    "id": 8275,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7359,
+                    "id": 8276,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7360,
+                    "id": 8277,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14941,35 +14941,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6479,
+                    "id": 7313,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6480,
+                    "id": 7314,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6481,
+                    "id": 7315,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6482,
+                    "id": 7316,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6483,
+                    "id": 7317,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15001,25 +15001,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7361,
+                    "id": 8278,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7362,
+                    "id": 8279,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7363,
+                    "id": 8280,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7364,
+                    "id": 8281,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15036,35 +15036,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6484,
+                    "id": 7318,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6485,
+                    "id": 7319,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6486,
+                    "id": 7320,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6487,
+                    "id": 7321,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6488,
+                    "id": 7322,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15096,25 +15096,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7365,
+                    "id": 8282,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7366,
+                    "id": 8283,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7367,
+                    "id": 8284,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7368,
+                    "id": 8285,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15131,28 +15131,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6489,
+                    "id": 7323,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6490,
+                    "id": 7324,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6491,
+                    "id": 7325,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6492,
+                    "id": 7326,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 }
@@ -15184,25 +15184,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7369,
+                    "id": 8286,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7370,
+                    "id": 8287,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7371,
+                    "id": 8288,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7372,
+                    "id": 8289,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15219,28 +15219,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6493,
+                    "id": 7327,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6494,
+                    "id": 7328,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6495,
+                    "id": 7329,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6496,
+                    "id": 7330,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15272,25 +15272,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7373,
+                    "id": 8290,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7374,
+                    "id": 8291,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7375,
+                    "id": 8292,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7376,
+                    "id": 8293,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15307,28 +15307,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6497,
+                    "id": 7331,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6498,
+                    "id": 7332,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6499,
+                    "id": 7333,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6500,
+                    "id": 7334,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15360,25 +15360,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7377,
+                    "id": 8294,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7378,
+                    "id": 8295,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7379,
+                    "id": 8296,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7380,
+                    "id": 8297,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15395,28 +15395,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6501,
+                    "id": 7335,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6502,
+                    "id": 7336,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6503,
+                    "id": 7337,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6504,
+                    "id": 7338,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15448,25 +15448,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7381,
+                    "id": 8298,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7382,
+                    "id": 8299,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7383,
+                    "id": 8300,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7384,
+                    "id": 8301,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15483,28 +15483,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6505,
+                    "id": 7339,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6506,
+                    "id": 7340,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6507,
+                    "id": 7341,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6508,
+                    "id": 7342,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15535,25 +15535,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7385,
+                    "id": 8302,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7386,
+                    "id": 8303,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7387,
+                    "id": 8304,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7388,
+                    "id": 8305,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15570,28 +15570,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6509,
+                    "id": 7343,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6510,
+                    "id": 7344,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6511,
+                    "id": 7345,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6512,
+                    "id": 7346,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15621,25 +15621,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7389,
+                    "id": 8306,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7390,
+                    "id": 8307,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7391,
+                    "id": 8308,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7392,
+                    "id": 8309,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15656,28 +15656,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6513,
+                    "id": 7347,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6514,
+                    "id": 7348,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6515,
+                    "id": 7349,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6516,
+                    "id": 7350,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15707,25 +15707,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7393,
+                    "id": 8310,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7394,
+                    "id": 8311,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7395,
+                    "id": 8312,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7396,
+                    "id": 8313,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15742,28 +15742,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6517,
+                    "id": 7351,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6518,
+                    "id": 7352,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6519,
+                    "id": 7353,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6520,
+                    "id": 7354,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15793,25 +15793,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7397,
+                    "id": 8314,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7398,
+                    "id": 8315,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7399,
+                    "id": 8316,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7400,
+                    "id": 8317,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15828,28 +15828,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6521,
+                    "id": 7355,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6522,
+                    "id": 7356,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6523,
+                    "id": 7357,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6524,
+                    "id": 7358,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15879,25 +15879,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7401,
+                    "id": 8318,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7402,
+                    "id": 8319,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7403,
+                    "id": 8320,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7404,
+                    "id": 8321,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15914,28 +15914,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6525,
+                    "id": 7359,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6526,
+                    "id": 7360,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6527,
+                    "id": 7361,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6528,
+                    "id": 7362,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15964,25 +15964,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7405,
+                    "id": 8322,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7406,
+                    "id": 8323,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7407,
+                    "id": 8324,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7408,
+                    "id": 8325,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15999,28 +15999,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6529,
+                    "id": 7363,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6530,
+                    "id": 7364,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6531,
+                    "id": 7365,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6532,
+                    "id": 7366,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16049,25 +16049,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7409,
+                    "id": 8326,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7410,
+                    "id": 8327,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7411,
+                    "id": 8328,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7412,
+                    "id": 8329,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16084,28 +16084,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6533,
+                    "id": 7367,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6534,
+                    "id": 7368,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6535,
+                    "id": 7369,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6536,
+                    "id": 7370,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16135,25 +16135,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7413,
+                    "id": 8330,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7414,
+                    "id": 8331,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7415,
+                    "id": 8332,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7416,
+                    "id": 8333,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16170,28 +16170,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6537,
+                    "id": 7371,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6538,
+                    "id": 7372,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6539,
+                    "id": 7373,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6540,
+                    "id": 7374,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16220,25 +16220,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7417,
+                    "id": 8334,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7418,
+                    "id": 8335,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7419,
+                    "id": 8336,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7420,
+                    "id": 8337,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16255,21 +16255,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6541,
+                    "id": 7375,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6542,
+                    "id": 7376,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6543,
+                    "id": 7377,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16302,25 +16302,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7421,
+                    "id": 8338,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7422,
+                    "id": 8339,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7423,
+                    "id": 8340,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7424,
+                    "id": 8341,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16337,21 +16337,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6544,
+                    "id": 7378,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6545,
+                    "id": 7379,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6546,
+                    "id": 7380,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16384,25 +16384,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7425,
+                    "id": 8342,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7426,
+                    "id": 8343,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7427,
+                    "id": 8344,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7428,
+                    "id": 8345,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16419,21 +16419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6547,
+                    "id": 7381,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6548,
+                    "id": 7382,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6549,
+                    "id": 7383,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16466,25 +16466,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7429,
+                    "id": 8346,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7430,
+                    "id": 8347,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7431,
+                    "id": 8348,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7432,
+                    "id": 8349,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16501,21 +16501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6550,
+                    "id": 7384,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6551,
+                    "id": 7385,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6552,
+                    "id": 7386,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16547,25 +16547,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7433,
+                    "id": 8350,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7434,
+                    "id": 8351,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7435,
+                    "id": 8352,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7436,
+                    "id": 8353,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16582,21 +16582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6553,
+                    "id": 7387,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6554,
+                    "id": 7388,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6555,
+                    "id": 7389,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16629,25 +16629,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7437,
+                    "id": 8354,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7438,
+                    "id": 8355,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7439,
+                    "id": 8356,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7440,
+                    "id": 8357,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16664,21 +16664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6556,
+                    "id": 7390,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6557,
+                    "id": 7391,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6558,
+                    "id": 7392,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16710,25 +16710,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7441,
+                    "id": 8358,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7442,
+                    "id": 8359,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7443,
+                    "id": 8360,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7444,
+                    "id": 8361,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16745,28 +16745,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6559,
+                    "id": 7393,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6560,
+                    "id": 7394,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6561,
+                    "id": 7395,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6562,
+                    "id": 7396,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16801,25 +16801,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7445,
+                    "id": 8362,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7446,
+                    "id": 8363,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7447,
+                    "id": 8364,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7448,
+                    "id": 8365,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16836,28 +16836,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6563,
+                    "id": 7397,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6564,
+                    "id": 7398,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6565,
+                    "id": 7399,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6566,
+                    "id": 7400,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16892,25 +16892,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7449,
+                    "id": 8366,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7450,
+                    "id": 8367,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7451,
+                    "id": 8368,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7452,
+                    "id": 8369,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16927,28 +16927,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6567,
+                    "id": 7401,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6568,
+                    "id": 7402,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6569,
+                    "id": 7403,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6570,
+                    "id": 7404,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16983,25 +16983,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7453,
+                    "id": 8370,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7454,
+                    "id": 8371,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7455,
+                    "id": 8372,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7456,
+                    "id": 8373,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17018,28 +17018,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6571,
+                    "id": 7405,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6572,
+                    "id": 7406,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6573,
+                    "id": 7407,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6574,
+                    "id": 7408,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17074,25 +17074,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7457,
+                    "id": 8374,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7458,
+                    "id": 8375,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7459,
+                    "id": 8376,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7460,
+                    "id": 8377,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17109,21 +17109,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6575,
+                    "id": 7409,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6576,
+                    "id": 7410,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6577,
+                    "id": 7411,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17156,25 +17156,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7461,
+                    "id": 8378,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7462,
+                    "id": 8379,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7463,
+                    "id": 8380,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7464,
+                    "id": 8381,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17191,21 +17191,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6578,
+                    "id": 7412,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6579,
+                    "id": 7413,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6580,
+                    "id": 7414,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17238,25 +17238,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7465,
+                    "id": 8382,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7466,
+                    "id": 8383,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7467,
+                    "id": 8384,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7468,
+                    "id": 8385,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17273,21 +17273,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6581,
+                    "id": 7415,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6582,
+                    "id": 7416,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6583,
+                    "id": 7417,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17319,25 +17319,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7469,
+                    "id": 8386,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7470,
+                    "id": 8387,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7471,
+                    "id": 8388,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7472,
+                    "id": 8389,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17354,21 +17354,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6584,
+                    "id": 7418,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6585,
+                    "id": 7419,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6586,
+                    "id": 7420,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17402,31 +17402,31 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7473,
+                    "id": 8390,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7474,
+                    "id": 8391,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7475,
+                    "id": 8392,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7476,
+                    "id": 8393,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7477,
+                    "id": 8394,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -17443,21 +17443,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6587,
+                    "id": 7421,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6588,
+                    "id": 7422,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6589,
+                    "id": 7423,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17491,25 +17491,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7478,
+                    "id": 8395,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7479,
+                    "id": 8396,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7480,
+                    "id": 8397,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7481,
+                    "id": 8398,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17526,21 +17526,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6590,
+                    "id": 7424,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6591,
+                    "id": 7425,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6592,
+                    "id": 7426,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17573,25 +17573,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7482,
+                    "id": 8399,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7483,
+                    "id": 8400,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7484,
+                    "id": 8401,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7485,
+                    "id": 8402,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17608,28 +17608,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6593,
+                    "id": 7427,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6594,
+                    "id": 7428,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6595,
+                    "id": 7429,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6596,
+                    "id": 7430,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17662,25 +17662,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7486,
+                    "id": 8403,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7487,
+                    "id": 8404,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7488,
+                    "id": 8405,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7489,
+                    "id": 8406,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17697,28 +17697,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6597,
+                    "id": 7431,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6598,
+                    "id": 7432,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6599,
+                    "id": 7433,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6600,
+                    "id": 7434,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17751,31 +17751,31 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7490,
+                    "id": 8407,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7491,
+                    "id": 8408,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7492,
+                    "id": 8409,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7493,
+                    "id": 8410,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7494,
+                    "id": 8411,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -17792,28 +17792,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6601,
+                    "id": 7435,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6602,
+                    "id": 7436,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6603,
+                    "id": 7437,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6604,
+                    "id": 7438,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17846,25 +17846,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7495,
+                    "id": 8412,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7496,
+                    "id": 8413,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7497,
+                    "id": 8414,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7498,
+                    "id": 8415,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17881,21 +17881,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6605,
+                    "id": 7439,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6606,
+                    "id": 7440,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6607,
+                    "id": 7441,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17931,25 +17931,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7499,
+                    "id": 8416,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7500,
+                    "id": 8417,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7501,
+                    "id": 8418,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7502,
+                    "id": 8419,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17966,21 +17966,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6608,
+                    "id": 7442,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6609,
+                    "id": 7443,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6610,
+                    "id": 7444,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18016,31 +18016,31 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7503,
+                    "id": 8420,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7504,
+                    "id": 8421,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7505,
+                    "id": 8422,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7506,
+                    "id": 8423,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7507,
+                    "id": 8424,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -18057,21 +18057,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6611,
+                    "id": 7445,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6612,
+                    "id": 7446,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6613,
+                    "id": 7447,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18107,25 +18107,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7508,
+                    "id": 8425,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7509,
+                    "id": 8426,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7510,
+                    "id": 8427,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7511,
+                    "id": 8428,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18142,21 +18142,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6614,
+                    "id": 7448,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6615,
+                    "id": 7449,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6616,
+                    "id": 7450,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18191,25 +18191,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7512,
+                    "id": 8429,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7513,
+                    "id": 8430,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7514,
+                    "id": 8431,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7515,
+                    "id": 8432,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18226,21 +18226,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6617,
+                    "id": 7451,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6618,
+                    "id": 7452,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6619,
+                    "id": 7453,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18273,31 +18273,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7516,
+                    "id": 8433,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7517,
+                    "id": 8434,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7518,
+                    "id": 8435,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7519,
+                    "id": 8436,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7520,
+                    "id": 8437,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -18314,21 +18314,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6620,
+                    "id": 7454,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6621,
+                    "id": 7455,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6622,
+                    "id": 7456,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18346,7 +18346,7 @@
                 6
             ],
             "card_type_id": 1,
-            "cost": "54",
+            "cost": "56",
             "faction_id": 3,
             "ffg_id": "XW_P_215",
             "force_side": null,
@@ -18356,30 +18356,30 @@
             "is_unique": true,
             "name": "•Manaroo",
             "restrictions": [],
-            "ship_ability_text": null,
+            "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7521,
+                    "id": 8438,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7522,
+                    "id": 8439,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7523,
+                    "id": 8440,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7524,
+                    "id": 8441,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18396,21 +18396,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6623,
+                    "id": 7457,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6624,
+                    "id": 7458,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6625,
+                    "id": 7459,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18443,31 +18443,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7525,
+                    "id": 8442,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7526,
+                    "id": 8443,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7527,
+                    "id": 8444,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7528,
+                    "id": 8445,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7529,
+                    "id": 8446,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -18484,21 +18484,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6626,
+                    "id": 7460,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6627,
+                    "id": 7461,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6628,
+                    "id": 7462,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18530,25 +18530,25 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7530,
+                    "id": 8447,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7531,
+                    "id": 8448,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7532,
+                    "id": 8449,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7533,
+                    "id": 8450,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18565,28 +18565,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6629,
+                    "id": 7463,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6630,
+                    "id": 7464,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6631,
+                    "id": 7465,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6632,
+                    "id": 7466,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18619,31 +18619,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7534,
+                    "id": 8451,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7535,
+                    "id": 8452,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7536,
+                    "id": 8453,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7537,
+                    "id": 8454,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7538,
+                    "id": 8455,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18660,28 +18660,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6633,
+                    "id": 7467,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6634,
+                    "id": 7468,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6635,
+                    "id": 7469,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6636,
+                    "id": 7470,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18714,37 +18714,37 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7539,
+                    "id": 8456,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7540,
+                    "id": 8457,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7541,
+                    "id": 8458,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7542,
+                    "id": 8459,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7543,
+                    "id": 8460,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7544,
+                    "id": 8461,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -18761,28 +18761,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6637,
+                    "id": 7471,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6638,
+                    "id": 7472,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6639,
+                    "id": 7473,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6640,
+                    "id": 7474,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18815,31 +18815,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7545,
+                    "id": 8462,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7546,
+                    "id": 8463,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7547,
+                    "id": 8464,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7548,
+                    "id": 8465,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7549,
+                    "id": 8466,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18856,28 +18856,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6641,
+                    "id": 7475,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6642,
+                    "id": 7476,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6643,
+                    "id": 7477,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6644,
+                    "id": 7478,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18909,31 +18909,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7550,
+                    "id": 8467,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7551,
+                    "id": 8468,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7552,
+                    "id": 8469,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7553,
+                    "id": 8470,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7554,
+                    "id": 8471,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18950,28 +18950,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6645,
+                    "id": 7479,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6646,
+                    "id": 7480,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6647,
+                    "id": 7481,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6648,
+                    "id": 7482,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19006,25 +19006,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7555,
+                    "id": 8472,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7556,
+                    "id": 8473,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7557,
+                    "id": 8474,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7558,
+                    "id": 8475,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19041,28 +19041,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6649,
+                    "id": 7483,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6650,
+                    "id": 7484,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6651,
+                    "id": 7485,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6652,
+                    "id": 7486,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19097,25 +19097,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7559,
+                    "id": 8476,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7560,
+                    "id": 8477,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7561,
+                    "id": 8478,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7562,
+                    "id": 8479,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19132,28 +19132,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6653,
+                    "id": 7487,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6654,
+                    "id": 7488,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6655,
+                    "id": 7489,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6656,
+                    "id": 7490,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19187,25 +19187,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7563,
+                    "id": 8480,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7564,
+                    "id": 8481,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7565,
+                    "id": 8482,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7566,
+                    "id": 8483,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19222,28 +19222,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 7491,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 7492,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 7493,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 7494,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19277,25 +19277,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 8484,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 8485,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 8486,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 8487,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19312,21 +19312,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6661,
+                    "id": 7495,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6662,
+                    "id": 7496,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6663,
+                    "id": 7497,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19356,25 +19356,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7571,
+                    "id": 8488,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7572,
+                    "id": 8489,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7573,
+                    "id": 8490,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7574,
+                    "id": 8491,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19391,21 +19391,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6664,
+                    "id": 7498,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6665,
+                    "id": 7499,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6666,
+                    "id": 7500,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19435,25 +19435,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7575,
+                    "id": 8492,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7576,
+                    "id": 8493,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7577,
+                    "id": 8494,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7578,
+                    "id": 8495,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19470,21 +19470,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6667,
+                    "id": 7501,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6668,
+                    "id": 7502,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6669,
+                    "id": 7503,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19514,25 +19514,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 8496,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7580,
+                    "id": 8497,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7581,
+                    "id": 8498,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7582,
+                    "id": 8499,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19549,21 +19549,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6670,
+                    "id": 7504,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6671,
+                    "id": 7505,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6672,
+                    "id": 7506,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19589,31 +19589,31 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7583,
+                    "id": 8500,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7584,
+                    "id": 8501,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7585,
+                    "id": 8502,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7586,
+                    "id": 8503,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7587,
+                    "id": 8504,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "3"
@@ -20685,7 +20685,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
@@ -20724,7 +20724,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wszystkie wyniki <hit>/<crit> przydzielają żetony zakłócania zamiast uszkodzeń.",
@@ -20763,7 +20763,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wszystkie wyniki <hit>/<crit> przydzielają żetony wiązki ściągającej zamiast uszkodzeń.",
@@ -20802,7 +20802,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak</smallcaps>",
@@ -20849,7 +20849,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Atak:</smallcaps> Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
@@ -20897,7 +20897,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>): </smallcaps>Wydaj 1 <standardcharge>. Zmień 1 wynik <hit> na wynik <crit>.",
@@ -20989,7 +20989,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Zmień 1 wynik <hit> na wynik <crit>.",
@@ -21036,7 +21036,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><focus><smallcaps>):</smallcaps> Wydaj 1<nonbreak><standardcharge>. Jeżeli obrońca znajduje się w twojej <bullseye>, możesz wydać 1 albo więcej <standardcharge>, aby przerzucić tyle samo kości ataku.",
@@ -21080,7 +21080,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Po wykonaniu tego ataku możesz wykonać go raz jeszcze jako dodatkowy atak przeciwko innemu celowi w zasięgu 0–1 od obrońcy, ignorując wymaganie <targetlock>.",
@@ -21126,7 +21126,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Gdy ten atak trafi, każdy statek w zasięgu 0–1 od obrońcy odkrywa 1 ze swoich kart uszkodzeń.",
@@ -21172,7 +21172,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Gdy wyznaczysz obrońcę, obrońca może zdecydować, że przyjmuje 1 uszkodzenie <hit>. Jeżeli tak zrobi, etapy rzutów ataku i obrony są pomijane, a atak jest traktowany jako trafienie.",
@@ -21217,7 +21217,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><targetlock><smallcaps>):</smallcaps> Wydaj 1 <standardcharge>. Jeżeli ten atak trafi, wydaj 1 wynik <hit> albo <crit>, aby obrońca przyjął 1 uszkodzenie <hit>. Wszystkie pozostałe wyniki <hit>/<crit> przydzielają żetony jonizacji zamiast uszkodzeń.",
@@ -21262,7 +21262,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Atak (</smallcaps><focus><smallcaps>):</smallcaps> Wydaj 1<nonbreak><standardcharge>.",
@@ -21307,7 +21307,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "Gdy się bronisz, przed rzutami ataku możesz wydać twoje namierzenie z atakującego statku, aby rzucić 1 kością ataku. Jeżeli tak zrobisz, atakujący otrzymuje 1 żeton zakłócania. Następnie, jeżeli wypadnie <hit> albo <crit>, otrzymujesz 1 żeton zakłócania.",

--- a/translation_helper/api_export_pt.json
+++ b/translation_helper/api_export_pt.json
@@ -1,6 +1,745 @@
 {
     "cards": [
         {
+            "ability_text": "Quando você realizar umataque, o defensor rola1 dado de defesa a menos.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5839,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5840,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5841,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_1",
+            "force_side": null,
+            "id": 1,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Wedge Antilles",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6671,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6672,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6673,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6674,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Vermelho Dois",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após se tornar o defensor(antes de rolar os dados),você pode recuperar 1 <forcecharge>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5842,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5843,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5844,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                17,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "62",
+            "faction_id": 1,
+            "ffg_id": "XW_P_2",
+            "force_side": 2,
+            "id": 2,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Luke Skywalker",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6675,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6676,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6677,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6678,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 6679,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Vermelho Cinco",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar um ataque,você pode gastar 1 resultado<nonbreak><focus>, <hit>, ou <crit>para olhar as cartas de danoviradas para baixo do defensor,escolher 1 e virá-la para cima.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5845,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5846,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5847,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_set_ids": [
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_3",
+            "force_side": null,
+            "id": 3,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Thane Kyrell",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6680,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6681,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6682,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6683,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Corona Quatro",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após gastar 1 ficha de foco, você pode escolher 1 nave amiga em alcance 1-3.A nave escolhida recebe 1 ficha de foco.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5848,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5849,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5850,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_4",
+            "force_side": null,
+            "id": 4,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6684,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6685,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6686,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6687,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Líder Vermelho",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após receber uma ficha deestresse, você pode rolar 1 dadode ataque para removê-la. Em um resultado <hit>, sofra 1 dano <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5851,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5852,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5853,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
+            "card_set_ids": [
+                1
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_5",
+            "force_side": null,
+            "id": 5,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Jek Porkins",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6688,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6689,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6690,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6691,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Vermelho Seis",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar uma ação <barrelroll> ou <boost>,você pode virar sua carta demelhoria <config> equipada.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5854,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5855,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5856,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_6",
+            "force_side": null,
+            "id": 6,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kullbee Sperado",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6692,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6693,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6694,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6695,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Atirador Enigmático",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando outra nave amiga emalcance 0-1 defender, antes da etapa Neutralizar Resultados, se vocêestiver no arco de ataque, você podesofrer 1<nonbreak>dano <hit> ou <crit> paracancelar 1 resultado correspondente.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5857,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5858,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5859,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
+            "card_set_ids": [
+                4,
+                7
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_7",
+            "force_side": null,
+            "id": 7,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Biggs Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6696,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6697,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6698,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6699,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Vermelho Três",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar uma ação <barrelroll> ou <boost>, você pode realizar uma ação vermelha <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5860,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5861,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5862,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_8",
+            "force_side": null,
+            "id": 8,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Leevan Tenza",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6700,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6701,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6702,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6703,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Desertor da Aliança Rebelde",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de ativar, se estiver focado, você pode realizar uma ação.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5863,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5864,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5865,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                10,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_9",
+            "force_side": null,
+            "id": 9,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Edrio Two Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 33,
+            "statistics": [
+                {
+                    "id": 6704,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6705,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6706,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6707,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Veterano dos Cavern Angels",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Criado para ser um esquadrão de caçasestelares de elite, o Esquadrão Vermelho inclui alguns dos melhores pilotos da Aliança Rebelde.</flavor>",
             "available_actions": [
                 {
@@ -84,164 +823,164 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Quando você realizar umataque, o defensor rola1 dado de defesa a menos.",
+            "ability_text": "<flavor>Projetada pela Incom Corporation,a X-wing T-65 se mostrou rapidamenteser um dos veículos militares mais efetivosda galáxia e uma dádiva para a Rebelião.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 5869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 5870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 5871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_1.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
             "card_set_ids": [
+                1,
                 4,
                 7
             ],
             "card_type_id": 1,
-            "cost": "52",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_1",
+            "ffg_id": "XW_P_11",
             "force_side": null,
-            "id": 1,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_1.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Wedge Antilles",
+            "id": 11,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Escolta do Esq. Azul",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 6712,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 6713,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 6714,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 6715,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Vermelho Dois",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "Quando realizar um ataque,você pode gastar 1 resultado<nonbreak><focus>, <hit>, ou <crit>para olhar as cartas de danoviradas para baixo do defensor,escolher 1 e virá-la para cima.",
+            "ability_text": "<flavor>Diferente da maioria das células Rebeldes, os partidários de Saw Gerrera estão dispostos a usar métodos extremos para minar os objetivos do Império Galático em batalhas brutais que vão de Geonosis à Jedha.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 5872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 5873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 5874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 5,
                 10,
+                13,
                 14,
                 18
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_3.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
             "card_set_ids": [
-                7
+                2
             ],
             "card_type_id": 1,
-            "cost": "48",
+            "cost": "41",
             "faction_id": 1,
-            "ffg_id": "XW_P_3",
+            "ffg_id": "XW_P_12",
             "force_side": null,
-            "id": 3,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_3.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Thane Kyrell",
+            "id": 12,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Fanático dos Cavern Angels",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 6716,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 6717,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 6718,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 6719,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Corona Quatro",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -332,343 +1071,6 @@
                 }
             ],
             "subtitle": "Dourado Nove",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após gastar 1 ficha de foco, você pode escolher 1 nave amiga em alcance 1-3.A nave escolhida recebe 1 ficha de foco.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5848,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5849,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5850,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_4.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_4",
-            "force_side": null,
-            "id": 4,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_4.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6684,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6685,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6686,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6687,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Líder Vermelho",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Projetada pela Incom Corporation,a X-wing T-65 se mostrou rapidamenteser um dos veículos militares mais efetivosda galáxia e uma dádiva para a Rebelião.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5869,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5870,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5871,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_11",
-            "force_side": null,
-            "id": 11,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_11.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Escolta do Esq. Azul",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6712,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6713,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6714,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6715,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar um ataque, você pode rerrolar 1 dado de ataque para cada outra nave amiga em alcance 0-1 do defensor.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5883,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5884,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5885,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5886,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
-            "card_set_ids": [
-                4,
-                8
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_15",
-            "force_side": null,
-            "id": 15,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Horton Salm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 6728,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6729,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6730,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6731,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Líder Cinza",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar uma ação <barrelroll> ou <boost>,você pode virar sua carta demelhoria <config> equipada.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5854,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5855,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5856,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_6.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_6",
-            "force_side": null,
-            "id": 6,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_6.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kullbee Sperado",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6692,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6693,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6694,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6695,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Atirador Enigmático",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -765,42 +1167,183 @@
             "weapon_range": null
         },
         {
-            "ability_text": "No início da Fase Final, você pode gastar 1 ficha de foco para reparar1 de suas cartas de dano viradas para cima.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
+            "ability_text": "Quando realizar um ataque, você pode rerrolar 1 dado de ataque para cada outra nave amiga em alcance 0-1 do defensor.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5883,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5884,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5885,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5886,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_15.png",
             "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_157",
-            "force_side": null,
-            "id": 382,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
+                4,
                 8
             ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_15",
+            "force_side": null,
+            "id": 15,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_15.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Horton Salm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6728,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6729,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6730,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6731,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Líder Cinza",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento, você pode gastar 1 ficha de foco para escolher uma nave amiga em alcance 0-1. Se você fizer isso, a nave escolhida rola 1 dadode defesa adicional quando defender atéo final da rodada.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5887,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5888,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5889,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 5890,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_set_ids": [
+                8
+            ],
+            "card_type_id": 1,
+            "cost": "36",
+            "faction_id": 1,
+            "ffg_id": "XW_P_16",
+            "force_side": null,
+            "id": 16,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Evaan Verlaine",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 6732,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6733,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6734,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6735,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Dourado Três",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -896,39 +1439,38 @@
             "weapon_range": null
         },
         {
-            "ability_text": "No início da Fase de Engajamento, você pode gastar 1 ficha de foco para escolher uma nave amiga em alcance 0-1. Se você fizer isso, a nave escolhida rola 1 dadode defesa adicional quando defender atéo final da rodada.",
+            "ability_text": "<flavor>Muito tempo depois de a Y-wing ser descontinuada pelo Império Galático, sua durabilidade, confiabilidade e armamento pesado ainda fazdela um recurso fundamental à frota Rebelde.</flavor>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 5895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 5896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 5897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 5898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                1,
                 4,
                 5,
                 10,
@@ -936,51 +1478,52 @@
                 14,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_16.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
             "card_set_ids": [
+                4,
                 8
             ],
             "card_type_id": 1,
-            "cost": "36",
+            "cost": "32",
             "faction_id": 1,
-            "ffg_id": "XW_P_16",
+            "ffg_id": "XW_P_18",
             "force_side": null,
-            "id": 16,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_16.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Evaan Verlaine",
+            "id": 18,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Bombardeiro do Esquadrão Cinza",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 6740,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 6741,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 6742,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 6743,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Dourado Três",
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1078,167 +1621,179 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Após realizar uma ação <barrelroll> ou <boost>, você pode realizar uma ação vermelha <evade>.",
+            "ability_text": "Você consegue realizar ataquesprimários em alcance 0.<return>Se você for falhar em uma ação <boost> porque sobrepôs outra nave, em vez disso, resolva-a como se estivesse executando parcialmente uma manobra.<return><sabold>Propulsores Vetorizados:</sabold> Após realizaruma ação, você pode realizar uma ação<boost> vermelha.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 5904,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 5906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 5907,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                5,
-                10,
-                13,
-                14,
-                18
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_8.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
             "card_set_ids": [
-                2
+                4
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_8",
+            "ffg_id": "XW_P_20",
             "force_side": null,
-            "id": 8,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_8.jpg",
+            "id": 20,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
             "initiative": 3,
             "is_unique": true,
-            "name": "•Leevan Tenza",
+            "name": "•Arvel Crynyd",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 33,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 6748,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6701,
-                    "recurring": false,
-                    "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 6749,
                     "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
+                    "statistic_id": 1,
+                    "value": "3"
                 },
                 {
-                    "id": 6703,
+                    "id": 6750,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6751,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Desertor da Aliança Rebelde",
+            "subtitle": "Líder Verde",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Muito tempo depois de a Y-wing ser descontinuada pelo Império Galático, sua durabilidade, confiabilidade e armamento pesado ainda fazdela um recurso fundamental à frota Rebelde.</flavor>",
+            "ability_text": "<flavor>Devido aos seus controles sensitivos e alta manobrabilidade, somente os pilotos mais talentosos ocupavam a cabine de uma A-wing.</flavor><return><sabold>Propulsores Vetorizados:</sabold>Após realizar uma ação, você poderealizar uma ação <boost> vermelha.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 5909,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 5911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "base_action_side_effect": null,
+                    "id": 5912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 5913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
-                4,
-                5,
-                10,
-                12,
-                14,
-                16
+                1,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_18.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
             "card_set_ids": [
-                4,
-                8
+                4
             ],
             "card_type_id": 1,
-            "cost": "32",
+            "cost": "34",
             "faction_id": 1,
-            "ffg_id": "XW_P_18",
+            "ffg_id": "XW_P_21",
             "force_side": null,
-            "id": 18,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_18.jpg",
-            "initiative": 2,
+            "id": 21,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
+            "initiative": 3,
             "is_unique": false,
-            "name": "Bombardeiro do Esquadrão Cinza",
+            "name": "Piloto do Esq. Verde",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 12,
+            "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 6752,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 6753,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "1"
+                    "value": "3"
                 },
                 {
-                    "id": 6742,
+                    "id": 6754,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "6"
+                    "value": "2"
                 },
                 {
-                    "id": 6743,
+                    "id": 6755,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1246,46 +1801,6 @@
             ],
             "subtitle": "",
             "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando tiver exatamente 1 fichade desarmamento, você ainda consegue realizar ataques <torpedo> e <missile> contra alvosnos quais você tem uma mira travada.Se fizer isso, você não pode gastarsua trava de mira durante este ataque.<return>Adicione os encaixes de melhoria <torpedo> e <missile>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_125",
-            "force_side": null,
-            "id": 350,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Carga de Arsenal Os-1",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 14,
-                            "raw_name": "Alpha-class Star Wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -1381,93 +1896,3985 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Você consegue realizar ataquesprimários em alcance 0.<return>Se você for falhar em uma ação <boost> porque sobrepôs outra nave, em vez disso, resolva-a como se estivesse executando parcialmente uma manobra.<return><sabold>Propulsores Vetorizados:</sabold> Após realizaruma ação, você pode realizar uma ação<boost> vermelha.",
+            "ability_text": "Quando defender ou realizar um ataque, se estiver estressado, você tem a opção de rerrolar até 2 de seus dados.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5905,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
+                    "id": 5919,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 5920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 5921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
                 1,
-                6
+                2,
+                3,
+                3,
+                5,
+                14
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_20.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_23",
+            "force_side": null,
+            "id": 23,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Braylen Stramm",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6760,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6761,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6762,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6763,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Líder Lâmina",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando defender ou realizar um ataque, você pode gastar 1 fichade estresse para mudar todosos seus resultados <focus> para resultados <evade> ou <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5922,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5923,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5924,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_24",
+            "force_side": null,
+            "id": 24,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Ten Numb",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6764,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6765,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6766,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6767,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Azul Cinco",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Um sistema de estabilização giroscópica único foi projetado em volta da cabine da B-wing, garantindo que o piloto permaneça estacionário durante o voo.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5925,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5926,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5927,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 1,
+            "ffg_id": "XW_P_25",
+            "force_side": null,
+            "id": 25,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Veterano do Esq. Lâmina",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6768,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6769,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6770,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6771,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Devido ao seu conjunto de armaspesadas e escudo resiliente, a B-wingse consolidou como o caça de assaltomais inovador da Aliança Rebelde.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5928,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5929,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5930,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                3,
+                5,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_26",
+            "force_side": null,
+            "id": 26,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto do Esq. Azul",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 17,
+            "statistics": [
+                {
+                    "id": 6772,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6773,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6774,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6775,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar um ataque, você pode escolher 1 nave amiga em alcance 1. A nave escolhida pode realizar uma ação, tratando-a como uma ação vermelha.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5931,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5932,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5933,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 1,
             "cost": "36",
             "faction_id": 1,
-            "ffg_id": "XW_P_20",
+            "ffg_id": "XW_P_27",
             "force_side": null,
-            "id": 20,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_20.jpg",
-            "initiative": 3,
+            "id": 27,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
+            "initiative": 5,
             "is_unique": true,
-            "name": "•Arvel Crynyd",
+            "name": "•Airen Cracken",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 35,
+            "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 6776,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 6777,
                     "recurring": false,
                     "statistic_id": 1,
-                    "value": "3"
+                    "value": "2"
                 },
                 {
-                    "id": 6750,
+                    "id": 6778,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 6779,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 }
             ],
-            "subtitle": "Líder Verde",
+            "subtitle": "Chefe de Inteligência",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar um ataque primário,se houver ao menos 1 outra nave amiga em alcance 0-1 de um defensor, você pode rolar 1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5934,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5935,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5936,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_28",
+            "force_side": null,
+            "id": 28,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Tenente Blount",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6780,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6781,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6782,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6783,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Espírito de Equipe",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>A série AF4 é o modelo mais recentede uma longa lista de projetos Headhunter.Barata e relativamente durável, ela éuma das naves favoritas entre grupos independentes como a Rebelião.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5937,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5938,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5939,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "25",
+            "faction_id": 1,
+            "ffg_id": "XW_P_29",
+            "force_side": null,
+            "id": 29,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto do Esq. Tala",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6784,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6785,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6786,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6787,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>A Z-95 Headhunter foi a principal inspiraçãoda Incom Corporation para criar o caça estelar X-wing T-65. Apesar de ser considerada ultrapassada para os padrões modernos, ela continua sendo um caça versátil e potente.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5940,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5941,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5942,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "23",
+            "faction_id": 1,
+            "ffg_id": "XW_P_30",
+            "force_side": null,
+            "id": 30,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Piloto do Esq. Bandido",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 6788,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6789,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6790,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 6791,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar um ataque primário,se estiver danificado, você pode rolar1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5943,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5944,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5945,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "56",
+            "faction_id": 1,
+            "ffg_id": "XW_P_31",
+            "force_side": null,
+            "id": 31,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Wullffwarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6792,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6793,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6794,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6795,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Chefe Wookiee",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após uma nave amiga em alcance 0-1se tornar defensora, você pode gastar1 ficha de reforço. Se você fizer isso,a nave que se tornou defensorarecebe 1 ficha de desvio.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5946,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5947,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5948,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_32",
+            "force_side": null,
+            "id": 32,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Lowhhrick",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6796,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6797,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6798,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6799,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Gladiador Fugitivo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Equipada com três canhões laser paralelosSureggi de longo alcance, a Nave de Ataque Auzituck age como um poderoso dissuasor das operações escravagistas do sistema Kashyyyk.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5949,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 5950,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 5951,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 1,
+            "ffg_id": "XW_P_33",
+            "force_side": null,
+            "id": 33,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Defensor Kashyyyk",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 6,
+            "statistics": [
+                {
+                    "id": 6800,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 6801,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6802,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6803,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após revelar uma manobra vermelha ou azul, você pode rotacionar seu disco para outra manobra de mesma dificuldade.<return><sabold>Pronto para o Ataque:</sabold> Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5952,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5953,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5954,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "39",
+            "faction_id": 1,
+            "ffg_id": "XW_P_34",
+            "force_side": null,
+            "id": 34,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6804,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6805,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6806,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6807,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de ativar, você poderealizar 1<nonbreak>ação <barrelroll> ou <boost>.<return><sabold>Pronto para o Ataque:</sabold>Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5955,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5956,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5957,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_35",
+            "force_side": null,
+            "id": 35,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6808,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6809,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6810,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6811,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando defender ou realizar um ataque, se estiver estressado, você pode gastar 1 <forcecharge> para mudar até 2 de seus resultados <focus> para resultados <evade> ou <hit>.<return><sabold>Pronto para o Ataque:</sabold> Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5958,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5959,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5960,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "41",
+            "faction_id": 1,
+            "ffg_id": "XW_P_36",
+            "force_side": 2,
+            "id": 36,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6812,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6813,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6814,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6815,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6816,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando você defender, osresultados <crit> são neutralizadosantes dos resultados <hit>.<return><sabold>Pronto para o Ataque:</sabold> Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5961,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5962,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5963,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 1,
+            "ffg_id": "XW_P_37",
+            "force_side": null,
+            "id": 37,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 32,
+            "statistics": [
+                {
+                    "id": 6817,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6818,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6819,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6820,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após uma nave inimiga em seu arco de tiro engajar, se você não estiver estressado, você pode receber 1 ficha de estresse. Se você fizer isso, a nave inimiga engajando não pode gastar fichas para modificar dados enquanto estiver realizando um ataque nesta fase.<return><sabold>Shuttle de Comunicação:</sabold> Quando vocêestiver acoplado, seu porta-naves ganha <coordinate>.Antes de o porta-naves ativar, ele poderealizar uma ação <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5964,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5965,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_38",
+            "force_side": null,
+            "id": 38,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6821,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6822,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6823,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6824,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6825,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Rebelde Relutante",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando defender ou realizar um ataque, se estiver estressado, você pode gastar 1 <forcecharge> para mudar até 2 de seus resultados <focus> para resultados <evade>/<hit>. <return><sabold>Shuttle de Comunicação:</sabold> Quandovocê estiver acoplado, seu porta-navesganha <coordinate>. Antes de o porta-naves ativar,ele pode realizar uma ação <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5966,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5967,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                10,
+                14,
+                15,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_39",
+            "force_side": 2,
+            "id": 39,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6826,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6827,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6828,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6829,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6830,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                },
+                {
+                    "id": 6831,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando você defender, os resultados <crit>são neutralizados antes dos resultados <hit>.<return><sabold>Shuttle de Comunicação:</sabold> Quandovocê estiver acoplado, seu porta-navesganha <coordinate>. Antes de o porta-naves ativar,ele pode realizar uma ação <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5968,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5969,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_40",
+            "force_side": null,
+            "id": 40,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6832,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6833,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6834,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6835,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6836,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando você coordenar, se escolheruma nave com exatamente 1 ficha de estresse, ela consegue realizar ações.<return><sabold>Shuttle de Comunicação:</sabold> Quandovocê estiver acoplado, seu porta-navesganha <coordinate>. Antes de o porta-naves ativar,ele pode realizar uma ação <coordinate>.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5970,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 5971,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                10,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 1,
+            "ffg_id": "XW_P_41",
+            "force_side": null,
+            "id": 41,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
+            "initiative": 1,
+            "is_unique": true,
+            "name": "•AP-5",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 8,
+            "statistics": [
+                {
+                    "id": 6837,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6838,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6839,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6840,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 6841,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Droide de Análise Fugitivo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando uma nave amiga emseu arco de tiro realizar um ataque primário, se você não estiver estressado, você tem a opçãode receber 1 ficha de estresse.Se você fizer isso, a nave amiga pode rolar 1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5972,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5973,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5974,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5975,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5976,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 1,
+            "ffg_id": "XW_P_42",
+            "force_side": null,
+            "id": 42,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Jan Ors",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6842,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6843,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6844,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6845,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Perita em Espionagem",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento, você pode transferir 1 de suas fichas de foco para uma nave amiga em seu arco de tiro.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5977,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5978,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5979,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5980,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5981,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_43",
+            "force_side": null,
+            "id": 43,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kyle Katarn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6846,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6847,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6848,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6849,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Agente Implacável",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento, você pode escolher 1 nave em seu arco de tiro. Se você fizer isso,ela engaja nesta fase utilizandoum valor de iniciativa 7, em vezdo valor de iniciativa normal dela.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5982,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5983,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5984,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5985,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5986,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 1,
+            "ffg_id": "XW_P_44",
+            "force_side": null,
+            "id": 44,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Roark Garnet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6850,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6851,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6852,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6853,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Contrabandista de Bom Coração",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Projetadas pela Corellian Engineering Corporation para se parecerem com pássaros em voo, as naves da série “hawk” são naves de transporte exemplares. Rápidas e robustas, a HWK-290 é comumente empregada por agentes Rebeldes como base de operações móvel.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5987,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 5988,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 5989,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5990,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 5991,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                14,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_45",
+            "force_side": null,
+            "id": 45,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Batedor Rebelde",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 6854,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 6855,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6856,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6857,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando defender ou realizar um ataque,se estiver estressado, você podegastar 1 <forcecharge> para mudar até 2 de seusresultados <focus> para resultados <evade> ou <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5992,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5993,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5994,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_46",
+            "force_side": 2,
+            "id": 46,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ezra Bridger",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6858,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6859,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6860,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6861,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Espectro-6",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de ativar, você poderealizar 1<nonbreak>ação <barrelroll> ou <boost>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5995,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5996,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 5997,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 1,
+            "ffg_id": "XW_P_47",
+            "force_side": null,
+            "id": 47,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Sabine Wren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6862,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6863,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6864,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Espectro-5",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar um ataque, atribua a condição <smallcaps>Tiro Supressivo</smallcaps> ao defensor.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 5998,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 5999,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6000,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 1,
+            "ffg_id": "XW_P_48",
+            "force_side": null,
+            "id": 48,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Capitão Rex",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6865,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6866,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6867,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Veterano das Guerras Clônicas",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando você defender, os resultados <crit> são neutralizados antes dos resultados <hit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6001,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6002,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6003,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "26",
+            "faction_id": 1,
+            "ffg_id": "XW_P_49",
+            "force_side": null,
+            "id": 49,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 11,
+            "statistics": [
+                {
+                    "id": 6868,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 6869,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6870,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Espectro-4",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Em iniciativa 0, você pode realizar um ataque primário bônus contra uma nave inimiga em seu <bullseye>. Se fizer isso, no início da próxima Fase de Planejamento, receba 1 ficha de desarmamento.<return><sabold>Sensores Experimentais:</sabold>Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6004,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6005,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6006,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6007,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6008,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 1,
+            "ffg_id": "XW_P_50",
+            "force_side": null,
+            "id": 50,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Corran Horn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6871,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6872,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6873,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6874,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Investigador Perseverante",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando uma nave amiga realizar um ataque, se o defensor estiver em seu <frontarc>, o atacante pode mudar 1 resultado <hit> para um resultado <crit>.<return><sabold>Sensores Experimentais:</sabold> Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1..",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6009,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6010,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6011,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6012,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6013,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 1,
+            "ffg_id": "XW_P_51",
+            "force_side": null,
+            "id": 51,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Gavin Darklighter",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6875,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6876,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6877,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6878,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Parceiro Ousado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Os pilotos de elite do Esquadrão Rogue estão entre os melhores da Rebelião. </flavor><return><sabold>Sensores Experimentais:</sabold>Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6014,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6015,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6016,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6017,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6018,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "63",
+            "faction_id": 1,
+            "ffg_id": "XW_P_52",
+            "force_side": null,
+            "id": 52,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Escolta do Esq. Rogue",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6879,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6880,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6881,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6882,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Projetada para combinar as melhores características das séries X-wing e A-wing, a E-wing apresenta poder de fogo, velocidade e manobrabilidade superiores.</flavor><return><sabold>Sensores Experimentais:</sabold>Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6019,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6020,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6021,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6022,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6023,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                10,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "61",
+            "faction_id": 1,
+            "ffg_id": "XW_P_53",
+            "force_side": null,
+            "id": 53,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Escolta do Esq. Valete",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 40,
+            "statistics": [
+                {
+                    "id": 6883,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6884,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 6885,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 6886,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Naves amigas conseguem travar mirasem objetos que estejam em alcance0-3 de qualquer nave amiga.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6024,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6025,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6026,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 1,
+            "ffg_id": "XW_P_54",
+            "force_side": null,
+            "id": 54,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Bodhi Rook",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6887,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6888,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6889,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6890,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Desertor Imperial",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando uma nave amiga danificada em alcance 0-3 realizar um ataque, ela pode rerrolar 1 dado de ataque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6027,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6028,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6029,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 1,
+            "ffg_id": "XW_P_55",
+            "force_side": null,
+            "id": 55,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Saw Gerrera",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6891,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6892,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6893,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6894,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Extremista Obsessivo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Ativação, vocêpode escolher 1 nave amiga em alcance 1-3. Se você fizer isso, a nave escolhida remove 1 ficha de estresse.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6030,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6031,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6032,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_56",
+            "force_side": null,
+            "id": 56,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Cassian Andor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6895,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6896,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6897,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6898,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Criado pela Rebelião",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando uma nave amiga em alcance 0-2 defender, o atacante não pode rerrolar mais de 1 dado de ataque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6033,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6034,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6035,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_57",
+            "force_side": null,
+            "id": 57,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6899,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6900,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6901,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6902,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Batedora dos Cavern Angels",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar uma ação <focus>, você pode transferir 1 de suas fichas de foco para uma nave amiga em alcance 1-2.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6036,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6037,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6038,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 1,
+            "ffg_id": "XW_P_58",
+            "force_side": null,
+            "id": 58,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Benthic Two Tubes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6903,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6904,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6905,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6906,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Artilheiro dos Cavern Angels",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após uma nave inimiga executar uma manobra, se ela estiver em alcance 0, você pode realizar uma ação.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6039,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6040,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6041,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "45",
+            "faction_id": 1,
+            "ffg_id": "XW_P_59",
+            "force_side": null,
+            "id": 59,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Heff Tobber",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6907,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6908,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6909,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6910,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Azul Oito",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Usada para deslocar tropas encobertas pelaescuridão ou até focos de batalha, a U-wing UT-60D atende a necessidade da aliança de ter um transporte de tropas rápido e robusto.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6042,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6043,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6044,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_60",
+            "force_side": null,
+            "id": 60,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Batedor do Esq. Azul",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6911,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6912,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6913,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6914,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Os partidários de Saw Gerrera foram formados inicialmente para opor às forças Separatistas em Onderon durante as Guerras Clônicas e continuaram a combater a tirania galática após a tomada do poder pelo Império.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6045,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6046,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6047,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                8,
+                13,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 1,
+            "ffg_id": "XW_P_61",
+            "force_side": null,
+            "id": 61,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Partidário Renegado ",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 15,
+            "statistics": [
+                {
+                    "id": 6915,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6916,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 6917,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 6918,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar um ataque primário, você pode gastar 1 escudo para rolar 1 dado de ataque adicional ou, se não tiver escudos, você pode rolar 1 dado de ataque a menos para recuperar 1 escudo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6048,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6049,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6050,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6051,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6052,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 1,
+            "ffg_id": "XW_P_62",
+            "force_side": null,
+            "id": 62,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Miranda Doni",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6919,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6920,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6921,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6922,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Atacante Pesado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando uma nave amiga em alcance0-2 defender ou realizar um ataque,ela pode gastar as suas fichas defoco como se fossem dela.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6053,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6054,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6055,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6056,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6057,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_63",
+            "force_side": null,
+            "id": 63,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Esege Tuketu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6923,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6924,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6925,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6926,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Herói Altruísta",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>A K-wing fabricada pela Koensayr Manufacturing dispunha de um avançado Motor de Aceleração Sub-Luz (SLAM) e incríveis 18 pontos de encaixe, garantindo velocidade e poder de fogo sem igual.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6058,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6059,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6060,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6061,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6062,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                8,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 1,
+            "ffg_id": "XW_P_64",
+            "force_side": null,
+            "id": 64,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto do Esq. Protetor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 30,
+            "statistics": [
+                {
+                    "id": 6927,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 6928,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6929,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6930,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando defender, se houver uma nave inimiga em alcance 0-1, você pode adicionar 1 resultado <evade> aos resultadosde seus dados.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6063,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6064,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6065,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "55",
+            "faction_id": 1,
+            "ffg_id": "XW_P_65",
+            "force_side": null,
+            "id": 65,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Norra Wexley",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6931,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6932,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6933,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6934,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6935,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Dourado Nove",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após gastar 1 ficha de foco, você pode escolher 1 nave amiga em alcance 1-3.A nave escolhida recebe 1 ficha de foco.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6066,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6067,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6068,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "51",
+            "faction_id": 1,
+            "ffg_id": "XW_P_66",
+            "force_side": null,
+            "id": 66,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Garven Dreis",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6936,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6937,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6938,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6939,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6940,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Líder Vermelho",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando defender ou realizar umataque primário, você pode gastar1 mira travada na nave inimiga para adicionar 1 resultado <nonbreak><focus> aoresultado de seus dados.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6069,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6070,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6071,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "53",
+            "faction_id": 1,
+            "ffg_id": "XW_P_67",
+            "force_side": null,
+            "id": 67,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Shara Bey",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6941,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6942,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6943,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6944,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6945,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Verde Quatro",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após executar completamenteuma manobra, se estiver estressado, você pode rolar 1 dado de ataque.Em um resultado <hit> ou <crit>, remova1 ficha de estresse.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6072,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6073,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6074,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                10,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 1,
+            "ffg_id": "XW_P_68",
+            "force_side": null,
+            "id": 68,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Ibtisam",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 31,
+            "statistics": [
+                {
+                    "id": 6946,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6947,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 6948,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6949,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 6950,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Sobrevivente de Endor",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após rolar os dados, se estiver em alcance 0-1 de um obstáculo, você pode rerrolar todos os seus dados. Para todos os outros efeitos, isso não conta como uma rerrolagem.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6075,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6076,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6077,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6078,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "92",
+            "faction_id": 1,
+            "ffg_id": "XW_P_69",
+            "force_side": null,
+            "id": 69,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6951,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6952,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6953,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6954,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Patife Mercenário",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1559,6 +5966,533 @@
                 }
             ],
             "subtitle": "General da Aliança",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de receber uma carta de dano virada para cima, você pode gastar1 <standardcharge> para, em vez disso, receber acarta virada para baixo.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6083,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6084,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6085,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6086,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 1,
+            "ffg_id": "XW_P_71",
+            "force_side": null,
+            "id": 71,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Chewbacca",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6959,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6960,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6961,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6962,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                },
+                {
+                    "id": 6963,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "O Poderoso",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Conhecido por sua durabilidadee modularidade, a YT-1300 é um doscargueiros mais populares, mais usadose mais extensivamente personalizadosda galáxia.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6087,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6088,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6089,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6090,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "78",
+            "faction_id": 1,
+            "ffg_id": "XW_P_72",
+            "force_side": null,
+            "id": 72,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Contrabandistada Orla Exterior",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 1,
+            "statistics": [
+                {
+                    "id": 6964,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 6965,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 6966,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 6967,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após revelar uma manobra vermelha ou azul, você pode rotacionar seu disco para outra manobra de mesma dificuldade.<return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6091,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6092,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6093,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "76",
+            "faction_id": 1,
+            "ffg_id": "XW_P_73",
+            "force_side": null,
+            "id": 73,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Hera Syndulla",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6968,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6969,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6970,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6971,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Espectro-2",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando uma nave amiga em seu arcode tiro defender, você pode gastar 1 <forcecharge>.Se você fizer isso, o atacante rola 1 dadode ataque a menos.<return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6094,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6095,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6096,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "90",
+            "faction_id": 1,
+            "ffg_id": "XW_P_74",
+            "force_side": 2,
+            "id": 74,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Kanan Jarrus",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6972,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6973,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6974,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6975,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                },
+                {
+                    "id": 6976,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Espectro-1",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento,cada nave inimiga em alcance 0recebe 2 fichas de interferência. <return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6097,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6098,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6099,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 1,
+            "ffg_id": "XW_P_75",
+            "force_side": null,
+            "id": 75,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Chopper\"",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6977,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6978,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6979,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6980,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Espectro-3",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Mais um projeto de sucesso de cargueiroda Corellian Engineering Corporation,o VCX-100 é maior que a popular série YT, dispondo de mais espaço interno e maior capacidade de personalização.</flavor><return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6100,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6101,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6102,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                4,
+                5,
+                8,
+                8,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 1,
+            "ffg_id": "XW_P_76",
+            "force_side": null,
+            "id": 76,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Rebelde de Lothal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 23,
+            "statistics": [
+                {
+                    "id": 6981,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "4"
+                },
+                {
+                    "id": 6982,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 6983,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "10"
+                },
+                {
+                    "id": 6984,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -1973,87 +6907,6 @@
                 }
             ],
             "subtitle": "Líder Obsidiana",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Diferente da maioria das células Rebeldes, os partidários de Saw Gerrera estão dispostos a usar métodos extremos para minar os objetivos do Império Galático em batalhas brutais que vão de Geonosis à Jedha.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5872,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5873,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5874,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_12.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_12",
-            "force_side": null,
-            "id": 12,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_12.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Fanático dos Cavern Angels",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6716,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6717,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6718,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6719,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -2647,9455 +7500,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Após realizar uma ação, você podegastar 1 <forcecharge> para realizar uma ação.<return><sabold>Computador de Mira Avançado:</sabold> Quando você realizar um ataque primário contra um defensor em quem você tem uma mira travada, role 1 dado de ataque adicional e mude 1 resultado <hit> para um resultado <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6154,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6155,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6156,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 2,
-            "ffg_id": "XW_P_93",
-            "force_side": 1,
-            "id": 93,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Darth Vader",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7038,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7039,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7040,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7041,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7042,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Líder Preto",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A TIE Advanced x1 foi produzida em quantidade limitada, porém os engenheiros da Sienar incorporaram muitas de suas melhores qualidades em seu próximo modelo de TIE: a TIE Interceptor.</flavor><return><sabold>Computador de Mira Avançado:</sabold> Quando você realizar um ataque primário contra um defensor em quem você tem uma mira travada, role 1 dado de ataque adicional e mude 1 resultado <hit> para um resultado <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6166,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6167,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6168,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
-            "card_set_ids": [
-                5,
-                10
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 2,
-            "ffg_id": "XW_P_97",
-            "force_side": null,
-            "id": 97,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Ás do Esq. Tormenta",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 13,
-            "statistics": [
-                {
-                    "id": 7055,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7056,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7057,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7058,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A TIE Advanced v1 da Sienar Fleet Systems é um projeto de caça estelar revolucionário, apresentando motores aprimorados, um lança-mísseis e s-foils dobráveis.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6182,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6183,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6184,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6185,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6186,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_101",
-            "force_side": null,
-            "id": 101,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Barão do Império",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 25,
-            "statistics": [
-                {
-                    "id": 7073,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7074,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7075,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7076,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar uma ação <reload>, você pode recuperar 1 <standardcharge> em 1 de suas cartas de melhoria <talent> equipadas. <return><shipability><sabold>Bombardeiro Ágil:</sabold> Se for soltar um dispositivo usando um gabarito <straight>,você pode, em vez disso, usar um gabarito <leftbank> ou <rightbank> de mesma velocidade.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6208,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6209,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6210,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6211,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 2,
-            "ffg_id": "XW_P_107",
-            "force_side": null,
-            "id": 107,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Tomax Bren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7094,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7095,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7096,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Dissidente Atrevido",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após ser destruído, antes de ser removido, você pode realizar umataque e soltar ou lançar 1 dispositivo.<return><shipability><sabold>Bombardeiro Ágil:</sabold> Se for soltar um dispositivo usando um gabarito <straight>, você pode, em vez disso, usar um gabarito<leftbank> ou <rightbank> de mesma velocidade.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6220,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6221,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6222,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6223,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_110",
-            "force_side": null,
-            "id": 110,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Deathfire”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 19,
-            "statistics": [
-                {
-                    "id": 7103,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7104,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7105,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                }
-            ],
-            "subtitle": "Obstinado Inabalável",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender, se o atacante não tiver fichas verdes, você pode mudar 1 de seus resultados em branco ou <focus> para um resultado <evade>.<return><sabold>Ailerons Adaptáveis:</sabold> Antes de revelarseu disco, se não estiver estressado,você <bold>deve</bold> executar uma manobra[<leftbank> 1], [<straight> 1] ou [<rightbank> 1] branca.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6236,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6237,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6238,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6239,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 2,
-            "ffg_id": "XW_P_114",
-            "force_side": null,
-            "id": 114,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitão Feroph",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 43,
-            "statistics": [
-                {
-                    "id": 7116,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7117,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7118,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7119,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Emissário Imperial",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender, após a etapa Neutralizar Resultados, se não estiver estressado, você pode sofrer 1 dano <hit> e receber 1 ficha de estresse. Se fizer isso, cancele todos os resultados dos dados.<return><sabold>Ailerons Adaptáveis:</sabold> Antes de revelar seu disco, se não estiver estressado, você <bold>deve</bold> executar uma manobra [<leftbank> 1], [<straight> 1] ou [<rightbank> 1] branca.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6251,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6252,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6253,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_118",
-            "force_side": null,
-            "id": 118,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•“Countdown”",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 16,
-            "statistics": [
-                {
-                    "id": 7131,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7132,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7133,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Aquele que Desafia a Morte",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar um ataque que acertou, se você estiver desviando, exponha 1 dascartas de dano do defensor.<return><shipability><sabold>Força Total:</sabold> Após executar completamente uma manobra de velocidade 3-5, você pode realizar uma ação <evade>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6263,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6264,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6265,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6266,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6267,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_122",
-            "force_side": null,
-            "id": 122,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Rexler Brath",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 18,
-            "statistics": [
-                {
-                    "id": 7143,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7144,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7145,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7146,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Líder Ônix",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Durante o desenvolvimento da TIE aggressor, a Sienar Fleet Systemsvalorizou mais a sua performance e versatilidade do que o custo-benefício.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6297,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6298,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6299,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 2,
-            "ffg_id": "XW_P_130",
-            "force_side": null,
-            "id": 130,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Especialista Sienar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7175,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7176,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7177,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7178,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Sendo o principal resultado de uma base de pesquisa escondida em Imdaar Alfa, a TIE phantom alcançou algo que muitos julgavam impossível: um pequeno caça estelar equipado com um dispositivo de camuflagem avançado.</flavor><return><shipability><sabold>Matriz de Stygium:</sabold> Após descamuflar, você pode realizar uma ação <evade>. No início da Fase Final, você pode gastar 1 ficha de desviopara receber 1 ficha de camuflagem.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6312,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6313,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6314,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 7,
-                    "base_action_side_effect": null,
-                    "id": 6315,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 2,
-            "ffg_id": "XW_P_134",
-            "force_side": null,
-            "id": 134,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Pil. de Testes de Imdaar",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 27,
-            "statistics": [
-                {
-                    "id": 7191,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7192,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7193,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7194,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Com design inspirado por outras navesda Cygnus Spaceworks, a star wing classe <untalic>Alfa</untalic>é uma nave versátil designada a unidadesespeciais da Marinha Imperial que precisamde um caça estelar capaz de ser equipado para executar os mais diversos tipos de missão.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6328,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6329,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6330,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6331,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                6,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "35",
-            "faction_id": 2,
-            "ffg_id": "XW_P_138",
-            "force_side": null,
-            "id": 138,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto do Esq. Nu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 14,
-            "statistics": [
-                {
-                    "id": 7207,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7208,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7209,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7210,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento,você pode escolher 1 ou mais navesamigas em alcance 0-3. Se fizerisso, transfira todas as fichas de mira inimigas das naves escolhidas para você.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6347,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6348,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 6349,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6350,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                8,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 2,
-            "ffg_id": "XW_P_142",
-            "force_side": null,
-            "id": 142,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Capitão Kagi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 26,
-            "statistics": [
-                {
-                    "id": 7223,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7224,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 7225,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7226,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7227,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "O Piloto da Shuttle do Imperador",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar um ataque, se estiver reforçado e o defensor estiver no <fullfront> ou <fullrear> correspondente à sua ficha de reforço, você pode mudar 1 de seus resultados <focus> para um resultado <crit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6368,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6369,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6370,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6371,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6372,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "88",
-            "faction_id": 2,
-            "ffg_id": "XW_P_147",
-            "force_side": null,
-            "id": 147,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Almirante deRetaguarda Chiraneau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7248,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7249,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7250,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7251,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Assessor do Almirante Piett",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você realizar um ataque primário, se houver ao menos 1 nave amiga não limitada em alcance 0 do defensor, role 1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6386,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6387,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": "stress",
-                    "id": 6388,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6389,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
-            "card_set_ids": [
-                6,
-                11
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 3,
-            "ffg_id": "XW_P_151",
-            "force_side": null,
-            "id": 151,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Kath Scarlet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 10,
-            "statistics": [
-                {
-                    "id": 7266,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7267,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "3"
-                },
-                {
-                    "id": 7268,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7269,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7270,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Capitã dos Piratas Binayre",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar umataque, se o alcance de ataque for 1, você pode rolar 1 dado adicional.<return><sabold>Afronta de Concórdia:</sabold> Quando você defender, se o alcance de ataque for 1 e você estiver no <frontarc> do atacante, mude 1 resultado para um resultado <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6402,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6403,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6404,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6405,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 3,
-            "ffg_id": "XW_P_155",
-            "force_side": null,
-            "id": 155,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7286,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7287,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7288,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Líder Caveira",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Devido aos seus controles sensitivos e alta manobrabilidade, somente os pilotos mais talentosos ocupavam a cabine de uma A-wing.</flavor><return><sabold>Propulsores Vetorizados:</sabold>Após realizar uma ação, você poderealizar uma ação <boost> vermelha.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5909,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5910,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5911,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5912,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 5913,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_21.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_21",
-            "force_side": null,
-            "id": 21,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_21.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Piloto do Esq. Verde",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 35,
-            "statistics": [
-                {
-                    "id": 6752,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6753,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6754,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6755,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Os ases do Esquadrão Caveira preferem aproximações agressivas, utilizando a tecnologia de asas pivotantes para alcançar uma agilidade imbatível durante perseguições. </flavor><return> <sabold>Afronta de Concórdia:</sabold> Quando você defender, se o alcance de ataque for 1 e você estiver no <frontarc> do atacante, mude 1 resultado para um resultado <evade>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6418,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6419,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6420,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6421,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
-            "card_set_ids": [
-                6,
-                12
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_159",
-            "force_side": null,
-            "id": 159,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Piloto do Esq. Caveira",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 36,
-            "statistics": [
-                {
-                    "id": 7298,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7299,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7300,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento, se houver uma ou mais naves em alcance 0, você e cada outra nave em alcance 0 recebem 1 ficha de tração.<return><shipability><sabold>Feixe de Rebocamento Espacial: </sabold><smallcaps>Ação:</smallcaps> Escolha uma nave em seu <frontarc> em alcance 1.A nave escolhida recebe 1 ficha de tração,ou 2 fichas de tração se estiver em seu<bullseye> em alcance 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6432,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6433,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6434,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 3,
-            "ffg_id": "XW_P_163",
-            "force_side": null,
-            "id": 163,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Unkar Plutt",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7310,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7311,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7312,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Senhor da Comida Racionada",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave amiga não limitadarealizar um ataque, se o defensorestiver em seu arco de tiro, o atacantepode rerrolar 1 dado de ataque.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6442,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6443,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6444,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6445,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 3,
-            "ffg_id": "XW_P_166",
-            "force_side": null,
-            "id": 166,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Drea Renthal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7320,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7321,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7322,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7323,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Lorde Pirata",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A mera menção de créditos Imperiaispode atrair uma legião de indivíduosnão-muito-confiáveis para o seu lado.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6446,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6447,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6448,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": "stress",
-                    "id": 6449,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                10,
-                12,
-                13,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 3,
-            "ffg_id": "XW_P_167",
-            "force_side": null,
-            "id": 167,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Mercenário",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 12,
-            "statistics": [
-                {
-                    "id": 7324,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7325,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7326,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7327,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Você consegue se destacar apenas com um destacamento de emergência, e possui o nome, a iniciativa, a habilidade de piloto e a <standardcharge> da <smallcaps>Hound’s Tooth</smallcaps> amiga destruída.<return><shipability><sabold>Módulo de Escape:</sabold> <smallcaps>Preparação:</smallcaps>Requer a <smallcaps>Hound’s Tooth</smallcaps>. Você <bold>deve</bold>iniciar o jogo acoplado na <smallcaps>Hound’s Tooth</smallcaps>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6460,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6461,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6462,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "6",
-            "faction_id": 3,
-            "ffg_id": "XW_P_171",
-            "force_side": null,
-            "id": 171,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Nashtah Pup</italic>",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 7340,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7341,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7342,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7343,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Plano de Contingência",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento, você pode escolher 1 nave inimigaem seu arco de tiro em alcance 0-2.Se fizer isso, transfira 1 fichade foco ou de desvio da naveescolhida para você.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6474,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6475,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6476,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6477,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 6478,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 3,
-            "ffg_id": "XW_P_175",
-            "force_side": null,
-            "id": 175,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Palob Godalhi",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 7357,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7358,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7359,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7360,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Membro da Resistência de Teth",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após executar completamenteuma manobra, você pode receber 1 ficha de estresse para rotacionar sua nave em 90º.<return><sabold>Micropropulsores:</sabold> Quando realizar uma pirueta, você<bold>deve</bold> usar o gabarito <leftbank> ou <rightbank>em vez do gabarito <straight>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6493,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6494,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6495,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6496,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_179",
-            "force_side": null,
-            "id": 179,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Dalan Oberos",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 3,
-            "statistics": [
-                {
-                    "id": 7373,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7374,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7375,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7376,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Caçador de Recompensas de Elite",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave amiga em alcance0-1 defender, ela pode rerrolar 1 de seus dados.<return><shipability><sabold>Encaixe de Arma:</sabold> Você consegueequipar 1 melhoria <cannon>, <torpedo>, ou <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6509,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6510,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6511,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6512,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_183",
-            "force_side": null,
-            "id": 183,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Serissu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7389,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7390,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7391,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7392,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Instrutor de Voo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você defender ou realizarum ataque, você pode sofrer1 dano <hit> para rerrolar qualquernúmero de seus dados.<return><shipability><sabold>Encaixe de Arma:</sabold> Você consegueequipar 1 melhoria <cannon>, <torpedo>, ou <missile>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6525,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6526,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6527,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6528,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                999
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 3,
-            "ffg_id": "XW_P_187",
-            "force_side": null,
-            "id": 187,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Inaldra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 44,
-            "statistics": [
-                {
-                    "id": 7405,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7406,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7407,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 7408,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Chefe de Ponto Tansarii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você defender em alcancede ataque 3 ou realizar um ataquecom alcance de ataque 1, role 1 dado adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6541,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6542,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6543,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_191",
-            "force_side": null,
-            "id": 191,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Talonbane Cobra",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7421,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7422,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7423,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7424,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Tormento de Ponto Tansarii",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>O caça de assalto Kihraxz foi especialmente desenvolvido para a organização criminosa Sol Negro, cujos áses muito bem pagos exigiam uma nave ágil e poderosa à altura de suas habilidades.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6553,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6554,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6555,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                13,
-                14,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 3,
-            "ffg_id": "XW_P_195",
-            "force_side": null,
-            "id": 195,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Ás do Sol Negro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 7,
-            "statistics": [
-                {
-                    "id": 7437,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7438,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7439,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7440,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar uma ação <boost>,você pode realizar uma ação <evade>.<return><shipability><sabold>Cérebro Droide Avançado:</sabold> Após realizar uma ação <calculate>, receba 1 ficha de cálculo.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6567,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6568,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6569,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6570,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                12,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 3,
-            "ffg_id": "XW_P_199",
-            "force_side": null,
-            "id": 199,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•IG-88C",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 21,
-            "statistics": [
-                {
-                    "id": 7453,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7454,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7455,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7456,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Engenhoca Calculista",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Os lendários Findsmen de Gand venerama névoa que encobre seu planeta natal,usando sinais, presságios e rituais mágicospara rastrear suas presas.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6581,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6582,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": null,
-                    "id": 6583,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 3,
-            "ffg_id": "XW_P_203",
-            "force_side": null,
-            "id": 203,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Findsman Gand",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 22,
-            "statistics": [
-                {
-                    "id": 7469,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7470,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7471,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 7472,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após você realizar um ataque, cada nave inimiga em seu <bullseye> sofre 1 dano<nonbreak><hit>,a menos que ela remova 1 ficha verde.<return><sabold>Na Palma da Mão:</sabold> Quando você realizar um ataque, se o defensor estiver em seu <bullseye>, os dados de defesa não podem ser modificados por fichas verdes.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6593,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6594,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6595,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6596,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                6,
-                10,
-                13,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 3,
-            "ffg_id": "XW_P_207",
-            "force_side": null,
-            "id": 207,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Torani Kulda",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 39,
-            "statistics": [
-                {
-                    "id": 7486,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7487,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7488,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "7"
-                },
-                {
-                    "id": 7489,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Freelancer Rodiano",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar um ataque, se estiver estressado, você tem a opção de rerrolar até 2 de seus dados.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5919,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5920,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5921,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_23.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_23",
-            "force_side": null,
-            "id": 23,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_23.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Braylen Stramm",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6760,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6761,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6762,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6763,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Líder Lâmina",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Se for fugir, você pode gastar 1 ￼.Se fizer isso, coloque-se na reserva,em vez de fugir. No início da próximaFase de Planejamento, posicione-se dentro de alcance 1 da borda da áreade jogo por onde você fugiu.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6608,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6609,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6610,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                3,
-                6,
-                8,
-                8,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 3,
-            "ffg_id": "XW_P_211",
-            "force_side": null,
-            "id": 211,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Moralo Eval",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 24,
-            "statistics": [
-                {
-                    "id": 7503,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 7504,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7505,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "9"
-                },
-                {
-                    "id": 7506,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                },
-                {
-                    "id": 7507,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Mestre do Crime",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento, você pode escolher uma nave amiga em alcance 0-1. Se fizer isso, transfira todas as suas fichas verdes para a nave escolhida.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6620,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6621,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6622,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                13,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_215",
-            "force_side": null,
-            "id": 215,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Manaroo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 45,
-            "statistics": [
-                {
-                    "id": 7521,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 7522,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7523,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 7524,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Aruzana Graciosa",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Devido ao seu conjunto de armaspesadas e escudo resiliente, a B-wingse consolidou como o caça de assaltomais inovador da Aliança Rebelde.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5928,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5929,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5930,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_26.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_26",
-            "force_side": null,
-            "id": 26,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_26.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto do Esq. Azul",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6772,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6773,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6774,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6775,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar um ataque, você pode gastar 1 fichade estresse para mudar todosos seus resultados <focus> para resultados <evade> ou <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5922,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5923,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5924,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_24.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_24",
-            "force_side": null,
-            "id": 24,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_24.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Ten Numb",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6764,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6765,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6766,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6767,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Azul Cinco",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Um sistema de estabilização giroscópica único foi projetado em volta da cabine da B-wing, garantindo que o piloto permaneça estacionário durante o voo.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5925,
-                    "related_action_id": 5,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5926,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5927,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                3,
-                3,
-                5,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_25.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "44",
-            "faction_id": 1,
-            "ffg_id": "XW_P_25",
-            "force_side": null,
-            "id": 25,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_25.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Veterano do Esq. Lâmina",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 17,
-            "statistics": [
-                {
-                    "id": 6768,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6769,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6770,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6771,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizarum ataque primário, se o ataqueestiver obstruído por um obstáculo,você pode rolar 1 dado adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6645,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6646,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6647,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6648,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "54",
-            "faction_id": 3,
-            "ffg_id": "XW_P_222",
-            "force_side": null,
-            "id": 222,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7555,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7556,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7557,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7558,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "O Garoto Corelliano",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar um ataque primário,se houver ao menos 1 outra nave amiga em alcance 0-1 de um defensor, você pode rolar 1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5934,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5935,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5936,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_28.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_28",
-            "force_side": null,
-            "id": 28,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_28.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Tenente Blount",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6780,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6781,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6782,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6783,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Espírito de Equipe",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Projetada para batalhas duradouras,a TIE/ag é pilotada principalmente por pilotos de elite treinados para dominartanto seu armamento exclusivo quantosua agilidade com eficiência total.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6294,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6295,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6296,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                6,
-                6,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 2,
-            "ffg_id": "XW_P_129",
-            "force_side": null,
-            "id": 129,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Batedor do Esq. Ônix",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 29,
-            "statistics": [
-                {
-                    "id": 7171,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7172,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7173,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 7174,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Naves amigas em alcance 0-1conseguem realizar ataques emalcance 0 de obstáculos.<return><shipability><sabold>Copiloto:</sabold> Quando estiver acoplado,seu porta-naves possui sua habilidadede piloto além da habilidade dele.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6664,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6665,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6666,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "24",
-            "faction_id": 3,
-            "ffg_id": "XW_P_227",
-            "force_side": null,
-            "id": 227,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Pioneiro da Orla Exterior",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
-            "statistics": [
-                {
-                    "id": 7575,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7576,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7577,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7578,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Fora-da-Lei Habilidoso",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A Z-95 Headhunter foi a principal inspiraçãoda Incom Corporation para criar o caça estelar X-wing T-65. Apesar de ser considerada ultrapassada para os padrões modernos, ela continua sendo um caça versátil e potente.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5940,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5941,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5942,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_30.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "23",
-            "faction_id": 1,
-            "ffg_id": "XW_P_30",
-            "force_side": null,
-            "id": 30,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_30.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Piloto do Esq. Bandido",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6788,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6789,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6790,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6791,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após rolar dados, se não estiver estressado, você pode receber1 ficha de estresse para rerrolartodos os seus resultados em branco.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6649,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6650,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6651,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6652,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 3,
-            "ffg_id": "XW_P_223",
-            "force_side": null,
-            "id": 223,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 3,
-            "ship_type": 47,
-            "statistics": [
-                {
-                    "id": 7559,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 7560,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 7561,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 7562,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Apostador Vigarista",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando outra nave amiga emalcance 0-1 defender, antes da etapa Neutralizar Resultados, se vocêestiver no arco de ataque, você podesofrer 1<nonbreak>dano <hit> ou <crit> paracancelar 1 resultado correspondente.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5857,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5858,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5859,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_7.png",
-            "card_set_ids": [
-                4,
-                7
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_7",
-            "force_side": null,
-            "id": 7,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_7.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Biggs Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6696,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6697,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6698,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6699,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Vermelho Três",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de ativar, se estiver focado, você pode realizar uma ação.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5863,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5864,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5865,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_9.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_9",
-            "force_side": null,
-            "id": 9,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_9.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Edrio Two Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6704,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6705,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6706,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6707,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Veterano dos Cavern Angels",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após uma nave amiga em alcance 0-1se tornar defensora, você pode gastar1 ficha de reforço. Se você fizer isso,a nave que se tornou defensorarecebe 1 ficha de desvio.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5946,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5947,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5948,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_32.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_32",
-            "force_side": null,
-            "id": 32,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_32.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Lowhhrick",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6796,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6797,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6798,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6799,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Gladiador Fugitivo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A série AF4 é o modelo mais recentede uma longa lista de projetos Headhunter.Barata e relativamente durável, ela éuma das naves favoritas entre grupos independentes como a Rebelião.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5937,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5938,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5939,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_29.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "25",
-            "faction_id": 1,
-            "ffg_id": "XW_P_29",
-            "force_side": null,
-            "id": 29,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_29.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto do Esq. Tala",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6784,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6785,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6786,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6787,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar um ataque primário,se estiver danificado, você pode rolar1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5943,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5944,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5945,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_31.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "56",
-            "faction_id": 1,
-            "ffg_id": "XW_P_31",
-            "force_side": null,
-            "id": 31,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_31.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Wullffwarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6792,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6793,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6794,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6795,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Chefe Wookiee",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar um ataque, você pode escolher 1 nave amiga em alcance 1. A nave escolhida pode realizar uma ação, tratando-a como uma ação vermelha.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5931,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5932,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5933,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_27.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "36",
-            "faction_id": 1,
-            "ffg_id": "XW_P_27",
-            "force_side": null,
-            "id": 27,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_27.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Airen Cracken",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 38,
-            "statistics": [
-                {
-                    "id": 6776,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6777,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6778,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 6779,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Chefe de Inteligência",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de ativar, você poderealizar 1<nonbreak>ação <barrelroll> ou <boost>.<return><sabold>Pronto para o Ataque:</sabold>Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5955,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5956,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5957,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_35.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_35",
-            "force_side": null,
-            "id": 35,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_35.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6808,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6809,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6810,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6811,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>O rebocador orbital Quadrijet, comumentechamado de \"Quadjumper\", é ágil tanto noespaço quanto na atmosfera, o que o tornou popular entre contrabandistas e exploradores. </flavor><return><shipability><sabold>Feixe de Rebocamento Espacial: </sabold><smallcaps>Ação:</smallcaps> Escolha uma nave em seu <frontarc> em alcance 1. A nave escolhida recebe 1 ficha de tração, ou 2 fichas de tração se estiver em seu <bullseye> em alcance 1.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6435,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": "stress",
-                    "id": 6436,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6437,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                13,
-                14,
-                19
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 3,
-            "ffg_id": "XW_P_164",
-            "force_side": null,
-            "id": 164,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Contrabandistade Armas de Jakku",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 9,
-            "statistics": [
-                {
-                    "id": 7313,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7314,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7315,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Equipada com três canhões laser paralelosSureggi de longo alcance, a Nave de Ataque Auzituck age como um poderoso dissuasor das operações escravagistas do sistema Kashyyyk.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5949,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 5950,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 5951,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_33.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_33",
-            "force_side": null,
-            "id": 33,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_33.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Defensor Kashyyyk",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 6,
-            "statistics": [
-                {
-                    "id": 6800,
-                    "recurring": false,
-                    "statistic_id": 9,
-                    "value": "3"
-                },
-                {
-                    "id": 6801,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6802,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6803,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar um ataque, se estiver estressado, você pode gastar 1 <forcecharge> para mudar até 2 de seus resultados <focus> para resultados <evade> ou <hit>.<return><sabold>Pronto para o Ataque:</sabold> Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5958,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5959,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5960,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_36.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "41",
-            "faction_id": 1,
-            "ffg_id": "XW_P_36",
-            "force_side": 2,
-            "id": 36,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_36.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6812,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6813,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6814,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6815,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6816,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar um ataque primário, você pode gastar 1 escudo para rolar 1 dado de ataque adicional ou, se não tiver escudos, você pode rolar 1 dado de ataque a menos para recuperar 1 escudo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6048,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6049,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6050,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6051,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6052,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_62.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "48",
-            "faction_id": 1,
-            "ffg_id": "XW_P_62",
-            "force_side": null,
-            "id": 62,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_62.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Miranda Doni",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6919,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6920,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6921,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6922,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Atacante Pesado",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante a etapa Realizar Ação,você pode realizar 1 ação, mesmose estiver estressado. Após realizar uma ação enquanto estressado, sofra 1 dano<nonbreak><hit>, a menos que você exponha uma de suas cartas de dano.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_83",
-            "force_side": null,
-            "id": 307,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Chopper”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ação:</smallcaps> Gaste 1 <standardcharge> não recursiva de outra melhoria equipada para recuperar 1 escudo. <return><smallcaps>Ação:</smallcaps> Gaste 2 escudos pararecuperar 1 <standardcharge> não recursivade uma melhoria equipada.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_99",
-            "force_side": null,
-            "id": 323,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Chopper\"",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após executar completamente uma manobra, se você não soltou nem lançou um dispositivo nesta rodada, você pode soltar 1 bomba.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_143",
-            "force_side": null,
-            "id": 368,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•“Gênio”",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Você consegue acoplar 1 shuttle deataque ou shuttle classe <italic>Sheathipede</italic>.<return>Suas naves acopladas conseguemser destacadas apenas a partirde suas guias traseiras.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_102",
-            "force_side": null,
-            "id": 326,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Ghost</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 23,
-                            "raw_name": "VCX-100 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "1 Z-95-AF4 Headhunterconsegue acoplar em você.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_148",
-            "force_side": null,
-            "id": 373,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Hound’s Tooth</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 24,
-                            "raw_name": "YV-666 Light Freighter"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Você consegue acoplar em alcance 0-1.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_106",
-            "force_side": null,
-            "id": 330,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Phantom</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 32,
-                            "raw_name": "Attack Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    },
-                    {
-                        "kwargs": {
-                            "pk": 8,
-                            "raw_name": "Sheathipede-class Shuttle"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar um ataque primário,se o defensor estiver em seu <frontarc>,role 1 dado de ataque adicional.<return>Remova o encaixe de melhoria <crew>. Adicione o encaixe de melhoria <astro>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_152",
-            "force_side": null,
-            "id": 377,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>Punishing One</italic>",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 45,
-                            "raw_name": "JumpMaster 5000"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                15
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento,você pode escolher 1 nave inimiga em alcance 0-1. Se fizer isso, você recebe 1 ficha de cálculo, a menos que a nave escolhida receba 1 ficha de estresse.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_127",
-            "force_side": null,
-            "id": 352,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•0-0-0",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 338
-                        },
-                        "type": "CARD_INCLUDED"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Darth Vader",
-                            "pk": 93
-                        },
-                        "type": "CARD_INCLUDED"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após outra nave amiga em alcance 0-3 defender, se ela for destruída, o atacante recebe 2 fichas de estresse.<return>Quando uma nave amiga em alcance 0-3 realizar um ataque contra uma nave estressada, ela pode rerrolar1 dado de ataque.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_109",
-            "force_side": null,
-            "id": 335,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Almirante Sloane",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar um ataque primário,se estiver focado, você pode realizar um ataque <turretarc> bônus contra uma nave que você ainda não atacou nesta rodada.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "14",
-            "faction_id": null,
-            "ffg_id": "XW_U_95",
-            "force_side": null,
-            "id": 319,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bistan",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar um ataque primárioque errou, se não estiver estressado, você <bold>deve</bold> receber 1 ficha de estresse para realizar um ataque primáriobônus contra o mesmo alvo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_139",
-            "force_side": null,
-            "id": 364,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Bossk",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar uma ação <focus>, você pode tratá-la como uma ação vermelha. Se fizer isso, receba 1 ficha de foco adicional para cada nave inimiga em alcance 0-1, até no máximo de 2.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_79",
-            "force_side": null,
-            "id": 303,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Baze Malbus",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante a Fase Final, você pode escolher 2 melhorias <illicit> equipadas em naves amigas em alcance 0-1. Se fizer isso, você pode trocar essas melhorias<return><smallcaps>Final do Jogo:</smallcaps> Returne todas as melhorias <illicit> para suas naves originais.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_131",
-            "force_side": null,
-            "id": 356,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Cikatro Vizago",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ação:</smallcaps> Gaste 1<nonbreak><standardcharge> para realizar uma ação <cloak>.<return>No início da Fase de Planejamento, role 1 dado de ataque. Em um resultado <focus>, descamufle ou descarte sua ficha de camuflagem.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_57",
-            "force_side": null,
-            "id": 286,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Dispositivo de Camuflagem",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6594,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante a Fase de Ativação, naves inimigas em alcance 0-1 não podem remover fichas de estresse.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
-            "card_set_ids": [
-                3
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_113",
-            "force_side": null,
-            "id": 339,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Death Troopers",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8,
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Durante a Fase de Sistema, você pode gastar 2 <standardcharge>.Se fizer isso, cada nave amiga pode travar uma mira em uma nave que você tem uma mira travada.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_117",
-            "force_side": null,
-            "id": 343,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Grão Moff Tarkin",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Lock",
-                            "pk": 4,
-                            "side_effect_name": "STRESS"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6601,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Preparação:</smallcaps> Após posicionar as forças, escolha 1 nave inimiga e atribua a condição <smallcaps>Dispositivo de Escuta</smallcaps> a ela.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_44",
-            "force_side": null,
-            "id": 273,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Informante",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Se uma nave amiga em alcance0-3 for receber uma ficha de foco,ela pode, em vez disso, receber1 ficha de desvio.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_85",
-            "force_side": null,
-            "id": 309,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Jyn Erso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender, se o atacanteestiver estressado, você poderemover 1 estresse do atacantepara mudar 1 de seus resultadosem branco/<focus> para um resultado <evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_135",
-            "force_side": null,
-            "id": 360,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Latts Razzi",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar um ataque,se não houver outranave amiga em alcance 0-2, você pode gastar1<nonbreak><standardcharge> para rerrolar 1 de seus dados.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_9",
-            "force_side": null,
-            "id": 238,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lobo Solitário",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6606,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após defender, se o ataque acertou, você pode travar a mira no atacante.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_89",
-            "force_side": null,
-            "id": 313,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você coordenar, a nave escolhida consegue realizar uma ação apenas se a ação em questão também estiver na sua barra de ações.",
-            "available_actions": [
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 5830,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_16",
-            "force_side": null,
-            "id": 245,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Líder de Esquadrão",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de sofrer dano de um obstáculo ou da detonação de uma bomba amiga, você pode gastar 1<nonbreak><standardcharge>. Se fizer isso, evite 1 dano.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "4",
-            "faction_id": null,
-            "ffg_id": "XW_U_68",
-            "force_side": null,
-            "id": 292,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Revestimento Ablativo",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "LARGE"
-                        },
-                        "type": "SHIP_SIZE"
-                    },
-                    {
-                        "kwargs": {
-                            "ship_size_name": "MEDIUM"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6614,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste1<nonbreak><standardcharge>. Mude 1 resultado<hit> para um resultado <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_33",
-            "force_side": null,
-            "id": 262,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Torpedos de Prótons Avan.",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6615,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "5"
-                },
-                {
-                    "id": 6617,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                5
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1"
-        },
-        {
-            "ability_text": "Após revelar seu disco, vocêpode realizar 1 ação.<return>Se fizer isso, você não pode realizar outra ação durante sua ativação.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_23",
-            "force_side": null,
-            "id": 252,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Sensores Avançados",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar uma ação <slam>, se você executou completamente a manobra,você pode realizar uma ação brancade sua barra de ações, tratando-acomo uma ação vermelha.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_69",
-            "force_side": null,
-            "id": 293,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "SLAM Avançado",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Slam",
-                            "pk": 13,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante a Fase de Sistema,você pode gastar 1 <standardcharge> para soltar uma Bomba Fragmentada com o gabarito [1<nonbreak><straight>].<return>No início da Fase de Ativação, você pode gastar 1 escudopara recuperar 2 <standardcharge>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_63",
-            "force_side": null,
-            "id": 392,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Gerador de Bombas Fragmentadas",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6622,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12,
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>. Após este ataque, vocêpode realizá-lo novamente como ataque bônus contraum alvo diferente em alcance 0-1 do defensor, ignorandoo requisito <targetlock>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_37",
-            "force_side": null,
-            "id": 266,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Mísseis de Fragmentação",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6623,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6625,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "4"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                6
-            ],
-            "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<flavor>Usada para deslocar tropas encobertas pelaescuridão ou até focos de batalha, a U-wing UT-60D atende a necessidade da aliança de ter um transporte de tropas rápido e robusto.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6042,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6043,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6044,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_60.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_60",
-            "force_side": null,
-            "id": 60,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_60.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Batedor do Esq. Azul",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6911,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6912,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6913,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6914,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar um impulso ou uma pirueta, você consegue se mover através e sobrepor obstáculos.<return>Após se mover através ou sobrepor um obstáculo, você pode gastar 1<nonbreak><standardcharge> para ignorar os efeitos do obstáculo até o final da rodada.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_24",
-            "force_side": null,
-            "id": 253,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Detector de Colisão",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6626,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de ativar, você pode gastar 1<nonbreak><standardcharge>. Se fizer isso, até o final da rodada, você consegue realizar ações e executar manobras vermelhas mesmo se estiver estressado.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
-            "card_set_ids": [
-                4,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_58",
-            "force_side": null,
-            "id": 287,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Cibernética Ilegal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6631,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                13
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando realizar uma ação <boost>branca, você pode tratá-lacomo se fosse vermelha parausar o gabarito [1<nonbreak><leftturn>] ou [1<nonbreak><rightturn>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                12
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_2",
-            "force_side": null,
-            "id": 231,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Audacioso",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "ship_size_name": "SMALL"
-                        },
-                        "type": "SHIP_SIZE"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "name": "Boost",
-                            "pk": 1,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Preparação:</smallcaps> Perca 1<nonbreak><standardcharge>.<return><smallcaps>Ação:</smallcaps> Recupere 1<nonbreak><standardcharge>.<return><smallcaps>Ação:</smallcaps> Gaste 1<nonbreak><standardcharge> para recuperar 1 escudo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_43",
-            "force_side": null,
-            "id": 272,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Droide “Gonk” GNK",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6636,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você realizar um ataque <turretarc>, após a etapa Modificar Dadosde Defesa, o defensor remove1 ficha de foco ou de cálculo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "7",
-            "faction_id": null,
-            "ffg_id": "XW_U_49",
-            "force_side": null,
-            "id": 278,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Atirador Excepcional",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Aqueles que não podemadquirir um bom gerador de escudo, adicionam placas encouraçadas adicionais aocasco da nave para compensar.</flavor>",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "*",
-            "faction_id": null,
-            "ffg_id": "XW_U_73",
-            "force_side": null,
-            "id": 297,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Melhoria de Casco",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6642,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                14
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_28",
-            "force_side": null,
-            "id": 257,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Canhão Iônico",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6643,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                3
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
-        },
-        {
-            "ability_text": "Quando realizar umataque <frontarc>, se você nãoestiver no arco de tirodo defensor, ele rola 1dado de defesa a menos.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
-            "card_set_ids": [
-                1,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_11",
-            "force_side": null,
-            "id": 240,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Perseguir",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após revelar seu disco, você pode gastar 1 <standardcharge>e receber 1 ficha de desarmamento para recuperar 1 escudo.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
-            "card_set_ids": [
-                1,
-                4,
-                6,
-                7
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_53",
-            "force_side": null,
-            "id": 282,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Astromecânico R2",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6663,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                10
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você defender, osresultados <crit> são neutralizadosantes dos resultados <hit>.<return><sabold>Pronto para o Ataque:</sabold> Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5961,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5962,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5963,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_37.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "34",
-            "faction_id": 1,
-            "ffg_id": "XW_P_37",
-            "force_side": null,
-            "id": 37,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_37.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6817,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6818,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6819,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6820,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após uma nave inimiga em seu arco de tiro engajar, se você não estiver estressado, você pode receber 1 ficha de estresse. Se você fizer isso, a nave inimiga engajando não pode gastar fichas para modificar dados enquanto estiver realizando um ataque nesta fase.<return><sabold>Shuttle de Comunicação:</sabold> Quando vocêestiver acoplado, seu porta-naves ganha <coordinate>.Antes de o porta-naves ativar, ele poderealizar uma ação <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5964,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5965,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_38.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_38",
-            "force_side": null,
-            "id": 38,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_38.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Fenn Rau",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6821,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6822,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6823,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6824,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6825,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Rebelde Relutante",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Projetadas pela Corellian Engineering Corporation para se parecerem com pássaros em voo, as naves da série “hawk” são naves de transporte exemplares. Rápidas e robustas, a HWK-290 é comumente empregada por agentes Rebeldes como base de operações móvel.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5987,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5988,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5989,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5990,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5991,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_45.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_45",
-            "force_side": null,
-            "id": 45,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_45.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Batedor Rebelde",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6854,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6855,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6856,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6857,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar um ataque, se estiver estressado, você pode gastar 1 <forcecharge> para mudar até 2 de seus resultados <focus> para resultados <evade>/<hit>. <return><sabold>Shuttle de Comunicação:</sabold> Quandovocê estiver acoplado, seu porta-navesganha <coordinate>. Antes de o porta-naves ativar,ele pode realizar uma ação <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5966,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5967,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                8,
-                10,
-                14,
-                15,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_39.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_39",
-            "force_side": 2,
-            "id": 39,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_39.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6826,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6827,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6828,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6829,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6830,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                },
-                {
-                    "id": 6831,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você defender, os resultados <crit>são neutralizados antes dos resultados <hit>.<return><sabold>Shuttle de Comunicação:</sabold> Quandovocê estiver acoplado, seu porta-navesganha <coordinate>. Antes de o porta-naves ativar,ele pode realizar uma ação <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5968,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5969,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_40.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_40",
-            "force_side": null,
-            "id": 40,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_40.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6832,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6833,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6834,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6835,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6836,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você coordenar, se escolheruma nave com exatamente 1 ficha de estresse, ela consegue realizar ações.<return><sabold>Shuttle de Comunicação:</sabold> Quandovocê estiver acoplado, seu porta-navesganha <coordinate>. Antes de o porta-naves ativar,ele pode realizar uma ação <coordinate>.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5970,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": null,
-                    "id": 5971,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                10,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_41.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "30",
-            "faction_id": 1,
-            "ffg_id": "XW_P_41",
-            "force_side": null,
-            "id": 41,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_41.jpg",
-            "initiative": 1,
-            "is_unique": true,
-            "name": "•AP-5",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 8,
-            "statistics": [
-                {
-                    "id": 6837,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6838,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6839,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6840,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6841,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Droide de Análise Fugitivo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave amiga emseu arco de tiro realizar um ataque primário, se você não estiver estressado, você tem a opçãode receber 1 ficha de estresse.Se você fizer isso, a nave amiga pode rolar 1 dado de ataque adicional.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5972,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5973,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5974,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5975,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5976,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_42.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "42",
-            "faction_id": 1,
-            "ffg_id": "XW_P_42",
-            "force_side": null,
-            "id": 42,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_42.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Jan Ors",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6842,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6843,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6844,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6845,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Perita em Espionagem",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento, você pode transferir 1 de suas fichas de foco para uma nave amiga em seu arco de tiro.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5977,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5978,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5979,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5980,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5981,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_43.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_43",
-            "force_side": null,
-            "id": 43,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_43.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kyle Katarn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6846,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6847,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6848,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6849,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Agente Implacável",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento, você pode escolher 1 nave em seu arco de tiro. Se você fizer isso,ela engaja nesta fase utilizandoum valor de iniciativa 7, em vezdo valor de iniciativa normal dela.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5982,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5983,
-                    "related_action_id": 14,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 5984,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5985,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 10,
-                    "base_action_side_effect": "stress",
-                    "id": 5986,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                12,
-                14,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_44.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "38",
-            "faction_id": 1,
-            "ffg_id": "XW_P_44",
-            "force_side": null,
-            "id": 44,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_44.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Roark Garnet",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 34,
-            "statistics": [
-                {
-                    "id": 6850,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                },
-                {
-                    "id": 6851,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6852,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6853,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Contrabandista de Bom Coração",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de ativar, você poderealizar 1<nonbreak>ação <barrelroll> ou <boost>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5995,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5996,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5997,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_47.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "28",
-            "faction_id": 1,
-            "ffg_id": "XW_P_47",
-            "force_side": null,
-            "id": 47,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_47.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Sabine Wren",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6862,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6863,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6864,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Espectro-5",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após se tornar o defensor(antes de rolar os dados),você pode recuperar 1 <forcecharge>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5842,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5843,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5844,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                10,
-                14,
-                17,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_2.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "62",
-            "faction_id": 1,
-            "ffg_id": "XW_P_2",
-            "force_side": 2,
-            "id": 2,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_2.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Luke Skywalker",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6675,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6676,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6677,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6678,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 6679,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Vermelho Cinco",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave amiga realizar um ataque, se o defensor estiver em seu <frontarc>, o atacante pode mudar 1 resultado <hit> para um resultado <crit>.<return><sabold>Sensores Experimentais:</sabold> Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1..",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6009,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6010,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6011,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6012,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6013,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_51.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "68",
-            "faction_id": 1,
-            "ffg_id": "XW_P_51",
-            "force_side": null,
-            "id": 51,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_51.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Gavin Darklighter",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6875,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6876,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6877,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6878,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Parceiro Ousado",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Os pilotos de elite do Esquadrão Rogue estão entre os melhores da Rebelião. </flavor><return><sabold>Sensores Experimentais:</sabold>Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6014,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6015,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6016,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6017,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6018,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_52.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "63",
-            "faction_id": 1,
-            "ffg_id": "XW_P_52",
-            "force_side": null,
-            "id": 52,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_52.jpg",
-            "initiative": 4,
-            "is_unique": false,
-            "name": "Escolta do Esq. Rogue",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6879,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6880,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6881,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6882,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Projetada para combinar as melhores características das séries X-wing e A-wing, a E-wing apresenta poder de fogo, velocidade e manobrabilidade superiores.</flavor><return><sabold>Sensores Experimentais:</sabold>Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6019,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6020,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6021,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6022,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6023,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_53.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "61",
-            "faction_id": 1,
-            "ffg_id": "XW_P_53",
-            "force_side": null,
-            "id": 53,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_53.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Escolta do Esq. Valete",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6883,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6884,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6885,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6886,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após revelar uma manobra vermelha ou azul, você pode rotacionar seu disco para outra manobra de mesma dificuldade.<return><sabold>Pronto para o Ataque:</sabold> Quando você estiver acoplado, após seu porta-naves realizar um ataque primário <frontarc> ou <turret>, ele pode realizar um ataque primário <reararc> bônus.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5952,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5953,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5954,
-                    "related_action_id": 3,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                8,
-                14,
-                15
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_34.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "39",
-            "faction_id": 1,
-            "ffg_id": "XW_P_34",
-            "force_side": null,
-            "id": 34,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_34.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 32,
-            "statistics": [
-                {
-                    "id": 6804,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6805,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6806,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6807,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após uma nave inimiga executar uma manobra, se ela estiver em alcance 0, você pode realizar uma ação.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6039,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6040,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6041,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_59.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "45",
-            "faction_id": 1,
-            "ffg_id": "XW_P_59",
-            "force_side": null,
-            "id": 59,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_59.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Heff Tobber",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6907,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6908,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6909,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6910,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Azul Oito",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Os partidários de Saw Gerrera foram formados inicialmente para opor às forças Separatistas em Onderon durante as Guerras Clônicas e continuaram a combater a tirania galática após a tomada do poder pelo Império.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6045,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6046,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6047,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_61.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "43",
-            "faction_id": 1,
-            "ffg_id": "XW_P_61",
-            "force_side": null,
-            "id": 61,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_61.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Partidário Renegado ",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6915,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6916,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6917,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6918,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>A K-wing fabricada pela Koensayr Manufacturing dispunha de um avançado Motor de Aceleração Sub-Luz (SLAM) e incríveis 18 pontos de encaixe, garantindo velocidade e poder de fogo sem igual.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6058,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6059,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6060,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6061,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6062,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_64.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "40",
-            "faction_id": 1,
-            "ffg_id": "XW_P_64",
-            "force_side": null,
-            "id": 64,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_64.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Piloto do Esq. Protetor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6927,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6928,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6929,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6930,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar um ataque,se estiver estressado, você podegastar 1 <forcecharge> para mudar até 2 de seusresultados <focus> para resultados <evade> ou <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5992,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5993,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5994,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_46.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_46",
-            "force_side": 2,
-            "id": 46,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_46.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ezra Bridger",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6858,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6859,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6860,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6861,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "Espectro-6",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar um ataque, atribua a condição <smallcaps>Tiro Supressivo</smallcaps> ao defensor.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5998,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 5999,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6000,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_48.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "32",
-            "faction_id": 1,
-            "ffg_id": "XW_P_48",
-            "force_side": null,
-            "id": 48,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_48.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Capitão Rex",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6865,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6866,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6867,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Veterano das Guerras Clônicas",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você defender, os resultados <crit> são neutralizados antes dos resultados <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6001,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6002,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6003,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_49.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "26",
-            "faction_id": 1,
-            "ffg_id": "XW_P_49",
-            "force_side": null,
-            "id": 49,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_49.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•“Zeb” Orrelios",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 11,
-            "statistics": [
-                {
-                    "id": 6868,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 6869,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6870,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Espectro-4",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Em iniciativa 0, você pode realizar um ataque primário bônus contra uma nave inimiga em seu <bullseye>. Se fizer isso, no início da próxima Fase de Planejamento, receba 1 ficha de desarmamento.<return><sabold>Sensores Experimentais:</sabold>Você consegue travar miras alémde alcance 3. Você não podetravar miras em alcance 1.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6004,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6005,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6006,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6007,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6008,
-                    "related_action_id": 4,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                5,
-                10,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_50.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "74",
-            "faction_id": 1,
-            "ffg_id": "XW_P_50",
-            "force_side": null,
-            "id": 50,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_50.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Corran Horn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 40,
-            "statistics": [
-                {
-                    "id": 6871,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6872,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 6873,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                },
-                {
-                    "id": 6874,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Investigador Perseverante",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender, se houver uma nave inimiga em alcance 0-1, você pode adicionar 1 resultado <evade> aos resultadosde seus dados.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6063,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6064,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6065,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_65.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "55",
-            "faction_id": 1,
-            "ffg_id": "XW_P_65",
-            "force_side": null,
-            "id": 65,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_65.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Norra Wexley",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6931,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6932,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6933,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6934,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6935,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Dourado Nove",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Naves amigas conseguem travar mirasem objetos que estejam em alcance0-3 de qualquer nave amiga.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6024,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6025,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6026,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_54.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "49",
-            "faction_id": 1,
-            "ffg_id": "XW_P_54",
-            "force_side": null,
-            "id": 54,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_54.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Bodhi Rook",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6887,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6888,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6889,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6890,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Desertor Imperial",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Ativação, vocêpode escolher 1 nave amiga em alcance 1-3. Se você fizer isso, a nave escolhida remove 1 ficha de estresse.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6030,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6031,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6032,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_56.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_56",
-            "force_side": null,
-            "id": 56,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_56.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Cassian Andor",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6895,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6896,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6897,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6898,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Criado pela Rebelião",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave amiga em alcance 0-2 defender, o atacante não pode rerrolar mais de 1 dado de ataque.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6033,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6034,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6035,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_57.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_57",
-            "force_side": null,
-            "id": 57,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_57.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Magva Yarro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6899,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6900,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6901,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6902,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Batedora dos Cavern Angels",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar uma ação <focus>, você pode transferir 1 de suas fichas de foco para uma nave amiga em alcance 1-2.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6036,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6037,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6038,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                2,
-                8,
-                8,
-                13,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_58.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "47",
-            "faction_id": 1,
-            "ffg_id": "XW_P_58",
-            "force_side": null,
-            "id": 58,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_58.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Benthic Two Tubes",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6903,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6904,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6905,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6906,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Artilheiro dos Cavern Angels",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave amiga em alcance0-2 defender ou realizar um ataque,ela pode gastar as suas fichas defoco como se fossem dela.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6053,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6054,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 13,
-                    "base_action_side_effect": null,
-                    "id": 6055,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6056,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 12,
-                    "base_action_side_effect": null,
-                    "id": 6057,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                5,
-                6,
-                6,
-                8,
-                12,
-                12,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_63.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_63",
-            "force_side": null,
-            "id": 63,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_63.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Esege Tuketu",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 30,
-            "statistics": [
-                {
-                    "id": 6923,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "2"
-                },
-                {
-                    "id": 6924,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6925,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6926,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Herói Altruísta",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após gastar 1 ficha de foco, você pode escolher 1 nave amiga em alcance 1-3.A nave escolhida recebe 1 ficha de foco.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6066,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6067,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6068,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_66.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "51",
-            "faction_id": 1,
-            "ffg_id": "XW_P_66",
-            "force_side": null,
-            "id": 66,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_66.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Garven Dreis",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6936,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6937,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6938,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6939,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6940,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Líder Vermelho",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando defender ou realizar umataque primário, você pode gastar1 mira travada na nave inimiga para adicionar 1 resultado <nonbreak><focus> aoresultado de seus dados.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6069,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6070,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6071,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_67.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "53",
-            "faction_id": 1,
-            "ffg_id": "XW_P_67",
-            "force_side": null,
-            "id": 67,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_67.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Shara Bey",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6941,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6942,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6943,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6944,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6945,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Verde Quatro",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após executar completamenteuma manobra, se estiver estressado, você pode rolar 1 dado de ataque.Em um resultado <hit> ou <crit>, remova1 ficha de estresse.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6072,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6073,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": "stress",
-                    "id": 6074,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                10,
-                14,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_68.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "50",
-            "faction_id": 1,
-            "ffg_id": "XW_P_68",
-            "force_side": null,
-            "id": 68,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_68.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Ibtisam",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 31,
-            "statistics": [
-                {
-                    "id": 6946,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6947,
-                    "recurring": false,
-                    "statistic_id": 14,
-                    "value": "2"
-                },
-                {
-                    "id": 6948,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6949,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "6"
-                },
-                {
-                    "id": 6950,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Sobrevivente de Endor",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após rolar os dados, se estiver em alcance 0-1 de um obstáculo, você pode rerrolar todos os seus dados. Para todos os outros efeitos, isso não conta como uma rerrolagem.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6075,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6076,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6077,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6078,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_69.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "92",
-            "faction_id": 1,
-            "ffg_id": "XW_P_69",
-            "force_side": null,
-            "id": 69,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_69.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Han Solo",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6951,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6952,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6953,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6954,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "Patife Mercenário",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de receber uma carta de dano virada para cima, você pode gastar1 <standardcharge> para, em vez disso, receber acarta virada para baixo.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6083,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6084,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6085,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6086,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_71.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 1,
-            "ffg_id": "XW_P_71",
-            "force_side": null,
-            "id": 71,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_71.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Chewbacca",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6959,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6960,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6961,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6962,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                },
-                {
-                    "id": 6963,
-                    "recurring": true,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": "O Poderoso",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Conhecido por sua durabilidadee modularidade, a YT-1300 é um doscargueiros mais populares, mais usadose mais extensivamente personalizadosda galáxia.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6087,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6088,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": "stress",
-                    "id": 6089,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6090,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                6,
-                8,
-                8,
-                13,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_72.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "78",
-            "faction_id": 1,
-            "ffg_id": "XW_P_72",
-            "force_side": null,
-            "id": 72,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_72.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Contrabandistada Orla Exterior",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 1,
-            "statistics": [
-                {
-                    "id": 6964,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 6965,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "1"
-                },
-                {
-                    "id": 6966,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "8"
-                },
-                {
-                    "id": 6967,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "5"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após revelar uma manobra vermelha ou azul, você pode rotacionar seu disco para outra manobra de mesma dificuldade.<return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6091,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6092,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6093,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_73.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "76",
-            "faction_id": 1,
-            "ffg_id": "XW_P_73",
-            "force_side": null,
-            "id": 73,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_73.jpg",
-            "initiative": 5,
-            "is_unique": true,
-            "name": "•Hera Syndulla",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6968,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6969,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6970,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6971,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Espectro-2",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave amiga em seu arcode tiro defender, você pode gastar 1 <forcecharge>.Se você fizer isso, o atacante rola 1 dadode ataque a menos.<return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6094,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6095,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6096,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_74.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "90",
-            "faction_id": 1,
-            "ffg_id": "XW_P_74",
-            "force_side": 2,
-            "id": 74,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_74.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Kanan Jarrus",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6972,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6973,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6974,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6975,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                },
-                {
-                    "id": 6976,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Espectro-1",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "No início da Fase de Engajamento,cada nave inimiga em alcance 0recebe 2 fichas de interferência. <return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6097,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6098,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6099,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_75.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "72",
-            "faction_id": 1,
-            "ffg_id": "XW_P_75",
-            "force_side": null,
-            "id": 75,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_75.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•Chopper\"",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6977,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6978,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6979,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6980,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Espectro-3",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Mais um projeto de sucesso de cargueiroda Corellian Engineering Corporation,o VCX-100 é maior que a popular série YT, dispondo de mais espaço interno e maior capacidade de personalização.</flavor><return><shipability><sabold>Arma de Cauda:</sabold> Quando tiver uma nave acoplada, você tem uma arma primária <reararc> com um valor de ataque igual ao valor de ataque primário da nave acoplada <frontarc>.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6100,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6101,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6102,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                4,
-                5,
-                8,
-                8,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_76.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 1,
-            "cost": "70",
-            "faction_id": 1,
-            "ffg_id": "XW_P_76",
-            "force_side": null,
-            "id": 76,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_76.jpg",
-            "initiative": 2,
-            "is_unique": false,
-            "name": "Rebelde de Lothal",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 23,
-            "statistics": [
-                {
-                    "id": 6981,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "4"
-                },
-                {
-                    "id": 6982,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 6983,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "10"
-                },
-                {
-                    "id": 6984,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>O pilotos de TIE/ln de elite do EsquadrãoPreto acompanharam Darth Vader emum ataque devastador contra as forçasRebeldes na Batalha de Yavin.</flavor>",
             "available_actions": [
                 {
@@ -12311,6 +7715,93 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar uma ação, você podegastar 1 <forcecharge> para realizar uma ação.<return><sabold>Computador de Mira Avançado:</sabold> Quando você realizar um ataque primário contra um defensor em quem você tem uma mira travada, role 1 dado de ataque adicional e mude 1 resultado <hit> para um resultado <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6154,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6155,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6156,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                14,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_93.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 2,
+            "ffg_id": "XW_P_93",
+            "force_side": 1,
+            "id": 93,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_93.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Darth Vader",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7038,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7039,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7040,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7041,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7042,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Líder Preto",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12552,6 +8043,87 @@
                 }
             ],
             "subtitle": "Administrador Cruel",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>A TIE Advanced x1 foi produzida em quantidade limitada, porém os engenheiros da Sienar incorporaram muitas de suas melhores qualidades em seu próximo modelo de TIE: a TIE Interceptor.</flavor><return><sabold>Computador de Mira Avançado:</sabold> Quando você realizar um ataque primário contra um defensor em quem você tem uma mira travada, role 1 dado de ataque adicional e mude 1 resultado <hit> para um resultado <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6166,
+                    "related_action_id": 5,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6167,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6168,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_97.png",
+            "card_set_ids": [
+                5,
+                10
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 2,
+            "ffg_id": "XW_P_97",
+            "force_side": null,
+            "id": 97,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_97.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Ás do Esq. Tormenta",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 13,
+            "statistics": [
+                {
+                    "id": 7055,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7056,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7057,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7058,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -12835,6 +8407,278 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>A TIE Advanced v1 da Sienar Fleet Systems é um projeto de caça estelar revolucionário, apresentando motores aprimorados, um lança-mísseis e s-foils dobráveis.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6182,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6183,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6184,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6185,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6186,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                6
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_101.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_101",
+            "force_side": null,
+            "id": 101,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_101.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Barão do Império",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7073,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7074,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7075,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7076,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Os temidos Inquisidores tinhamuma grande autonomia e acesso às tecnologias mais recentes do Império,como o protótipo TIE Advanced v1.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6187,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6188,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6189,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6190,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6191,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                2,
+                6,
+                17
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 2,
+            "ffg_id": "XW_P_102",
+            "force_side": 1,
+            "id": 102,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Inquisidor",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 25,
+            "statistics": [
+                {
+                    "id": 7077,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7078,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7079,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7080,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                },
+                {
+                    "id": 7081,
+                    "recurring": true,
+                    "statistic_id": 4,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento,se houver uma nave inimiga emseu <bullseye>, receba 1 ficha de foco. <return><shipability><sabold>Autopropulsores:</sabold> Após realizaruma ação, você pode realizaruma ação <barrelroll> ou <boost> vermelha.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6192,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6193,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6194,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6195,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "52",
+            "faction_id": 2,
+            "ffg_id": "XW_P_103",
+            "force_side": null,
+            "id": 103,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Soontir Fel",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 41,
+            "statistics": [
+                {
+                    "id": 7082,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7083,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7084,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Ás Lendário",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Após realizar um ataque, você poderealizar uma ação <barrelroll> ou <boost>,mesmo se estiver estressado.<return><shipability><sabold>Autopropulsores:</sabold> Após realizaruma ação, você pode realizaruma ação <barrelroll> ou <boost> vermelha.</shipability>",
             "available_actions": [
                 {
@@ -12995,86 +8839,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "No início da Fase de Engajamento,se houver uma nave inimiga emseu <bullseye>, receba 1 ficha de foco. <return><shipability><sabold>Autopropulsores:</sabold> Após realizaruma ação, você pode realizaruma ação <barrelroll> ou <boost> vermelha.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6192,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6193,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6194,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6195,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                14,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_103.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 2,
-            "ffg_id": "XW_P_103",
-            "force_side": null,
-            "id": 103,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_103.jpg",
-            "initiative": 6,
-            "is_unique": true,
-            "name": "•Soontir Fel",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 41,
-            "statistics": [
-                {
-                    "id": 7082,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 7083,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "3"
-                },
-                {
-                    "id": 7084,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Ás Lendário",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<flavor>A Sienar Fleet Systems projetou a TIE interceptor com quatro canhões lasers em suas asas, um aumento drástico em seu poder de fogo se comparado com seus antecessores.</flavor><return><shipability><sabold>Autopropulsores:</sabold> Após realizaruma ação, você pode realizaruma ação <barrelroll> ou <boost> vermelha.</shipability>",
             "available_actions": [
                 {
@@ -13149,6 +8913,91 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar uma ação <reload>, você pode recuperar 1 <standardcharge> em 1 de suas cartas de melhoria <talent> equipadas. <return><shipability><sabold>Bombardeiro Ágil:</sabold> Se for soltar um dispositivo usando um gabarito <straight>,você pode, em vez disso, usar um gabarito <leftbank> ou <rightbank> de mesma velocidade.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6208,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6209,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6210,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6211,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_107.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 2,
+            "ffg_id": "XW_P_107",
+            "force_side": null,
+            "id": 107,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_107.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Tomax Bren",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7094,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7095,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7096,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Dissidente Atrevido",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13319,6 +9168,90 @@
                 }
             ],
             "subtitle": "Líder Cimitarra",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após ser destruído, antes de ser removido, você pode realizar umataque e soltar ou lançar 1 dispositivo.<return><shipability><sabold>Bombardeiro Ágil:</sabold> Se for soltar um dispositivo usando um gabarito <straight>, você pode, em vez disso, usar um gabarito<leftbank> ou <rightbank> de mesma velocidade.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6220,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6221,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6222,
+                    "related_action_id": 4,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6223,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                5,
+                6,
+                6,
+                12,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_110.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_110",
+            "force_side": null,
+            "id": 110,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_110.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•“Deathfire”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 19,
+            "statistics": [
+                {
+                    "id": 7103,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7104,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7105,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                }
+            ],
+            "subtitle": "Obstinado Inabalável",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -13580,6 +9513,93 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando defender, se o atacante não tiver fichas verdes, você pode mudar 1 de seus resultados em branco ou <focus> para um resultado <evade>.<return><sabold>Ailerons Adaptáveis:</sabold> Antes de revelarseu disco, se não estiver estressado,você <bold>deve</bold> executar uma manobra[<leftbank> 1], [<straight> 1] ou [<rightbank> 1] branca.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6236,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6237,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6238,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6239,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_114.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 1,
+            "cost": "47",
+            "faction_id": 2,
+            "ffg_id": "XW_P_114",
+            "force_side": null,
+            "id": 114,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_114.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitão Feroph",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 43,
+            "statistics": [
+                {
+                    "id": 7116,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7117,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7118,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7119,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Emissário Imperial",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Após executar completamente uma manobra de velocidade 1 usando sua habilidade de nave <smallcaps>Ailerons Adaptáveis</smallcaps>, você pode realizar uma ação <coordinate>. Se você fizer isso, pule o passo Realizar Ação.<return><sabold>Ailerons Adaptáveis:</sabold> Antes de revelarseu disco, se não estiver estressado,você <bold>deve</bold> executar uma manobra[<leftbank> 1], [<straight> 1] ou [<rightbank> 1] branca.",
             "available_actions": [
                 {
@@ -13826,6 +9846,80 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando defender, após a etapa Neutralizar Resultados, se não estiver estressado, você pode sofrer 1 dano <hit> e receber 1 ficha de estresse. Se fizer isso, cancele todos os resultados dos dados.<return><sabold>Ailerons Adaptáveis:</sabold> Antes de revelar seu disco, se não estiver estressado, você <bold>deve</bold> executar uma manobra [<leftbank> 1], [<straight> 1] ou [<rightbank> 1] branca.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6251,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6252,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6253,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                12,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_118.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_118",
+            "force_side": null,
+            "id": 118,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_118.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•“Countdown”",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 16,
+            "statistics": [
+                {
+                    "id": 7131,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7132,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7133,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Aquele que Desafia a Morte",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando realizar um ataque, se tiver1 ou menos cartas de dano, você poderolar 1 dado de ataque adicional.<return><sabold>Ailerons Adaptáveis:</sabold> Antes de revelar seu disco, se não estiver estressado, você <bold>deve</bold> executar uma manobra [<leftbank> 1], [<straight> 1] ou [<rightbank> 1] branca.",
             "available_actions": [
                 {
@@ -14047,26 +10141,40 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Quando uma nave amiga danificada em alcance 0-3 realizar um ataque, ela pode rerrolar 1 dado de ataque.",
+            "ability_text": "Após realizar um ataque que acertou, se você estiver desviando, exponha 1 dascartas de dano do defensor.<return><shipability><sabold>Força Total:</sabold> Após executar completamente uma manobra de velocidade 3-5, você pode realizar uma ação <evade>.</shipability>",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6263,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6266,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14074,156 +10182,54 @@
             "available_upgrades": [
                 1,
                 2,
-                8,
-                8,
-                13,
-                14,
-                18
+                3,
+                6
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_55.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 1,
-            "cost": "52",
-            "faction_id": 1,
-            "ffg_id": "XW_P_55",
-            "force_side": null,
-            "id": 55,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_55.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 2,
-            "ship_type": 15,
-            "statistics": [
-                {
-                    "id": 6891,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6892,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6893,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "5"
-                },
-                {
-                    "id": 6894,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "3"
-                }
-            ],
-            "subtitle": "Extremista Obsessivo",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<flavor>Os temidos Inquisidores tinhamuma grande autonomia e acesso às tecnologias mais recentes do Império,como o protótipo TIE Advanced v1.</flavor>",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6187,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 3,
-                    "base_action_side_effect": null,
-                    "id": 6188,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6189,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6190,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                },
-                {
-                    "base_action_id": 1,
-                    "base_action_side_effect": null,
-                    "id": 6191,
-                    "related_action_id": 2,
-                    "related_action_side_effect": "stress"
-                }
-            ],
-            "available_upgrades": [
-                2,
-                6,
-                17
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_102.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_122.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 1,
-            "cost": "40",
+            "cost": "84",
             "faction_id": 2,
-            "ffg_id": "XW_P_102",
-            "force_side": 1,
-            "id": 102,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_102.jpg",
-            "initiative": 3,
-            "is_unique": false,
-            "name": "Inquisidor",
+            "ffg_id": "XW_P_122",
+            "force_side": null,
+            "id": 122,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_122.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Rexler Brath",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": 1,
-            "ship_type": 25,
+            "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7143,
                     "recurring": false,
                     "statistic_id": 10,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7078,
+                    "id": 7144,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7145,
                     "recurring": false,
                     "statistic_id": 2,
-                    "value": "2"
+                    "value": "3"
                 },
                 {
-                    "id": 7080,
+                    "id": 7146,
                     "recurring": false,
                     "statistic_id": 3,
-                    "value": "2"
-                },
-                {
-                    "id": 7081,
-                    "recurring": true,
-                    "statistic_id": 4,
-                    "value": "1"
+                    "value": "4"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "Líder Ônix",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -14768,6 +10774,169 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Projetada para batalhas duradouras,a TIE/ag é pilotada principalmente por pilotos de elite treinados para dominartanto seu armamento exclusivo quantosua agilidade com eficiência total.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6294,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6295,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6296,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_129.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 2,
+            "ffg_id": "XW_P_129",
+            "force_side": null,
+            "id": 129,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_129.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Batedor do Esq. Ônix",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7171,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7172,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7173,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7174,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Durante o desenvolvimento da TIE aggressor, a Sienar Fleet Systemsvalorizou mais a sua performance e versatilidade do que o custo-benefício.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6297,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6298,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6299,
+                    "related_action_id": 3,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                4,
+                6,
+                6,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_130.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 2,
+            "ffg_id": "XW_P_130",
+            "force_side": null,
+            "id": 130,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_130.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Especialista Sienar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 29,
+            "statistics": [
+                {
+                    "id": 7175,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7176,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7177,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7178,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Após você realizar um ataque queacertou, receba 1 ficha de desvio.<return><shipability><sabold>Matriz de Stygium:</sabold> Após descamuflar, você pode realizar uma ação <evade>. No início da Fase Final, você pode gastar 1 ficha de desvio para receber 1 ficha de camuflagem.</shipability>",
             "available_actions": [
                 {
@@ -15018,6 +11187,92 @@
                 },
                 {
                     "id": 7190,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Sendo o principal resultado de uma base de pesquisa escondida em Imdaar Alfa, a TIE phantom alcançou algo que muitos julgavam impossível: um pequeno caça estelar equipado com um dispositivo de camuflagem avançado.</flavor><return><shipability><sabold>Matriz de Stygium:</sabold> Após descamuflar, você pode realizar uma ação <evade>. No início da Fase Final, você pode gastar 1 ficha de desviopara receber 1 ficha de camuflagem.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6312,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6313,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6314,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 7,
+                    "base_action_side_effect": null,
+                    "id": 6315,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_134.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "44",
+            "faction_id": 2,
+            "ffg_id": "XW_P_134",
+            "force_side": null,
+            "id": 134,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_134.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Pil. de Testes de Imdaar",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 27,
+            "statistics": [
+                {
+                    "id": 7191,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7192,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7193,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7194,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15285,6 +11540,94 @@
                 },
                 {
                     "id": 7206,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>Com design inspirado por outras navesda Cygnus Spaceworks, a star wing classe <untalic>Alfa</untalic>é uma nave versátil designada a unidadesespeciais da Marinha Imperial que precisamde um caça estelar capaz de ser equipado para executar os mais diversos tipos de missão.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6328,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6329,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 13,
+                    "base_action_side_effect": null,
+                    "id": 6330,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6331,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                5,
+                6,
+                14,
+                18
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_138.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "35",
+            "faction_id": 2,
+            "ffg_id": "XW_P_138",
+            "force_side": null,
+            "id": 138,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_138.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Piloto do Esq. Nu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 14,
+            "statistics": [
+                {
+                    "id": 7207,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7208,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7209,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7210,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -15590,6 +11933,101 @@
             "weapon_range": null
         },
         {
+            "ability_text": "No início da Fase de Engajamento,você pode escolher 1 ou mais navesamigas em alcance 0-3. Se fizerisso, transfira todas as fichas de mira inimigas das naves escolhidas para você.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6347,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6348,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": null,
+                    "id": 6349,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6350,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                3,
+                8,
+                8,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_142.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "48",
+            "faction_id": 2,
+            "ffg_id": "XW_P_142",
+            "force_side": null,
+            "id": 142,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_142.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Capitão Kagi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 26,
+            "statistics": [
+                {
+                    "id": 7223,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7224,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "2"
+                },
+                {
+                    "id": 7225,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7226,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7227,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "O Piloto da Shuttle do Imperador",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "No início da Fase de Ativação, você pode gastar 1 <standardcharge>. Se fizer isso, quando naves amigas travarem miras nesta rodada,elas devem travar miras além de alcance3, em vez de em alcance 0-3.",
             "available_actions": [
                 {
@@ -15876,6 +12314,202 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Você consegue realizar ataquesprimários em alcance 0.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6363,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6364,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6365,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6366,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6367,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "84",
+            "faction_id": 2,
+            "ffg_id": "XW_P_146",
+            "force_side": null,
+            "id": 146,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Capitão Oicunn",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7244,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7245,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7246,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7247,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Estrategista Inspirado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar um ataque, se estiver reforçado e o defensor estiver no <fullfront> ou <fullrear> correspondente à sua ficha de reforço, você pode mudar 1 de seus resultados <focus> para um resultado <crit>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6368,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6369,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6370,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6371,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6372,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                8,
+                12,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_147.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 1,
+            "cost": "88",
+            "faction_id": 2,
+            "ffg_id": "XW_P_147",
+            "force_side": null,
+            "id": 147,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_147.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Almirante deRetaguarda Chiraneau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 28,
+            "statistics": [
+                {
+                    "id": 7248,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "3"
+                },
+                {
+                    "id": 7249,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "0"
+                },
+                {
+                    "id": 7250,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "12"
+                },
+                {
+                    "id": 7251,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Assessor do Almirante Piett",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -16174,6 +12808,104 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando você realizar um ataque primário, se houver ao menos 1 nave amiga não limitada em alcance 0 do defensor, role 1 dado de ataque adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6386,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6387,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": "stress",
+                    "id": 6388,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6389,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_151.png",
+            "card_set_ids": [
+                6,
+                11
+            ],
+            "card_type_id": 1,
+            "cost": "74",
+            "faction_id": 3,
+            "ffg_id": "XW_P_151",
+            "force_side": null,
+            "id": 151,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_151.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Kath Scarlet",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 10,
+            "statistics": [
+                {
+                    "id": 7266,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7267,
+                    "recurring": false,
+                    "statistic_id": 14,
+                    "value": "3"
+                },
+                {
+                    "id": 7268,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7269,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7270,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Capitã dos Piratas Binayre",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando defender ou realizar um ataque, se a nave inimiga estiver estressada,você pode rerrolar 1 de seus dados.",
             "available_actions": [
                 {
@@ -16466,6 +13198,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando defender ou realizar umataque, se o alcance de ataque for 1, você pode rolar 1 dado adicional.<return><sabold>Afronta de Concórdia:</sabold> Quando você defender, se o alcance de ataque for 1 e você estiver no <frontarc> do atacante, mude 1 resultado para um resultado <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6402,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6403,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6404,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6405,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_155.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "68",
+            "faction_id": 3,
+            "ffg_id": "XW_P_155",
+            "force_side": null,
+            "id": 155,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_155.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Fenn Rau",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7286,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7287,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7288,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "Líder Caveira",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "No início da Fase de Engajamento,você pode escolher 1 nave inimiga em alcance 1. Se você fizer isso e estiverno <frontarc> da nave escolhida, ela removetodas as fichas verdes dela.<return><sabold>Afronta de Concórdia:</sabold> Quando você defender, se o alcance de ataque for 1e você estiver no <frontarc> do atacante, mude1 resultado para um resultado <evade>.",
             "available_actions": [
                 {
@@ -16705,6 +13517,86 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Os ases do Esquadrão Caveira preferem aproximações agressivas, utilizando a tecnologia de asas pivotantes para alcançar uma agilidade imbatível durante perseguições. </flavor><return> <sabold>Afronta de Concórdia:</sabold> Quando você defender, se o alcance de ataque for 1 e você estiver no <frontarc> do atacante, mude 1 resultado para um resultado <evade>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6418,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6419,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6420,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6421,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_159.png",
+            "card_set_ids": [
+                6,
+                12
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_159",
+            "force_side": null,
+            "id": 159,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_159.jpg",
+            "initiative": 4,
+            "is_unique": false,
+            "name": "Piloto do Esq. Caveira",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 36,
+            "statistics": [
+                {
+                    "id": 7298,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7299,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7300,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<flavor>Os pilotos do caça Mandaloriano Fang devem dominar a manobra Afronta de Concórdia, aproveitando a silhueta esguia de suas naves para executar ataques frontais mortais. </flavor><return><sabold>Afronta de Concórdia:</sabold> Quando você defender, se o alcance de ataque for 1 e você estiver no <frontarc> do atacante, mude 1 resultado para um resultado <evade>.",
             "available_actions": [
                 {
@@ -16935,6 +13827,156 @@
             "weapon_range": null
         },
         {
+            "ability_text": "No início da Fase de Engajamento, se houver uma ou mais naves em alcance 0, você e cada outra nave em alcance 0 recebem 1 ficha de tração.<return><shipability><sabold>Feixe de Rebocamento Espacial: </sabold><smallcaps>Ação:</smallcaps> Escolha uma nave em seu <frontarc> em alcance 1.A nave escolhida recebe 1 ficha de tração,ou 2 fichas de tração se estiver em seu<bullseye> em alcance 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6432,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6433,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6434,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_163.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "30",
+            "faction_id": 3,
+            "ffg_id": "XW_P_163",
+            "force_side": null,
+            "id": 163,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_163.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Unkar Plutt",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7310,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7311,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7312,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "Senhor da Comida Racionada",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>O rebocador orbital Quadrijet, comumentechamado de \"Quadjumper\", é ágil tanto noespaço quanto na atmosfera, o que o tornou popular entre contrabandistas e exploradores. </flavor><return><shipability><sabold>Feixe de Rebocamento Espacial: </sabold><smallcaps>Ação:</smallcaps> Escolha uma nave em seu <frontarc> em alcance 1. A nave escolhida recebe 1 ficha de tração, ou 2 fichas de tração se estiver em seu <bullseye> em alcance 1.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6435,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": "stress",
+                    "id": 6436,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6437,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                8,
+                12,
+                13,
+                14,
+                19
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_164.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "28",
+            "faction_id": 3,
+            "ffg_id": "XW_P_164",
+            "force_side": null,
+            "id": 164,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_164.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Contrabandistade Armas de Jakku",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 9,
+            "statistics": [
+                {
+                    "id": 7313,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7314,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7315,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando realizar um ataque não <frontarc>,role 1 dado de ataque adicional.",
             "available_actions": [
                 {
@@ -17021,6 +14063,188 @@
                 }
             ],
             "subtitle": "Corsário Calejado",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando uma nave amiga não limitadarealizar um ataque, se o defensorestiver em seu arco de tiro, o atacantepode rerrolar 1 dado de ataque.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6442,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6443,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6444,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6445,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_166.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "40",
+            "faction_id": 3,
+            "ffg_id": "XW_P_166",
+            "force_side": null,
+            "id": 166,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_166.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Drea Renthal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7320,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7321,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7322,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7323,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Lorde Pirata",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>A mera menção de créditos Imperiaispode atrair uma legião de indivíduosnão-muito-confiáveis para o seu lado.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6446,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6447,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6448,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": "stress",
+                    "id": 6449,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                4,
+                5,
+                10,
+                12,
+                13,
+                14,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_167.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "34",
+            "faction_id": 3,
+            "ffg_id": "XW_P_167",
+            "force_side": null,
+            "id": 167,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_167.jpg",
+            "initiative": 2,
+            "is_unique": false,
+            "name": "Mercenário",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 12,
+            "statistics": [
+                {
+                    "id": 7324,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7325,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7326,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7327,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17271,6 +14495,85 @@
                 }
             ],
             "subtitle": "Saqueador Imponente",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Você consegue se destacar apenas com um destacamento de emergência, e possui o nome, a iniciativa, a habilidade de piloto e a <standardcharge> da <smallcaps>Hound’s Tooth</smallcaps> amiga destruída.<return><shipability><sabold>Módulo de Escape:</sabold> <smallcaps>Preparação:</smallcaps>Requer a <smallcaps>Hound’s Tooth</smallcaps>. Você <bold>deve</bold>iniciar o jogo acoplado na <smallcaps>Hound’s Tooth</smallcaps>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6460,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6461,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6462,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_171.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "6",
+            "faction_id": 3,
+            "ffg_id": "XW_P_171",
+            "force_side": null,
+            "id": 171,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_171.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Nashtah Pup</italic>",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 38,
+            "statistics": [
+                {
+                    "id": 7340,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7341,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7342,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7343,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Plano de Contingência",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17532,6 +14835,102 @@
                 }
             ],
             "subtitle": "Mercenário da Orla Exterior",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento, você pode escolher 1 nave inimigaem seu arco de tiro em alcance 0-2.Se fizer isso, transfira 1 fichade foco ou de desvio da naveescolhida para você.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6474,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6475,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6476,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6477,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": "stress",
+                    "id": 6478,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_175.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "38",
+            "faction_id": 3,
+            "ffg_id": "XW_P_175",
+            "force_side": null,
+            "id": 175,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_175.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Palob Godalhi",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 34,
+            "statistics": [
+                {
+                    "id": 7357,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7358,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7359,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7360,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Membro da Resistência de Teth",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -17815,6 +15214,94 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Após executar completamenteuma manobra, você pode receber 1 ficha de estresse para rotacionar sua nave em 90º.<return><sabold>Micropropulsores:</sabold> Quando realizar uma pirueta, você<bold>deve</bold> usar o gabarito <leftbank> ou <rightbank>em vez do gabarito <straight>.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6493,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6494,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6495,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6496,
+                    "related_action_id": 2,
+                    "related_action_side_effect": "stress"
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                5,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_179.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_179",
+            "force_side": null,
+            "id": 179,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_179.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Dalan Oberos",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 3,
+            "statistics": [
+                {
+                    "id": 7373,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7374,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7375,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "4"
+                },
+                {
+                    "id": 7376,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Caçador de Recompensas de Elite",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando você defender, após a etapa Neutralizar Resultados, outra nave amiga em alcance 0-1 e no arco de ataque pode sofrer 1<nonbreak>dano <hit> ou <crit>. Se ela fizer isso, cancele 1 resultado correspondente.<return><sabold>Micropropulsores:</sabold> Quando realizaruma pirueta, você <bold>deve</bold> usar ogabarito <leftbank> ou <rightbank> em vez do gabarito <straight>.",
             "available_actions": [
                 {
@@ -18078,6 +15565,92 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando uma nave amiga em alcance0-1 defender, ela pode rerrolar 1 de seus dados.<return><shipability><sabold>Encaixe de Arma:</sabold> Você consegueequipar 1 melhoria <cannon>, <torpedo>, ou <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6509,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6510,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6511,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6512,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_183.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_183",
+            "force_side": null,
+            "id": 183,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_183.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Serissu",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7389,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7390,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7391,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7392,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Instrutor de Voo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Após travar uma mira, você deveremover todas as suas fichas de focoe de desvio. Então, receba a mesma quantidade de fichas de foco e de desvioque a nave mirada possui.<return><shipability><sabold>Encaixe de Arma:</sabold> Você consegueequipar 1 melhoria <cannon>, <torpedo>, ou <missile>.</shipability>",
             "available_actions": [
                 {
@@ -18331,6 +15904,91 @@
                 }
             ],
             "subtitle": "Caçador de Fortuna",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando você defender ou realizarum ataque, você pode sofrer1 dano <hit> para rerrolar qualquernúmero de seus dados.<return><shipability><sabold>Encaixe de Arma:</sabold> Você consegueequipar 1 melhoria <cannon>, <torpedo>, ou <missile>.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6525,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6526,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6527,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6528,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                14,
+                999
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_187.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "32",
+            "faction_id": 3,
+            "ffg_id": "XW_P_187",
+            "force_side": null,
+            "id": 187,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_187.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•Inaldra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 44,
+            "statistics": [
+                {
+                    "id": 7405,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7406,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7407,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "3"
+                },
+                {
+                    "id": 7408,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Chefe de Ponto Tansarii",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -18592,6 +16250,88 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando você defender em alcancede ataque 3 ou realizar um ataquecom alcance de ataque 1, role 1 dado adicional.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6541,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6542,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6543,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_191.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_191",
+            "force_side": null,
+            "id": 191,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_191.jpg",
+            "initiative": 5,
+            "is_unique": true,
+            "name": "•Talonbane Cobra",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7421,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7422,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7423,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7424,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "Tormento de Ponto Tansarii",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando defender, se você estiver atrás do atacante, role 1 dado de defesa adicional.<return>Quando realizar um ataque, se vocêestiver atrás do defensor, role 1 dadode ataque adicional.",
             "available_actions": [
                 {
@@ -18832,6 +16572,88 @@
                 }
             ],
             "subtitle": "Oportunista Agressivo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<flavor>O caça de assalto Kihraxz foi especialmente desenvolvido para a organização criminosa Sol Negro, cujos áses muito bem pagos exigiam uma nave ágil e poderosa à altura de suas habilidades.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6553,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6554,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6555,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                13,
+                14,
+                14,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_195.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "42",
+            "faction_id": 3,
+            "ffg_id": "XW_P_195",
+            "force_side": null,
+            "id": 195,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_195.jpg",
+            "initiative": 3,
+            "is_unique": false,
+            "name": "Ás do Sol Negro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 1,
+            "ship_type": 7,
+            "statistics": [
+                {
+                    "id": 7437,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7438,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7439,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7440,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "1"
+                }
+            ],
+            "subtitle": "",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19100,6 +16922,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Após realizar uma ação <boost>,você pode realizar uma ação <evade>.<return><shipability><sabold>Cérebro Droide Avançado:</sabold> Após realizar uma ação <calculate>, receba 1 ficha de cálculo.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6567,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 3,
+                    "base_action_side_effect": null,
+                    "id": 6568,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6569,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": null,
+                    "id": 6570,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                2,
+                3,
+                3,
+                12,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_199.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "70",
+            "faction_id": 3,
+            "ffg_id": "XW_P_199",
+            "force_side": null,
+            "id": 199,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_199.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•IG-88C",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 21,
+            "statistics": [
+                {
+                    "id": 7453,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7454,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "3"
+                },
+                {
+                    "id": 7455,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7456,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Engenhoca Calculista",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando executar uma manobra Loop de Segnor (<leftsloop> ou <rightsloop>), você pode usar, em vez desses, outro gabarito de mesma velocidade de: curva acentuada (<leftturn> ou <rightturn>) para a mesma direção ou linha reta (<straight>).<return><shipability><sabold>Cérebro Droide Avançado:</sabold> Após realizar uma ação <calculate>, receba 1 ficha de cálculo.</shipability>",
             "available_actions": [
                 {
@@ -19355,6 +17268,87 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Os lendários Findsmen de Gand venerama névoa que encobre seu planeta natal,usando sinais, presságios e rituais mágicospara rastrear suas presas.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6581,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6582,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 10,
+                    "base_action_side_effect": null,
+                    "id": 6583,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                2,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_203.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "43",
+            "faction_id": 3,
+            "ffg_id": "XW_P_203",
+            "force_side": null,
+            "id": 203,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_203.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Findsman Gand",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 22,
+            "statistics": [
+                {
+                    "id": 7469,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7470,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7471,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "5"
+                },
+                {
+                    "id": 7472,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "4"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Antes que uma bomba ou minaamiga for detonar, você pode gastar1 ￼ para evitar que ela detone.<return>Quando você defender de um ataque obstruído por uma bomba ou mina,role 1 dado de defesa adicional.",
             "available_actions": [
                 {
@@ -19604,6 +17598,95 @@
                 }
             ],
             "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após você realizar um ataque, cada nave inimiga em seu <bullseye> sofre 1 dano<nonbreak><hit>,a menos que ela remova 1 ficha verde.<return><sabold>Na Palma da Mão:</sabold> Quando você realizar um ataque, se o defensor estiver em seu <bullseye>, os dados de defesa não podem ser modificados por fichas verdes.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6593,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6594,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6595,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 12,
+                    "base_action_side_effect": null,
+                    "id": 6596,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                6,
+                10,
+                13,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_207.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "50",
+            "faction_id": 3,
+            "ffg_id": "XW_P_207",
+            "force_side": null,
+            "id": 207,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_207.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Torani Kulda",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 2,
+            "ship_type": 39,
+            "statistics": [
+                {
+                    "id": 7486,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 7487,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7488,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "7"
+                },
+                {
+                    "id": 7489,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Freelancer Rodiano",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -19878,6 +17961,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Se for fugir, você pode gastar 1 ￼.Se fizer isso, coloque-se na reserva,em vez de fugir. No início da próximaFase de Planejamento, posicione-se dentro de alcance 1 da borda da áreade jogo por onde você fugiu.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6608,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 6,
+                    "base_action_side_effect": null,
+                    "id": 6609,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6610,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                3,
+                6,
+                8,
+                8,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_211.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "72",
+            "faction_id": 3,
+            "ffg_id": "XW_P_211",
+            "force_side": null,
+            "id": 211,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_211.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Moralo Eval",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 24,
+            "statistics": [
+                {
+                    "id": 7503,
+                    "recurring": false,
+                    "statistic_id": 9,
+                    "value": "3"
+                },
+                {
+                    "id": 7504,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7505,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "9"
+                },
+                {
+                    "id": 7506,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                },
+                {
+                    "id": 7507,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Mestre do Crime",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "No início da Fase de Engajamento, você pode escolher uma nave em alcance 1 e gastar uma mira sua que estiver travada na nave escolhida. Se fizer isso, a nave escolhida recebe 1 ficha de tração.",
             "available_actions": [
                 {
@@ -20130,6 +18304,88 @@
                 }
             ],
             "subtitle": "Corelliano Vingativo",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento, você pode escolher uma nave amiga em alcance 0-1. Se fizer isso, transfira todas as suas fichas verdes para a nave escolhida.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6620,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6621,
+                    "related_action_id": 14,
+                    "related_action_side_effect": "stress"
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": "stress",
+                    "id": 6622,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                5,
+                8,
+                13,
+                14,
+                15
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_215.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 1,
+            "cost": "54",
+            "faction_id": 3,
+            "ffg_id": "XW_P_215",
+            "force_side": null,
+            "id": 215,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_215.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Manaroo",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": 3,
+            "ship_type": 45,
+            "statistics": [
+                {
+                    "id": 7521,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "2"
+                },
+                {
+                    "id": 7522,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7523,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "6"
+                },
+                {
+                    "id": 7524,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Aruzana Graciosa",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20689,38 +18945,39 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<flavor>Muitos pilotos ganhavam a vida em viagens à Orla Exterior, onde a diferença entre contrabando e comércio legalizado é muitas vezes inexistente.Às margens da civilização, os compradores raramente questionavam a origem das mercadorias, pelo menos enquanto o preço era baixo o suficiente.</flavor>",
+            "ability_text": "Quando defender ou realizarum ataque primário, se o ataqueestiver obstruído por um obstáculo,você pode rolar 1 dado adicional.",
             "available_actions": [
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 6645,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 6646,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 6647,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 6648,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
             ],
             "available_upgrades": [
+                1,
                 6,
                 8,
                 8,
@@ -20729,51 +18986,142 @@
                 15,
                 16
             ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_222.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 1,
-            "cost": "46",
+            "cost": "54",
             "faction_id": 3,
-            "ffg_id": "XW_P_225",
+            "ffg_id": "XW_P_222",
             "force_side": null,
-            "id": 225,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
-            "initiative": 1,
-            "is_unique": false,
-            "name": "Capitão de Cargueiro",
+            "id": 222,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_222.jpg",
+            "initiative": 6,
+            "is_unique": true,
+            "name": "•Han Solo",
             "restrictions": [],
             "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 7555,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 7556,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 7557,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 7558,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 }
             ],
-            "subtitle": "",
+            "subtitle": "O Garoto Corelliano",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após rolar dados, se não estiver estressado, você pode receber1 ficha de estresse para rerrolartodos os seus resultados em branco.",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6649,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6650,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6651,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6652,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_223.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "49",
+            "faction_id": 3,
+            "ffg_id": "XW_P_223",
+            "force_side": null,
+            "id": 223,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_223.jpg",
+            "initiative": 4,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7559,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7560,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7561,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7562,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "Apostador Vigarista",
             "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -20869,6 +19217,96 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Muitos pilotos ganhavam a vida em viagens à Orla Exterior, onde a diferença entre contrabando e comércio legalizado é muitas vezes inexistente.Às margens da civilização, os compradores raramente questionavam a origem das mercadorias, pelo menos enquanto o preço era baixo o suficiente.</flavor>",
+            "available_actions": [
+                {
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6657,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 4,
+                    "base_action_side_effect": null,
+                    "id": 6658,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 1,
+                    "base_action_side_effect": "stress",
+                    "id": 6659,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 6660,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                6,
+                8,
+                8,
+                13,
+                14,
+                15,
+                16
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_225.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "46",
+            "faction_id": 3,
+            "ffg_id": "XW_P_225",
+            "force_side": null,
+            "id": 225,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_225.jpg",
+            "initiative": 1,
+            "is_unique": false,
+            "name": "Capitão de Cargueiro",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 3,
+            "ship_type": 47,
+            "statistics": [
+                {
+                    "id": 7567,
+                    "recurring": false,
+                    "statistic_id": 8,
+                    "value": "2"
+                },
+                {
+                    "id": 7568,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "1"
+                },
+                {
+                    "id": 7569,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "8"
+                },
+                {
+                    "id": 7570,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "3"
+                }
+            ],
+            "subtitle": "",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Após rolar dados, se não estiver estressado, você pode receber1 ficha de estresse para rerrolartodos os seus resultados em branco.<return><shipability><sabold>Copiloto:</sabold> Quando estiver acoplado,seu porta-naves possui sua habilidadede piloto além da habilidade dele.</shipability>",
             "available_actions": [
                 {
@@ -20948,42 +19386,160 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Quando realizar um ataque primário, se o defensor estiver em seu <bullseye>, antes da etapa Neutralizar Resultados, você pode gastar 1 <standardcharge> paracancelar 1 resultado<nonbreak><evade>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                9
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_1",
-            "force_side": null,
-            "id": 230,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Tiro Certeiro",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
+            "ability_text": "Naves amigas em alcance 0-1conseguem realizar ataques emalcance 0 de obstáculos.<return><shipability><sabold>Copiloto:</sabold> Quando estiver acoplado,seu porta-naves possui sua habilidadede piloto além da habilidade dele.</shipability>",
+            "available_actions": [
                 {
-                    "id": 6632,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
+                    "base_action_id": 2,
+                    "base_action_side_effect": null,
+                    "id": 6664,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6665,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6666,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
                 }
             ],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+            "available_upgrades": [
+                1,
+                8,
+                14
             ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_227.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "24",
+            "faction_id": 3,
+            "ffg_id": "XW_P_227",
+            "force_side": null,
+            "id": 227,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_227.jpg",
+            "initiative": 3,
+            "is_unique": true,
+            "name": "•Pioneiro da Orla Exterior",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7575,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7576,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7577,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7578,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Fora-da-Lei Habilidoso",
+            "upgrade_types": [],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Se você não tiver escudos,reduza a dificuldade das suasmanobras de curva (<leftbank> e <rightbank>).<return><shipability><sabold>Copiloto:</sabold> Quando estiver acoplado,seu porta-naves possui sua habilidadede piloto além da habilidade dele.</shipability>",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 6667,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 5,
+                    "base_action_side_effect": null,
+                    "id": 6668,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                },
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 6669,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [
+                1,
+                8,
+                14
+            ],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 1,
+            "cost": "22",
+            "faction_id": 3,
+            "ffg_id": "XW_P_228",
+            "force_side": null,
+            "id": 228,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
+            "initiative": 2,
+            "is_unique": true,
+            "name": "•L3-37",
+            "restrictions": [],
+            "ship_ability_text": "",
+            "ship_size": 1,
+            "ship_type": 48,
+            "statistics": [
+                {
+                    "id": 7579,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "2"
+                },
+                {
+                    "id": 7580,
+                    "recurring": false,
+                    "statistic_id": 1,
+                    "value": "2"
+                },
+                {
+                    "id": 7581,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "2"
+                },
+                {
+                    "id": 7582,
+                    "recurring": false,
+                    "statistic_id": 3,
+                    "value": "2"
+                }
+            ],
+            "subtitle": "Droide Revolucionário",
+            "upgrade_types": [],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21069,81 +19625,94 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Se você não tiver escudos,reduza a dificuldade das suasmanobras de curva (<leftbank> e <rightbank>).<return><shipability><sabold>Copiloto:</sabold> Quando estiver acoplado,seu porta-naves possui sua habilidadede piloto além da habilidade dele.</shipability>",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 6667,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 6668,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6669,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                8,
-                14
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_228.png",
+            "ability_text": "Quando realizar um ataque primário, se o defensor estiver em seu <bullseye>, antes da etapa Neutralizar Resultados, você pode gastar 1 <standardcharge> paracancelar 1 resultado<nonbreak><evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_1.png",
             "card_set_ids": [
-                13
+                4,
+                5,
+                6,
+                9
             ],
-            "card_type_id": 1,
-            "cost": "22",
-            "faction_id": 3,
-            "ffg_id": "XW_P_228",
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_1",
             "force_side": null,
-            "id": 228,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_228.jpg",
-            "initiative": 2,
-            "is_unique": true,
-            "name": "•L3-37",
+            "id": 230,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_1.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Tiro Certeiro",
             "restrictions": [],
-            "ship_ability_text": "",
-            "ship_size": 1,
-            "ship_type": 48,
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 6632,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "2"
-                },
-                {
-                    "id": 7580,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 7581,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "2"
-                },
-                {
-                    "id": 7582,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
+                    "statistic_id": 7,
+                    "value": "1"
                 }
             ],
-            "subtitle": "Droide Revolucionário",
-            "upgrade_types": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar uma ação <boost>branca, você pode tratá-lacomo se fosse vermelha parausar o gabarito [1<nonbreak><leftturn>] ou [1<nonbreak><rightturn>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_2.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                12
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_2",
+            "force_side": null,
+            "id": 231,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_2.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Audacioso",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Boost",
+                            "pk": 1,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
@@ -21351,6 +19920,39 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando uma nave inimiga emalcance 0 defender, ela rola1 dado de defesa a menos.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_7",
+            "force_side": null,
+            "id": 236,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Intimidação",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando realizar um ataque, seestiver desviando, você podemudar 1 dos resultados <evade> dodefensor para um resultado <focus>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21400,6 +20002,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando defender ou realizar um ataque,se não houver outranave amiga em alcance 0-2, você pode gastar1<nonbreak><standardcharge> para rerrolar 1 de seus dados.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_9.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_9",
+            "force_side": null,
+            "id": 238,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_9.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lobo Solitário",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6606,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando realizar um ataque,se o defensor estiver em seu <bullseye>,você pode mudar 1 resultado <hit>para um resultado <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21420,6 +20062,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Franco-Atirador",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar umataque <frontarc>, se você nãoestiver no arco de tirodo defensor, ele rola 1dado de defesa a menos.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_11.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_11",
+            "force_side": null,
+            "id": 240,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_11.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Perseguir",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21558,37 +20233,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "No início da Fase de Engajamento,você pode gastar 1 <forcecharge>. Se fizer isso, engaje em iniciativa 7 nesta fase em vez do seu valor de iniciativa normal.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
-            "card_set_ids": [
-                1,
-                10
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_19",
-            "force_side": null,
-            "id": 248,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Percepção Aguçada",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                17
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Quando outra nave amiga em alcance 0-1 defender, antes da etapa Neutralizar Resultados, se você estiver no arco de ataque, você pode sofrer 1<nonbreak>dano <crit>para cancelar 1<nonbreak>resultado <crit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21630,6 +20274,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Quando você coordenar, a nave escolhida consegue realizar uma ação apenas se a ação em questão também estiver na sua barra de ações.",
+            "available_actions": [
+                {
+                    "base_action_id": 8,
+                    "base_action_side_effect": "stress",
+                    "id": 5830,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_16.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_16",
+            "force_side": null,
+            "id": 245,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_16.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Líder de Esquadrão",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "No início da Fase de Engajamento,você pode escolher 1 nave amiga em alcance 1. Se fizer isso, trate a iniciativa da nave escolhida como se ela fosse igual à sua até o final da rodada.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21658,6 +20343,70 @@
             "subtitle": null,
             "upgrade_types": [
                 1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando você realizar um ataque obstruído por um obstáculo,role 1 dado de ataque adicional.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_18",
+            "force_side": null,
+            "id": 247,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Tiro Ardiloso",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento,você pode gastar 1 <forcecharge>. Se fizer isso, engaje em iniciativa 7 nesta fase em vez do seu valor de iniciativa normal.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_19.png",
+            "card_set_ids": [
+                1,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_19",
+            "force_side": null,
+            "id": 248,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_19.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Percepção Aguçada",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                17
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -21763,6 +20512,78 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Após revelar seu disco, vocêpode realizar 1 ação.<return>Se fizer isso, você não pode realizar outra ação durante sua ativação.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_23.png",
+            "card_set_ids": [
+                2,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_23",
+            "force_side": null,
+            "id": 252,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_23.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Sensores Avançados",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar um impulso ou uma pirueta, você consegue se mover através e sobrepor obstáculos.<return>Após se mover através ou sobrepor um obstáculo, você pode gastar 1<nonbreak><standardcharge> para ignorar os efeitos do obstáculo até o final da rodada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_24.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_24",
+            "force_side": null,
+            "id": 253,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_24.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Detector de Colisão",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6626,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando realizar um ataque, se você tiver uma mira travada no defensor, você pode rerrolar 1 dado de ataque. Se fizer isso, você não pode gastarsua mira durante este ataque.",
             "available_actions": [],
             "available_upgrades": [],
@@ -21783,6 +20604,37 @@
             "initiative": null,
             "is_unique": false,
             "name": "Sistema de Controle de Tiro",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                2
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante a Fase de Sistema, se vocêfor soltar ou lançar uma bomba,você pode, em vez disso, lançá-la usando o gabarito [5<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_set_ids": [
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_26",
+            "force_side": null,
+            "id": 255,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Simulador de Trajetória",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -21836,83 +20688,43 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Durante a Fase de Sistema, se vocêfor soltar ou lançar uma bomba,você pode, em vez disso, lançá-la usando o gabarito [5<nonbreak><straight>].",
+            "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_26.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_28.png",
             "card_set_ids": [
+                4,
                 5,
                 6
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "5",
             "faction_id": null,
-            "ffg_id": "XW_U_26",
+            "ffg_id": "XW_U_28",
             "force_side": null,
-            "id": 255,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_26.jpg",
+            "id": 257,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_28.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Simulador de Trajetória",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                2
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5835,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_32",
-            "force_side": null,
-            "id": 261,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Torre de Canhão Iônico",
+            "name": "Canhão Iônico",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6645,
+                    "id": 6643,
                     "recurring": false,
-                    "statistic_id": 12,
+                    "statistic_id": 10,
                     "value": "3"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
-                4
+                3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 - 3"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, todos os resultados <hit>/<crit> atribuem fichasde interferência em vez de causarem dano.",
@@ -21993,48 +20805,144 @@
             "weapon_range": "1 - 3"
         },
         {
-            "ability_text": "<smallcaps>Ataque (</smallcaps><focus><smallcaps>):</smallcaps> Gaste1<nonbreak><standardcharge>. Se o defensorestiver em seu <bullseye>, você pode gastar 1 ou mais <standardcharge> para rerrolar essa mesma quantidade em dados de ataque.",
-            "available_actions": [],
+            "ability_text": "<smallcaps>Ataque</smallcaps>",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5832,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
             "card_set_ids": [
-                5
+                4,
+                5,
+                6
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_36",
+            "ffg_id": "XW_U_31",
             "force_side": null,
-            "id": 265,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "id": 260,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Torrente de Foguetes",
+            "name": "Torre Dorsal",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6619,
+                    "id": 6633,
                     "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6621,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "5"
+                    "statistic_id": 12,
+                    "value": "2"
                 }
             ],
             "subtitle": null,
             "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
+            "available_actions": [
+                {
+                    "base_action_id": 14,
+                    "base_action_side_effect": null,
+                    "id": 5835,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_32.png",
+            "card_set_ids": [
+                4,
+                5,
                 6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_32",
+            "force_side": null,
+            "id": 261,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_32.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Torre de Canhão Iônico",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6645,
+                    "recurring": false,
+                    "statistic_id": 12,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                4
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": "1 - 2"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste1<nonbreak><standardcharge>. Mude 1 resultado<hit> para um resultado <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_33.png",
+            "card_set_ids": [
+                4,
+                5,
                 6
             ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_33",
+            "force_side": null,
+            "id": 262,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_33.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Torpedos de Prótons Avan.",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6615,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "5"
+                },
+                {
+                    "id": 6617,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                5
+            ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "1"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>.Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
@@ -22129,6 +21037,96 @@
             ],
             "weapon_no_bonus": true,
             "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque (</smallcaps><focus><smallcaps>):</smallcaps> Gaste1<nonbreak><standardcharge>. Se o defensorestiver em seu <bullseye>, você pode gastar 1 ou mais <standardcharge> para rerrolar essa mesma quantidade em dados de ataque.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_36.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_36",
+            "force_side": null,
+            "id": 265,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_36.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Torrente de Foguetes",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6619,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6621,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "5"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6,
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "2 - 3"
+        },
+        {
+            "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>. Após este ataque, vocêpode realizá-lo novamente como ataque bônus contraum alvo diferente em alcance 0-1 do defensor, ignorandoo requisito <targetlock>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_37.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                10
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_37",
+            "force_side": null,
+            "id": 266,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_37.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Mísseis de Fragmentação",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6623,
+                    "recurring": false,
+                    "statistic_id": 10,
+                    "value": "3"
+                },
+                {
+                    "id": 6625,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "4"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                6
+            ],
+            "weapon_no_bonus": true,
+            "weapon_range": "1 - 2"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>. Após este ataque acertar, cada nave em alcance 0-1do defensor expõe 1 desuas cartas de dano.",
@@ -22267,38 +21265,6 @@
             "weapon_range": "2 - 3"
         },
         {
-            "ability_text": "Quando defender, antes que osdados de ataque sejam rolados, você pode gastar uma mira sua travada no atacante para rolar 1 dado de ataque. Se você fizer isso, o atacante recebe 1 ficha de interferência. Então, em um resultado <hit> ou <crit>, receba 1 ficha de interferência.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_42",
-            "force_side": null,
-            "id": 271,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Invasor Independente",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Ataque (</smallcaps><focus><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22344,6 +21310,109 @@
             "weapon_range": "1 - 2"
         },
         {
+            "ability_text": "Quando defender, antes que osdados de ataque sejam rolados, você pode gastar uma mira sua travada no atacante para rolar 1 dado de ataque. Se você fizer isso, o atacante recebe 1 ficha de interferência. Então, em um resultado <hit> ou <crit>, receba 1 ficha de interferência.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_42.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_42",
+            "force_side": null,
+            "id": 271,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_42.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Invasor Independente",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Preparação:</smallcaps> Perca 1<nonbreak><standardcharge>.<return><smallcaps>Ação:</smallcaps> Recupere 1<nonbreak><standardcharge>.<return><smallcaps>Ação:</smallcaps> Gaste 1<nonbreak><standardcharge> para recuperar 1 escudo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_43.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_43",
+            "force_side": null,
+            "id": 272,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_43.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Droide “Gonk” GNK",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6636,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Preparação:</smallcaps> Após posicionar as forças, escolha 1 nave inimiga e atribua a condição <smallcaps>Dispositivo de Escuta</smallcaps> a ela.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_44.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_44",
+            "force_side": null,
+            "id": 273,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_44.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Informante",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "No final da rodada, você pode rolar1 dado de ataque para reparar 1 carta de dano virada para cima. Então, se o resultado foi um <hit>, exponha 1 carta de dano.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22363,6 +21432,39 @@
             "initiative": null,
             "is_unique": false,
             "name": "Técnico Novato",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar uma ação <focus>,receba 1 ficha de foco.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_46",
+            "force_side": null,
+            "id": 275,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Co-piloto Perspicaz",
             "restrictions": [],
             "ship_ability_text": null,
             "ship_size": null,
@@ -22456,6 +21558,38 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando você realizar um ataque <turretarc>, após a etapa Modificar Dadosde Defesa, o defensor remove1 ficha de foco ou de cálculo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_49.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_49",
+            "force_side": null,
+            "id": 278,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_49.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Atirador Excepcional",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -22587,6 +21721,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Após revelar seu disco, você pode gastar 1 <standardcharge>e receber 1 ficha de desarmamento para recuperar 1 escudo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_53.png",
+            "card_set_ids": [
+                1,
+                4,
+                6,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_53",
+            "force_side": null,
+            "id": 282,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_53.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Astromecânico R2",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6663,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Você consegue ter até 2 miras travadas simultaneamente. Cada mira deve estar em um objeto diferente.<return>Após realizar uma ação <targetlock>,você pode travar uma mira.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22702,6 +21876,97 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<smallcaps>Ação:</smallcaps> Gaste 1<nonbreak><standardcharge> para realizar uma ação <cloak>.<return>No início da Fase de Planejamento, role 1 dado de ataque. Em um resultado <focus>, descamufle ou descarte sua ficha de camuflagem.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_57.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_57",
+            "force_side": null,
+            "id": 286,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_57.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Dispositivo de Camuflagem",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "SMALL"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6594,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de ativar, você pode gastar 1<nonbreak><standardcharge>. Se fizer isso, até o final da rodada, você consegue realizar ações e executar manobras vermelhas mesmo se estiver estressado.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_58.png",
+            "card_set_ids": [
+                4,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_58",
+            "force_side": null,
+            "id": 287,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_58.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cibernética Ilegal",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6631,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                13
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Após ser destruído, cada outra nave em alcance 0-1 sofre 1 dano<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -22797,45 +22062,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>Durante a Fase de Sistema, você pode gastar 1 <standardcharge> para soltar uma Rede Conner com o gabarito [1<nonbreak><straight>].<return>A <standardcharge> dessa carta nãopode ser recuperada.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
-            "card_set_ids": [
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_64",
-            "force_side": null,
-            "id": 393,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Rede Conner",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6630,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "<smallcaps>Ação:</smallcaps> Gaste 1<nonbreak><standardcharge>.Solte 1 carregamento solto usando o gabarito [1<nonbreak><straight>].",
             "available_actions": [],
             "available_upgrades": [],
@@ -22890,18 +22116,10 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Ataque</smallcaps>",
-            "available_actions": [
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 5832,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
+            "ability_text": "Antes de sofrer dano de um obstáculo ou da detonação de uma bomba amiga, você pode gastar 1<nonbreak><standardcharge>. Se fizer isso, evite 1 dano.",
+            "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_31.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_68.png",
             "card_set_ids": [
                 4,
                 5,
@@ -22910,60 +22128,35 @@
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_31",
+            "ffg_id": "XW_U_68",
             "force_side": null,
-            "id": 260,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_31.jpg",
+            "id": 292,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_68.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Torre Dorsal",
-            "restrictions": [],
+            "name": "Revestimento Ablativo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "ship_size_name": "LARGE"
+                        },
+                        "type": "SHIP_SIZE"
+                    },
+                    {
+                        "kwargs": {
+                            "ship_size_name": "MEDIUM"
+                        },
+                        "type": "SHIP_SIZE"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
             "statistics": [
                 {
-                    "id": 6633,
-                    "recurring": false,
-                    "statistic_id": 12,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                4
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante a Fase de Sistema, você pode gastar 1 <standardcharge>para soltar umaBomba de Prótonscom o gabarito [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8
-            ],
-            "card_type_id": 2,
-            "cost": "5",
-            "faction_id": null,
-            "ffg_id": "XW_U_65",
-            "force_side": null,
-            "id": 394,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Bombas de Prótons",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6655,
+                    "id": 6614,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -22971,88 +22164,50 @@
             ],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
         },
         {
-            "ability_text": "<bitalic>Mina</bitalic><return>Durante a Fase deSistema, você pode gastar1 <standardcharge> para soltar uma Minade Proximidade como gabarito [1<nonbreak><straight>].<return>A <standardcharge> dessa carta nãopode ser recuperada.",
+            "ability_text": "Após realizar uma ação <slam>, se você executou completamente a manobra,você pode realizar uma ação brancade sua barra de ações, tratando-acomo uma ação vermelha.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_69.png",
             "card_set_ids": [
                 4,
                 5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "6",
-            "faction_id": null,
-            "ffg_id": "XW_U_66",
-            "force_side": null,
-            "id": 395,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Minas de Proximidade",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6662,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                12
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "<bitalic>Bomba</bitalic><return>Durante a Fase de Sistema, você pode gastar 1 <standardcharge> para soltar uma Carga Sísmica com o gabarito [1<nonbreak><straight>].",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                8,
-                11
+                6
             ],
             "card_type_id": 2,
             "cost": "3",
             "faction_id": null,
-            "ffg_id": "XW_U_67",
+            "ffg_id": "XW_U_69",
             "force_side": null,
-            "id": 396,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "id": 293,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_69.jpg",
             "initiative": null,
             "is_unique": false,
-            "name": "Cargas Sísmicas",
-            "restrictions": [],
+            "name": "SLAM Avançado",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Slam",
+                            "pk": 13,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6666,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "2"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                12
+                14
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23187,6 +22342,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "<flavor>Aqueles que não podemadquirir um bom gerador de escudo, adicionam placas encouraçadas adicionais aocasco da nave para compensar.</flavor>",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_73.png",
+            "card_set_ids": [
+                1,
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "*",
+            "faction_id": null,
+            "ffg_id": "XW_U_73",
+            "force_side": null,
+            "id": 297,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_73.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Melhoria de Casco",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6642,
+                    "recurring": false,
+                    "statistic_id": 2,
+                    "value": "+1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando realizar um ataque <torpedo> ou <missile>, após rolar os dados de ataque, você pode cancelar todos os resultados dos dados para recuperar 1 <standardcharge> que gastou como custo do ataque.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23291,54 +22486,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Antes de rolar os dados de defesa, você pode gastar 1 ficha de cálculo para chutar em voz alta um número que seja 1 ou maior. Se você fizer isso e seu chute acertar o número exato de resultados <evade>, adicione1 resultado<nonbreak><evade>.<return>Após realizar a ação <calculate>,receba 1 ficha de cálculo.",
-            "available_actions": [
-                {
-                    "base_action_id": 9,
-                    "base_action_side_effect": null,
-                    "id": 5827,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
-            "card_set_ids": [
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_80",
-            "force_side": null,
-            "id": 304,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•C-3PO",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Quando você defender, se sua <standardcharge> estiver ativa, role 1 dado de defesa adicional.<return>Após sofrer dano,perca 1<nonbreak><standardcharge>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23422,6 +22569,94 @@
             "subtitle": null,
             "upgrade_types": [
                 14
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar uma ação <focus>, você pode tratá-la como uma ação vermelha. Se fizer isso, receba 1 ficha de foco adicional para cada nave inimiga em alcance 0-1, até no máximo de 2.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_79.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_79",
+            "force_side": null,
+            "id": 303,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_79.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Baze Malbus",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de rolar os dados de defesa, você pode gastar 1 ficha de cálculo para chutar em voz alta um número que seja 1 ou maior. Se você fizer isso e seu chute acertar o número exato de resultados <evade>, adicione1 resultado<nonbreak><evade>.<return>Após realizar a ação <calculate>,receba 1 ficha de cálculo.",
+            "available_actions": [
+                {
+                    "base_action_id": 9,
+                    "base_action_side_effect": null,
+                    "id": 5827,
+                    "related_action_id": null,
+                    "related_action_side_effect": null
+                }
+            ],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_80.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "12",
+            "faction_id": null,
+            "ffg_id": "XW_U_80",
+            "force_side": null,
+            "id": 304,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_80.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•C-3PO",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23514,6 +22749,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante a etapa Realizar Ação,você pode realizar 1 ação, mesmose estiver estressado. Após realizar uma ação enquanto estressado, sofra 1 dano<nonbreak><hit>, a menos que você exponha uma de suas cartas de dano.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_83.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_83",
+            "force_side": null,
+            "id": 307,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_83.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Chopper”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Você consegue executar manobrasvermelhas mesmo se estiver estressado. Após executar completamente uma manobra vermelha, se tiver 3 ou mais fichas de estresse, remova 1 ficha de estresse e sofra 1 dano<nonbreak><hit>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23531,6 +22806,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Hera Syndulla",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Se uma nave amiga em alcance0-3 for receber uma ficha de foco,ela pode, em vez disso, receber1 ficha de desvio.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_85.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_85",
+            "force_side": null,
+            "id": 309,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_85.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Jyn Erso",
             "restrictions": [
                 [
                     {
@@ -23688,6 +23003,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Após defender, se o ataque acertou, você pode travar a mira no atacante.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_89.png",
+            "card_set_ids": [
+                2
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_89",
+            "force_side": null,
+            "id": 313,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_89.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Magva Yarro",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Reduza a dificuldade das suas manobras de curva (<leftbank> e <rightbank>).",
             "available_actions": [],
             "available_upgrades": [],
@@ -23705,6 +23060,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Nien Nunb",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante a Fase Final, se vocêestiver danificado e não tiver escudos, você pode rolar 1 dado de ataque para recuperar 1 escudo. Em um resultado <hit>, exponha 1 de suas cartas de dano.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_91",
+            "force_side": null,
+            "id": 315,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R2-D2",
             "restrictions": [
                 [
                     {
@@ -23768,23 +23163,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Durante a Fase Final, se vocêestiver danificado e não tiver escudos, você pode rolar 1 dado de ataque para recuperar 1 escudo. Em um resultado <hit>, exponha 1 de suas cartas de dano.",
+            "ability_text": "Ao realizar um ataque, vocêpode sofrer 1<nonbreak>dano <hit> para mudar todos os seus resultados <focus> para resultados <crit>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_91.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
             "card_set_ids": [
-                4
+                2
             ],
             "card_type_id": 2,
             "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_91",
+            "ffg_id": "XW_U_93",
             "force_side": null,
-            "id": 315,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_91.jpg",
+            "id": 317,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R2-D2",
+            "name": "•Saw Gerrera",
             "restrictions": [
                 [
                     {
@@ -23803,6 +23198,86 @@
             "subtitle": null,
             "upgrade_types": [
                 8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Você consegue realizar ataques primários em alcance 0. Naves inimigas em alcance 0 conseguem realizar ataques primários contra você.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_94",
+            "force_side": null,
+            "id": 318,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Zeb” Orrelios",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar um ataque primário,se estiver focado, você pode realizar um ataque <turretarc> bônus contra uma nave que você ainda não atacou nesta rodada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_95.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "14",
+            "faction_id": null,
+            "ffg_id": "XW_U_95",
+            "force_side": null,
+            "id": 319,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_95.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bistan",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -23895,46 +23370,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Ao realizar um ataque, vocêpode sofrer 1<nonbreak>dano <hit> para mudar todos os seus resultados <focus> para resultados <crit>.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_93.png",
-            "card_set_ids": [
-                2
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_93",
-            "force_side": null,
-            "id": 317,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_93.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Saw Gerrera",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Rebel Alliance",
-                            "pk": 1
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "No início da Fasede Engajamento, vocêpode gastar 1 <forcecharge>para rotacionarseu indicador <turretarc>.",
             "available_actions": [],
             "available_upgrades": [],
@@ -23977,6 +23412,46 @@
             "subtitle": null,
             "upgrade_types": [
                 16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<smallcaps>Ação:</smallcaps> Gaste 1 <standardcharge> não recursiva de outra melhoria equipada para recuperar 1 escudo. <return><smallcaps>Ação:</smallcaps> Gaste 2 escudos pararecuperar 1 <standardcharge> não recursivade uma melhoria equipada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_99.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_99",
+            "force_side": null,
+            "id": 323,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_99.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Chopper\"",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24076,23 +23551,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Você consegue realizar ataques primários em alcance 0. Naves inimigas em alcance 0 conseguem realizar ataques primários contra você.",
+            "ability_text": "Você consegue acoplar 1 shuttle deataque ou shuttle classe <italic>Sheathipede</italic>.<return>Suas naves acopladas conseguemser destacadas apenas a partirde suas guias traseiras.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_94.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_102.png",
             "card_set_ids": [
                 4
             ],
             "card_type_id": 2,
-            "cost": "1",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_94",
+            "ffg_id": "XW_U_102",
             "force_side": null,
-            "id": 318,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_94.jpg",
+            "id": 326,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_102.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•“Zeb” Orrelios",
+            "name": "•<italic>Ghost</italic>",
             "restrictions": [
                 [
                     {
@@ -24102,6 +23577,15 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 23,
+                            "raw_name": "VCX-100 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
@@ -24110,40 +23594,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando você realizar um ataque obstruído por um obstáculo,role 1 dado de ataque adicional.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_18.png",
-            "card_set_ids": [
-                2,
-                4,
-                5,
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_18",
-            "force_side": null,
-            "id": 247,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_18.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Tiro Ardiloso",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24311,6 +23762,103 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Você consegue acoplar em alcance 0-1.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_106.png",
+            "card_set_ids": [
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_106",
+            "force_side": null,
+            "id": 330,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_106.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>Phantom</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Rebel Alliance",
+                            "pk": 1
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 32,
+                            "raw_name": "Attack Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    },
+                    {
+                        "kwargs": {
+                            "pk": 8,
+                            "raw_name": "Sheathipede-class Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de ativar, você podevirar esta carta.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
+            "card_set_ids": [
+                2,
+                4
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_107",
+            "force_side": null,
+            "id": 331,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Asas Pivotantes (Abertas)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 15,
+                            "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando você defender, role1 dado de defesa a menos.<return>Após executar uma manobra [0 <stop>], você pode rotacionar sua nave em90° ou 180°.<return>Antes de ativar, você podevirar esta carta.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24332,6 +23880,49 @@
                         "kwargs": {
                             "pk": 15,
                             "raw_name": "UT-60D U-wing"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Antes de ativar, você podevirar esta carta.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_set_ids": [
+                1,
+                2,
+                4,
+                7
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_108",
+            "force_side": null,
+            "id": 333,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Servomotor de S-foils (Aberto)",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "pk": 33,
+                            "raw_name": "T-65 X-wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -24402,34 +23993,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Antes de ativar, você podevirar esta carta.",
+            "ability_text": "Após outra nave amiga em alcance 0-3 defender, se ela for destruída, o atacante recebe 2 fichas de estresse.<return>Quando uma nave amiga em alcance 0-3 realizar um ataque contra uma nave estressada, ela pode rerrolar1 dado de ataque.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_108.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_109.png",
             "card_set_ids": [
-                1,
-                2,
-                4,
-                7
+                5
             ],
             "card_type_id": 2,
-            "cost": "0",
+            "cost": "10",
             "faction_id": null,
-            "ffg_id": "XW_U_108",
+            "ffg_id": "XW_U_109",
             "force_side": null,
-            "id": 333,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_108.jpg",
+            "id": 335,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_109.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Servomotor de S-foils (Aberto)",
+            "is_unique": true,
+            "name": "•Almirante Sloane",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "pk": 33,
-                            "raw_name": "T-65 X-wing"
+                            "name": "Galactic Empire",
+                            "pk": 2
                         },
-                        "type": "SHIP_TYPE"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -24439,7 +24027,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                18
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -24590,6 +24178,47 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante a Fase de Ativação, naves inimigas em alcance 0-1 não podem remover fichas de estresse.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_113.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_113",
+            "force_side": null,
+            "id": 339,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_113.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Death Troopers",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8,
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "<smallcaps>Preparação:</smallcaps> Antes de posicionar as forças, atribua a condição <smallcaps>Protótipo Otimizado</smallcaps> a outra nave amiga.",
             "available_actions": [
                 {
@@ -24733,6 +24362,111 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Durante a Fase de Sistema, você pode gastar 2 <standardcharge>.Se fizer isso, cada nave amiga pode travar uma mira em uma nave que você tem uma mira travada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_117.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_117",
+            "force_side": null,
+            "id": 343,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_117.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Grão Moff Tarkin",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Lock",
+                            "pk": 4,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6601,
+                    "recurring": true,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante a Fase Final, naves inimigas em alcance 1-2 não podem remover fichas de interferência.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_set_ids": [
+                3
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_118",
+            "force_side": null,
+            "id": 344,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Invasor do DSI",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "No início da Fase de Engajamento, se você estiver danificado, você poderealizar uma ação <reinforce> vermelha.",
             "available_actions": [],
             "available_upgrades": [],
@@ -24838,23 +24572,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Durante a Fase Final, naves inimigas em alcance 1-2 não podem remover fichas de interferência.",
+            "ability_text": "Se uma nave inimiga em alcance 0-1 for receberuma ficha de estresse, você pode gastar 1 <forcecharge> para fazer com que ela receba, em vez disso, 1 ficha de interferência ou de tração.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_118.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
             "card_set_ids": [
-                3
+                5
             ],
             "card_type_id": 2,
-            "cost": "3",
+            "cost": "12",
             "faction_id": null,
-            "ffg_id": "XW_U_118",
+            "ffg_id": "XW_U_121",
             "force_side": null,
-            "id": 344,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_118.jpg",
+            "id": 347,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Invasor do DSI",
+            "is_unique": true,
+            "name": "•Sétima Irmã",
             "restrictions": [
                 [
                     {
@@ -24869,7 +24603,14 @@
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [],
+            "statistics": [
+                {
+                    "id": 6613,
+                    "recurring": false,
+                    "statistic_id": 4,
+                    "value": "+1"
+                }
+            ],
             "subtitle": null,
             "upgrade_types": [
                 8
@@ -24925,94 +24666,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Se uma nave inimiga em alcance 0-1 for receberuma ficha de estresse, você pode gastar 1 <forcecharge> para fazer com que ela receba, em vez disso, 1 ficha de interferência ou de tração.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_121.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 2,
-            "cost": "12",
-            "faction_id": null,
-            "ffg_id": "XW_U_121",
-            "force_side": null,
-            "id": 347,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_121.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Sétima Irmã",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6613,
-                    "recurring": false,
-                    "statistic_id": 4,
-                    "value": "+1"
-                }
-            ],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Antes de ativar, você podevirar esta carta.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_107.png",
-            "card_set_ids": [
-                2,
-                4
-            ],
-            "card_type_id": 2,
-            "cost": "0",
-            "faction_id": null,
-            "ffg_id": "XW_U_107",
-            "force_side": null,
-            "id": 331,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_107.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Asas Pivotantes (Abertas)",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "pk": 15,
-                            "raw_name": "UT-60D U-wing"
-                        },
-                        "type": "SHIP_TYPE"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                18
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Após executar parcialmenteuma manobra, você pode realizar1 ação branca, tratando-a comose fosse vermelha.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25062,38 +24715,29 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Após realizar uma ação <coordinate>, você tem a opção de escolher uma nave inimiga em alcance 0-3 da nave que você coordenou. Se fizer isso, trave uma mira na nave inimiga escolhida, ignorando as restrições de alcance.",
+            "ability_text": "Quando tiver exatamente 1 fichade desarmamento, você ainda consegue realizar ataques <torpedo> e <missile> contra alvosnos quais você tem uma mira travada.Se fizer isso, você não pode gastarsua trava de mira durante este ataque.<return>Adicione os encaixes de melhoria <torpedo> e <missile>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_125.png",
             "card_set_ids": [
                 5
             ],
             "card_type_id": 2,
-            "cost": "6",
+            "cost": "0",
             "faction_id": null,
-            "ffg_id": "XW_U_124",
+            "ffg_id": "XW_U_125",
             "force_side": null,
-            "id": 391,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "id": 350,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_125.jpg",
             "initiative": null,
-            "is_unique": true,
-            "name": "•<italic>ST-321</italic>",
+            "is_unique": false,
+            "name": "Carga de Arsenal Os-1",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Galactic Empire",
-                            "pk": 2
-                        },
-                        "type": "FACTION"
-                    }
-                ],
-                [
-                    {
-                        "kwargs": {
-                            "pk": 26,
-                            "raw_name": "Lambda-class T-4a Shuttle"
+                            "pk": 14,
+                            "raw_name": "Alpha-class Star Wing"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -25105,7 +24749,7 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                15
+                18
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25146,6 +24790,60 @@
             "subtitle": null,
             "upgrade_types": [
                 18
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase de Engajamento,você pode escolher 1 nave inimiga em alcance 0-1. Se fizer isso, você recebe 1 ficha de cálculo, a menos que a nave escolhida receba 1 ficha de estresse.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_127.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_127",
+            "force_side": null,
+            "id": 352,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_127.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•0-0-0",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 338
+                        },
+                        "type": "CARD_INCLUDED"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Darth Vader",
+                            "pk": 93
+                        },
+                        "type": "CARD_INCLUDED"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25249,6 +24947,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Cad Bane",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Durante a Fase Final, você pode escolher 2 melhorias <illicit> equipadas em naves amigas em alcance 0-1. Se fizer isso, você pode trocar essas melhorias<return><smallcaps>Final do Jogo:</smallcaps> Returne todas as melhorias <illicit> para suas naves originais.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_131.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_131",
+            "force_side": null,
+            "id": 356,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_131.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Cikatro Vizago",
             "restrictions": [
                 [
                     {
@@ -25385,6 +25123,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Ketsu Onyo",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando defender, se o atacanteestiver estressado, você poderemover 1 estresse do atacantepara mudar 1 de seus resultadosem branco/<focus> para um resultado <evade>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_135.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "7",
+            "faction_id": null,
+            "ffg_id": "XW_U_135",
+            "force_side": null,
+            "id": 360,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_135.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Latts Razzi",
             "restrictions": [
                 [
                     {
@@ -25563,6 +25341,46 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Após realizar um ataque primárioque errou, se não estiver estressado, você <bold>deve</bold> receber 1 ficha de estresse para realizar um ataque primáriobônus contra o mesmo alvo.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_139.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "10",
+            "faction_id": null,
+            "ffg_id": "XW_U_139",
+            "force_side": null,
+            "id": 364,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_139.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Bossk",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                16
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Quando realizar um ataque, você pode mudar 1 resultado<nonbreak><hit> para um resultado <crit> para cada ficha de estresse que o defensor tiver.",
             "available_actions": [],
             "available_upgrades": [],
@@ -25711,6 +25529,133 @@
             "weapon_range": null
         },
         {
+            "ability_text": "Após executar completamente uma manobra, se você não soltou nem lançou um dispositivo nesta rodada, você pode soltar 1 bomba.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_143.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "0",
+            "faction_id": null,
+            "ffg_id": "XW_U_143",
+            "force_side": null,
+            "id": 368,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_143.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•“Gênio”",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando realizar um ataque contra um defensor emseu <frontarc>, você pode gastar 1 <standardcharge> para rerrolar 1 dado de ataque. Se o resultado rerrolado for um <crit>, sofra 1 dano <crit>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "4",
+            "faction_id": null,
+            "ffg_id": "XW_U_144",
+            "force_side": null,
+            "id": 369,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-P8",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6612,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "3"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Você consegue realizar ataquescontra naves amigas.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "1",
+            "faction_id": null,
+            "ffg_id": "XW_U_145",
+            "force_side": null,
+            "id": 370,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•R5-TK",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                10
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
             "ability_text": "Adicione o encaixede melhoria <bomb>.",
             "available_actions": [
                 {
@@ -25818,23 +25763,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Quando realizar um ataque contra um defensor emseu <frontarc>, você pode gastar 1 <standardcharge> para rerrolar 1 dado de ataque. Se o resultado rerrolado for um <crit>, sofra 1 dano <crit>.",
+            "ability_text": "1 Z-95-AF4 Headhunterconsegue acoplar em você.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_144.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_148.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "4",
+            "cost": "1",
             "faction_id": null,
-            "ffg_id": "XW_U_144",
+            "ffg_id": "XW_U_148",
             "force_side": null,
-            "id": 369,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_144.jpg",
+            "id": 373,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_148.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•R5-P8",
+            "name": "•<italic>Hound’s Tooth</italic>",
             "restrictions": [
                 [
                     {
@@ -25844,22 +25789,73 @@
                         },
                         "type": "FACTION"
                     }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 24,
+                            "raw_name": "YV-666 Light Freighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
                 ]
             ],
             "ship_ability_text": null,
             "ship_size": null,
             "ship_type": null,
-            "statistics": [
-                {
-                    "id": 6612,
-                    "recurring": false,
-                    "statistic_id": 7,
-                    "value": "3"
-                }
-            ],
+            "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                10
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Você tem a habilidade de pilotode cada outra nave amiga coma carta de melhoria <sabold>IG-2000</sabold>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_set_ids": [
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_149",
+            "force_side": null,
+            "id": 374,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "<italic>IG-2000</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 21,
+                            "raw_name": "Aggressor Assault Fighter"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -25971,23 +25967,23 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Você tem a habilidade de pilotode cada outra nave amiga coma carta de melhoria <sabold>IG-2000</sabold>.",
+            "ability_text": "Quando realizar um ataque primário,se o defensor estiver em seu <frontarc>,role 1 dado de ataque adicional.<return>Remova o encaixe de melhoria <crew>. Adicione o encaixe de melhoria <astro>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_149.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_152.png",
             "card_set_ids": [
                 6
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "8",
             "faction_id": null,
-            "ffg_id": "XW_U_149",
+            "ffg_id": "XW_U_152",
             "force_side": null,
-            "id": 374,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_149.jpg",
+            "id": 377,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_152.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "<italic>IG-2000</italic>",
+            "is_unique": true,
+            "name": "•<italic>Punishing One</italic>",
             "restrictions": [
                 [
                     {
@@ -26001,8 +25997,8 @@
                 [
                     {
                         "kwargs": {
-                            "pk": 21,
-                            "raw_name": "Aggressor Assault Fighter"
+                            "pk": 45,
+                            "raw_name": "JumpMaster 5000"
                         },
                         "type": "SHIP_TYPE"
                     }
@@ -26172,23 +26168,72 @@
             "weapon_range": null
         },
         {
-            "ability_text": "<smallcaps>Preparação:</smallcaps> Equipe estelado para cima.<return>Quando defender, você pode virar esta carta. Se fizer isso, o atacante devererrolar todos os dados de ataque.",
+            "ability_text": "Após falhar em uma ação, se vocênão tiver fichas verdes, você pode realizar uma ação <focus>.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_156",
+            "force_side": null,
+            "id": 381,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Compostura",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "STRESS"
+                        },
+                        "type": "ACTION"
+                    },
+                    {
+                        "kwargs": {
+                            "name": "Focus",
+                            "pk": 2,
+                            "side_effect_name": "NONE"
+                        },
+                        "type": "ACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                1
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "No início da Fase Final, você pode gastar 1 ficha de foco para reparar1 de suas cartas de dano viradas para cima.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_157.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
             "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_158",
+            "ffg_id": "XW_U_157",
             "force_side": null,
-            "id": 384,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
+            "id": 382,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_157.jpg",
             "initiative": null,
             "is_unique": true,
-            "name": "•L3-37",
+            "name": "•Chewbacca",
             "restrictions": [
                 [
                     {
@@ -26250,40 +26295,31 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Após falhar em uma ação, se vocênão tiver fichas verdes, você pode realizar uma ação <focus>.",
+            "ability_text": "<smallcaps>Preparação:</smallcaps> Equipe estelado para cima.<return>Quando defender, você pode virar esta carta. Se fizer isso, o atacante devererrolar todos os dados de ataque.",
             "available_actions": [],
             "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_156.png",
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_158.png",
             "card_set_ids": [
                 13
             ],
             "card_type_id": 2,
-            "cost": "2",
+            "cost": "4",
             "faction_id": null,
-            "ffg_id": "XW_U_156",
+            "ffg_id": "XW_U_158",
             "force_side": null,
-            "id": 381,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_156.jpg",
+            "id": 384,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_158.jpg",
             "initiative": null,
-            "is_unique": false,
-            "name": "Compostura",
+            "is_unique": true,
+            "name": "•L3-37",
             "restrictions": [
                 [
                     {
                         "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "STRESS"
+                            "name": "Scum and Villainy",
+                            "pk": 3
                         },
-                        "type": "ACTION"
-                    },
-                    {
-                        "kwargs": {
-                            "name": "Focus",
-                            "pk": 2,
-                            "side_effect_name": "NONE"
-                        },
-                        "type": "ACTION"
+                        "type": "FACTION"
                     }
                 ]
             ],
@@ -26293,7 +26329,47 @@
             "statistics": [],
             "subtitle": null,
             "upgrade_types": [
-                1
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após rolar dados, você podegastar 1 ficha verde para rerrolaraté 2 de seus resultados.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "8",
+            "faction_id": null,
+            "ffg_id": "XW_U_159",
+            "force_side": null,
+            "id": 385,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Lando Calrissian",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26316,6 +26392,46 @@
             "initiative": null,
             "is_unique": true,
             "name": "•Tobias Beckett",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Scum and Villainy",
+                            "pk": 3
+                        },
+                        "type": "FACTION"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                8
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Quando se mover e realizarataques, você ignora obstáculosem que tem uma mira travada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
+            "card_set_ids": [
+                13
+            ],
+            "card_type_id": 2,
+            "cost": "2",
+            "faction_id": null,
+            "ffg_id": "XW_U_161",
+            "force_side": null,
+            "id": 387,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•Qi’ra",
             "restrictions": [
                 [
                     {
@@ -26369,46 +26485,6 @@
             "weapon_range": null
         },
         {
-            "ability_text": "Após rolar dados, você podegastar 1 ficha verde para rerrolaraté 2 de seus resultados.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_159.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "8",
-            "faction_id": null,
-            "ffg_id": "XW_U_159",
-            "force_side": null,
-            "id": 385,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_159.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Lando Calrissian",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
             "ability_text": "Antes de engajar, você poderealizar uma ação <focus> vermelha.",
             "available_actions": [],
             "available_upgrades": [],
@@ -26444,331 +26520,6 @@
             "subtitle": null,
             "upgrade_types": [
                 16
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando se mover e realizarataques, você ignora obstáculosem que tem uma mira travada.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_161.png",
-            "card_set_ids": [
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "2",
-            "faction_id": null,
-            "ffg_id": "XW_U_161",
-            "force_side": null,
-            "id": 387,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_161.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•Qi’ra",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após receber uma ficha deestresse, você pode rolar 1 dadode ataque para removê-la. Em um resultado <hit>, sofra 1 dano <hit>.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 5851,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 5852,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 5,
-                    "base_action_side_effect": null,
-                    "id": 5853,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                10,
-                14,
-                18
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_5.png",
-            "card_set_ids": [
-                1
-            ],
-            "card_type_id": 1,
-            "cost": "46",
-            "faction_id": 1,
-            "ffg_id": "XW_P_5",
-            "force_side": null,
-            "id": 5,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_5.jpg",
-            "initiative": 4,
-            "is_unique": true,
-            "name": "•Jek Porkins",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 1,
-            "ship_type": 33,
-            "statistics": [
-                {
-                    "id": 6688,
-                    "recurring": false,
-                    "statistic_id": 10,
-                    "value": "3"
-                },
-                {
-                    "id": 6689,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "2"
-                },
-                {
-                    "id": 6690,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "4"
-                },
-                {
-                    "id": 6691,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "2"
-                }
-            ],
-            "subtitle": "Vermelho Seis",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Você consegue realizar ataquesprimários em alcance 0.",
-            "available_actions": [
-                {
-                    "base_action_id": 2,
-                    "base_action_side_effect": null,
-                    "id": 6363,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 4,
-                    "base_action_side_effect": null,
-                    "id": 6364,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 6,
-                    "base_action_side_effect": null,
-                    "id": 6365,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 14,
-                    "base_action_side_effect": null,
-                    "id": 6366,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                },
-                {
-                    "base_action_id": 8,
-                    "base_action_side_effect": "stress",
-                    "id": 6367,
-                    "related_action_id": null,
-                    "related_action_side_effect": null
-                }
-            ],
-            "available_upgrades": [
-                1,
-                5,
-                8,
-                8,
-                12,
-                14,
-                15,
-                16
-            ],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Pilot_146.png",
-            "card_set_ids": [
-                5
-            ],
-            "card_type_id": 1,
-            "cost": "84",
-            "faction_id": 2,
-            "ffg_id": "XW_P_146",
-            "force_side": null,
-            "id": 146,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_P_146.jpg",
-            "initiative": 3,
-            "is_unique": true,
-            "name": "•Capitão Oicunn",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": 3,
-            "ship_type": 28,
-            "statistics": [
-                {
-                    "id": 7244,
-                    "recurring": false,
-                    "statistic_id": 8,
-                    "value": "3"
-                },
-                {
-                    "id": 7245,
-                    "recurring": false,
-                    "statistic_id": 1,
-                    "value": "0"
-                },
-                {
-                    "id": 7246,
-                    "recurring": false,
-                    "statistic_id": 2,
-                    "value": "12"
-                },
-                {
-                    "id": 7247,
-                    "recurring": false,
-                    "statistic_id": 3,
-                    "value": "4"
-                }
-            ],
-            "subtitle": "Estrategista Inspirado",
-            "upgrade_types": [],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Quando uma nave inimiga emalcance 0 defender, ela rola1 dado de defesa a menos.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_7.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                13
-            ],
-            "card_type_id": 2,
-            "cost": "3",
-            "faction_id": null,
-            "ffg_id": "XW_U_7",
-            "force_side": null,
-            "id": 236,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_7.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Intimidação",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                1
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Após realizar uma ação <focus>,receba 1 ficha de foco.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_46.png",
-            "card_set_ids": [
-                4,
-                5,
-                6,
-                11
-            ],
-            "card_type_id": 2,
-            "cost": "10",
-            "faction_id": null,
-            "ffg_id": "XW_U_46",
-            "force_side": null,
-            "id": 275,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_46.jpg",
-            "initiative": null,
-            "is_unique": false,
-            "name": "Co-piloto Perspicaz",
-            "restrictions": [],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                8
-            ],
-            "weapon_no_bonus": false,
-            "weapon_range": null
-        },
-        {
-            "ability_text": "Você consegue realizar ataquescontra naves amigas.",
-            "available_actions": [],
-            "available_upgrades": [],
-            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_145.png",
-            "card_set_ids": [
-                6
-            ],
-            "card_type_id": 2,
-            "cost": "1",
-            "faction_id": null,
-            "ffg_id": "XW_U_145",
-            "force_side": null,
-            "id": 370,
-            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_145.jpg",
-            "initiative": null,
-            "is_unique": true,
-            "name": "•R5-TK",
-            "restrictions": [
-                [
-                    {
-                        "kwargs": {
-                            "name": "Scum and Villainy",
-                            "pk": 3
-                        },
-                        "type": "FACTION"
-                    }
-                ]
-            ],
-            "ship_ability_text": null,
-            "ship_size": null,
-            "ship_type": null,
-            "statistics": [],
-            "subtitle": null,
-            "upgrade_types": [
-                10
             ],
             "weapon_no_bonus": false,
             "weapon_range": null
@@ -26818,6 +26569,255 @@
             "subtitle": null,
             "upgrade_types": [
                 15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "Após realizar uma ação <coordinate>, você tem a opção de escolher uma nave inimiga em alcance 0-3 da nave que você coordenou. Se fizer isso, trave uma mira na nave inimiga escolhida, ignorando as restrições de alcance.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_124.png",
+            "card_set_ids": [
+                5
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_124",
+            "force_side": null,
+            "id": 391,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_124.jpg",
+            "initiative": null,
+            "is_unique": true,
+            "name": "•<italic>ST-321</italic>",
+            "restrictions": [
+                [
+                    {
+                        "kwargs": {
+                            "name": "Galactic Empire",
+                            "pk": 2
+                        },
+                        "type": "FACTION"
+                    }
+                ],
+                [
+                    {
+                        "kwargs": {
+                            "pk": 26,
+                            "raw_name": "Lambda-class T-4a Shuttle"
+                        },
+                        "type": "SHIP_TYPE"
+                    }
+                ]
+            ],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [],
+            "subtitle": null,
+            "upgrade_types": [
+                15
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante a Fase de Sistema,você pode gastar 1 <standardcharge> para soltar uma Bomba Fragmentada com o gabarito [1<nonbreak><straight>].<return>No início da Fase de Ativação, você pode gastar 1 escudopara recuperar 2 <standardcharge>.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_63.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_63",
+            "force_side": null,
+            "id": 392,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_63.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Gerador de Bombas Fragmentadas",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6622,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12,
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>Durante a Fase de Sistema, você pode gastar 1 <standardcharge> para soltar uma Rede Conner com o gabarito [1<nonbreak><straight>].<return>A <standardcharge> dessa carta nãopode ser recuperada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_64.png",
+            "card_set_ids": [
+                4,
+                5,
+                6
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_64",
+            "force_side": null,
+            "id": 393,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_64.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Rede Conner",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6630,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "1"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante a Fase de Sistema, você pode gastar 1 <standardcharge>para soltar umaBomba de Prótonscom o gabarito [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_65.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8
+            ],
+            "card_type_id": 2,
+            "cost": "5",
+            "faction_id": null,
+            "ffg_id": "XW_U_65",
+            "force_side": null,
+            "id": 394,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_65.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Bombas de Prótons",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6655,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Mina</bitalic><return>Durante a Fase deSistema, você pode gastar1 <standardcharge> para soltar uma Minade Proximidade como gabarito [1<nonbreak><straight>].<return>A <standardcharge> dessa carta nãopode ser recuperada.",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_66.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "6",
+            "faction_id": null,
+            "ffg_id": "XW_U_66",
+            "force_side": null,
+            "id": 395,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_66.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Minas de Proximidade",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6662,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
+            ],
+            "weapon_no_bonus": false,
+            "weapon_range": null
+        },
+        {
+            "ability_text": "<bitalic>Bomba</bitalic><return>Durante a Fase de Sistema, você pode gastar 1 <standardcharge> para soltar uma Carga Sísmica com o gabarito [1<nonbreak><straight>].",
+            "available_actions": [],
+            "available_upgrades": [],
+            "card_image": "https://sb-cdn.fantasyflightgames.com/card_images/Card_Upgrade_67.png",
+            "card_set_ids": [
+                4,
+                5,
+                6,
+                8,
+                11
+            ],
+            "card_type_id": 2,
+            "cost": "3",
+            "faction_id": null,
+            "ffg_id": "XW_U_67",
+            "force_side": null,
+            "id": 396,
+            "image": "https://sb-cdn.fantasyflightgames.com/card_art/Card_art_XW_U_67.jpg",
+            "initiative": null,
+            "is_unique": false,
+            "name": "Cargas Sísmicas",
+            "restrictions": [],
+            "ship_ability_text": null,
+            "ship_size": null,
+            "ship_type": null,
+            "statistics": [
+                {
+                    "id": 6666,
+                    "recurring": false,
+                    "statistic_id": 7,
+                    "value": "2"
+                }
+            ],
+            "subtitle": null,
+            "upgrade_types": [
+                12
             ],
             "weapon_no_bonus": false,
             "weapon_range": null

--- a/translation_helper/api_export_pt.json
+++ b/translation_helper/api_export_pt.json
@@ -6,21 +6,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5839,
+                    "id": 6673,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5840,
+                    "id": 6674,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5841,
+                    "id": 6675,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -53,25 +53,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6671,
+                    "id": 7588,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6672,
+                    "id": 7589,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6673,
+                    "id": 7590,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6674,
+                    "id": 7591,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -88,21 +88,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5842,
+                    "id": 6676,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5843,
+                    "id": 6677,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5844,
+                    "id": 6678,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -134,31 +134,31 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6675,
+                    "id": 7592,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6676,
+                    "id": 7593,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6677,
+                    "id": 7594,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6678,
+                    "id": 7595,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 6679,
+                    "id": 7596,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -175,21 +175,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5845,
+                    "id": 6679,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5846,
+                    "id": 6680,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5847,
+                    "id": 6681,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -221,25 +221,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6680,
+                    "id": 7597,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6681,
+                    "id": 7598,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6682,
+                    "id": 7599,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6683,
+                    "id": 7600,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -256,21 +256,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5848,
+                    "id": 6682,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5849,
+                    "id": 6683,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5850,
+                    "id": 6684,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -303,25 +303,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6684,
+                    "id": 7601,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6685,
+                    "id": 7602,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6686,
+                    "id": 7603,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6687,
+                    "id": 7604,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -338,21 +338,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5851,
+                    "id": 6685,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5852,
+                    "id": 6686,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5853,
+                    "id": 6687,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -384,25 +384,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6688,
+                    "id": 7605,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6689,
+                    "id": 7606,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6690,
+                    "id": 7607,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6691,
+                    "id": 7608,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -419,21 +419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5854,
+                    "id": 6688,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5855,
+                    "id": 6689,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5856,
+                    "id": 6690,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -466,25 +466,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6692,
+                    "id": 7609,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6693,
+                    "id": 7610,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6694,
+                    "id": 7611,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6695,
+                    "id": 7612,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -501,21 +501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5857,
+                    "id": 6691,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5858,
+                    "id": 6692,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5859,
+                    "id": 6693,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -547,25 +547,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6696,
+                    "id": 7613,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6697,
+                    "id": 7614,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6698,
+                    "id": 7615,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6699,
+                    "id": 7616,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -582,21 +582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5860,
+                    "id": 6694,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5861,
+                    "id": 6695,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5862,
+                    "id": 6696,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -629,25 +629,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6700,
+                    "id": 7617,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6701,
+                    "id": 7618,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6702,
+                    "id": 7619,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6703,
+                    "id": 7620,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -664,21 +664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5863,
+                    "id": 6697,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5864,
+                    "id": 6698,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5865,
+                    "id": 6699,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -710,25 +710,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6704,
+                    "id": 7621,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6705,
+                    "id": 7622,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6706,
+                    "id": 7623,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6707,
+                    "id": 7624,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -745,21 +745,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5866,
+                    "id": 6700,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5867,
+                    "id": 6701,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5868,
+                    "id": 6702,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -793,25 +793,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6708,
+                    "id": 7625,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6709,
+                    "id": 7626,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6710,
+                    "id": 7627,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6711,
+                    "id": 7628,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -828,21 +828,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5869,
+                    "id": 6703,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5870,
+                    "id": 6704,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5871,
+                    "id": 6705,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -875,25 +875,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6712,
+                    "id": 7629,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6713,
+                    "id": 7630,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6714,
+                    "id": 7631,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6715,
+                    "id": 7632,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -910,21 +910,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5872,
+                    "id": 6706,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5873,
+                    "id": 6707,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5874,
+                    "id": 6708,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -956,25 +956,25 @@
             "ship_type": 33,
             "statistics": [
                 {
-                    "id": 6716,
+                    "id": 7633,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6717,
+                    "id": 7634,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6718,
+                    "id": 7635,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6719,
+                    "id": 7636,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -991,28 +991,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5875,
+                    "id": 6709,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5876,
+                    "id": 6710,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5877,
+                    "id": 6711,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5878,
+                    "id": 6712,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1046,25 +1046,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6720,
+                    "id": 7637,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6721,
+                    "id": 7638,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6722,
+                    "id": 7639,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6723,
+                    "id": 7640,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1081,28 +1081,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5879,
+                    "id": 6713,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5880,
+                    "id": 6714,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5881,
+                    "id": 6715,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5882,
+                    "id": 6716,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1137,25 +1137,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6724,
+                    "id": 7641,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6725,
+                    "id": 7642,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6726,
+                    "id": 7643,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6727,
+                    "id": 7644,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1172,28 +1172,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5883,
+                    "id": 6717,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5884,
+                    "id": 6718,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5885,
+                    "id": 6719,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5886,
+                    "id": 6720,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1228,25 +1228,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6728,
+                    "id": 7645,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6729,
+                    "id": 7646,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6730,
+                    "id": 7647,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6731,
+                    "id": 7648,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1263,28 +1263,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5887,
+                    "id": 6721,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5888,
+                    "id": 6722,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5889,
+                    "id": 6723,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5890,
+                    "id": 6724,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1318,25 +1318,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6732,
+                    "id": 7649,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6733,
+                    "id": 7650,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6734,
+                    "id": 7651,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6735,
+                    "id": 7652,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1353,28 +1353,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5891,
+                    "id": 6725,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5892,
+                    "id": 6726,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5893,
+                    "id": 6727,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5894,
+                    "id": 6728,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1409,25 +1409,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6736,
+                    "id": 7653,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6737,
+                    "id": 7654,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6738,
+                    "id": 7655,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6739,
+                    "id": 7656,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1444,28 +1444,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5895,
+                    "id": 6729,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5896,
+                    "id": 6730,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5897,
+                    "id": 6731,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 5898,
+                    "id": 6732,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1499,25 +1499,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 6740,
+                    "id": 7657,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6741,
+                    "id": 7658,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6742,
+                    "id": 7659,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6743,
+                    "id": 7660,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1534,35 +1534,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5899,
+                    "id": 6733,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5900,
+                    "id": 6734,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5901,
+                    "id": 6735,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5902,
+                    "id": 6736,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5903,
+                    "id": 6737,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1591,25 +1591,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6744,
+                    "id": 7661,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6745,
+                    "id": 7662,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6746,
+                    "id": 7663,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6747,
+                    "id": 7664,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1626,35 +1626,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5904,
+                    "id": 6738,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5905,
+                    "id": 6739,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5906,
+                    "id": 6740,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5907,
+                    "id": 6741,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5908,
+                    "id": 6742,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1683,25 +1683,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6748,
+                    "id": 7665,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6749,
+                    "id": 7666,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6750,
+                    "id": 7667,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6751,
+                    "id": 7668,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1718,35 +1718,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5909,
+                    "id": 6743,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5910,
+                    "id": 6744,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5911,
+                    "id": 6745,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5912,
+                    "id": 6746,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5913,
+                    "id": 6747,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1775,25 +1775,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6752,
+                    "id": 7669,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6753,
+                    "id": 7670,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6754,
+                    "id": 7671,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6755,
+                    "id": 7672,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1810,35 +1810,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5914,
+                    "id": 6748,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5915,
+                    "id": 6749,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5916,
+                    "id": 6750,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5917,
+                    "id": 6751,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 5918,
+                    "id": 6752,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1866,25 +1866,25 @@
             "ship_type": 35,
             "statistics": [
                 {
-                    "id": 6756,
+                    "id": 7673,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6757,
+                    "id": 7674,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6758,
+                    "id": 7675,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6759,
+                    "id": 7676,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -1901,21 +1901,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5919,
+                    "id": 6753,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5920,
+                    "id": 6754,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5921,
+                    "id": 6755,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -1948,25 +1948,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6760,
+                    "id": 7677,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6761,
+                    "id": 7678,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6762,
+                    "id": 7679,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6763,
+                    "id": 7680,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -1983,21 +1983,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5922,
+                    "id": 6756,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5923,
+                    "id": 6757,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5924,
+                    "id": 6758,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2030,25 +2030,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6764,
+                    "id": 7681,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6765,
+                    "id": 7682,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6766,
+                    "id": 7683,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6767,
+                    "id": 7684,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2065,21 +2065,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5925,
+                    "id": 6759,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5926,
+                    "id": 6760,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5927,
+                    "id": 6761,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2112,25 +2112,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6768,
+                    "id": 7685,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6769,
+                    "id": 7686,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6770,
+                    "id": 7687,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6771,
+                    "id": 7688,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2147,21 +2147,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5928,
+                    "id": 6762,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5929,
+                    "id": 6763,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5930,
+                    "id": 6764,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2193,25 +2193,25 @@
             "ship_type": 17,
             "statistics": [
                 {
-                    "id": 6772,
+                    "id": 7689,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6773,
+                    "id": 7690,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6774,
+                    "id": 7691,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6775,
+                    "id": 7692,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -2228,21 +2228,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5931,
+                    "id": 6765,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5932,
+                    "id": 6766,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5933,
+                    "id": 6767,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2272,25 +2272,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6776,
+                    "id": 7693,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6777,
+                    "id": 7694,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6778,
+                    "id": 7695,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6779,
+                    "id": 7696,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2307,21 +2307,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5934,
+                    "id": 6768,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5935,
+                    "id": 6769,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5936,
+                    "id": 6770,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2351,25 +2351,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6780,
+                    "id": 7697,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6781,
+                    "id": 7698,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6782,
+                    "id": 7699,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6783,
+                    "id": 7700,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2386,21 +2386,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5937,
+                    "id": 6771,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5938,
+                    "id": 6772,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5939,
+                    "id": 6773,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2430,25 +2430,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6784,
+                    "id": 7701,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6785,
+                    "id": 7702,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6786,
+                    "id": 7703,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6787,
+                    "id": 7704,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2465,21 +2465,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5940,
+                    "id": 6774,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5941,
+                    "id": 6775,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5942,
+                    "id": 6776,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2508,25 +2508,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 6788,
+                    "id": 7705,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6789,
+                    "id": 7706,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6790,
+                    "id": 7707,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 6791,
+                    "id": 7708,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2543,21 +2543,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5943,
+                    "id": 6777,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5944,
+                    "id": 6778,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5945,
+                    "id": 6779,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2588,25 +2588,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6792,
+                    "id": 7709,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6793,
+                    "id": 7710,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6794,
+                    "id": 7711,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6795,
+                    "id": 7712,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2623,21 +2623,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5946,
+                    "id": 6780,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5947,
+                    "id": 6781,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5948,
+                    "id": 6782,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2668,25 +2668,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6796,
+                    "id": 7713,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6797,
+                    "id": 7714,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6798,
+                    "id": 7715,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6799,
+                    "id": 7716,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2703,21 +2703,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5949,
+                    "id": 6783,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 5950,
+                    "id": 6784,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 5951,
+                    "id": 6785,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -2747,25 +2747,25 @@
             "ship_type": 6,
             "statistics": [
                 {
-                    "id": 6800,
+                    "id": 7717,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 6801,
+                    "id": 7718,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6802,
+                    "id": 7719,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6803,
+                    "id": 7720,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -2782,21 +2782,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5952,
+                    "id": 6786,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5953,
+                    "id": 6787,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5954,
+                    "id": 6788,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2828,25 +2828,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6804,
+                    "id": 7721,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6805,
+                    "id": 7722,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6806,
+                    "id": 7723,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6807,
+                    "id": 7724,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2863,21 +2863,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5955,
+                    "id": 6789,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5956,
+                    "id": 6790,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5957,
+                    "id": 6791,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2909,25 +2909,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6808,
+                    "id": 7725,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6809,
+                    "id": 7726,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6810,
+                    "id": 7727,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6811,
+                    "id": 7728,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -2944,21 +2944,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5958,
+                    "id": 6792,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5959,
+                    "id": 6793,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5960,
+                    "id": 6794,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -2990,31 +2990,31 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6812,
+                    "id": 7729,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6813,
+                    "id": 7730,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6814,
+                    "id": 7731,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6815,
+                    "id": 7732,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6816,
+                    "id": 7733,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3031,21 +3031,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5961,
+                    "id": 6795,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5962,
+                    "id": 6796,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5963,
+                    "id": 6797,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -3076,25 +3076,25 @@
             "ship_type": 32,
             "statistics": [
                 {
-                    "id": 6817,
+                    "id": 7734,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6818,
+                    "id": 7735,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6819,
+                    "id": 7736,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6820,
+                    "id": 7737,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3111,14 +3111,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5964,
+                    "id": 6798,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5965,
+                    "id": 6799,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3150,31 +3150,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6821,
+                    "id": 7738,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6822,
+                    "id": 7739,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6823,
+                    "id": 7740,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6824,
+                    "id": 7741,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6825,
+                    "id": 7742,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3191,14 +3191,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5966,
+                    "id": 6800,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5967,
+                    "id": 6801,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3230,37 +3230,37 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6826,
+                    "id": 7743,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6827,
+                    "id": 7744,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6828,
+                    "id": 7745,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6829,
+                    "id": 7746,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6830,
+                    "id": 7747,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
                 },
                 {
-                    "id": 6831,
+                    "id": 7748,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3277,14 +3277,14 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5968,
+                    "id": 6802,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5969,
+                    "id": 6803,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3316,31 +3316,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6832,
+                    "id": 7749,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6833,
+                    "id": 7750,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6834,
+                    "id": 7751,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6835,
+                    "id": 7752,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6836,
+                    "id": 7753,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3357,14 +3357,14 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 5970,
+                    "id": 6804,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 5971,
+                    "id": 6805,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3396,31 +3396,31 @@
             "ship_type": 8,
             "statistics": [
                 {
-                    "id": 6837,
+                    "id": 7754,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6838,
+                    "id": 7755,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6839,
+                    "id": 7756,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6840,
+                    "id": 7757,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 6841,
+                    "id": 7758,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -3437,35 +3437,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5972,
+                    "id": 6806,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5973,
+                    "id": 6807,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5974,
+                    "id": 6808,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5975,
+                    "id": 6809,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5976,
+                    "id": 6810,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3498,25 +3498,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6842,
+                    "id": 7759,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6843,
+                    "id": 7760,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6844,
+                    "id": 7761,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6845,
+                    "id": 7762,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3533,35 +3533,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5977,
+                    "id": 6811,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5978,
+                    "id": 6812,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5979,
+                    "id": 6813,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5980,
+                    "id": 6814,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5981,
+                    "id": 6815,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3594,25 +3594,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6846,
+                    "id": 7763,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6847,
+                    "id": 7764,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6848,
+                    "id": 7765,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6849,
+                    "id": 7766,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3629,35 +3629,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5982,
+                    "id": 6816,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5983,
+                    "id": 6817,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5984,
+                    "id": 6818,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5985,
+                    "id": 6819,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5986,
+                    "id": 6820,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3690,25 +3690,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6850,
+                    "id": 7767,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6851,
+                    "id": 7768,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6852,
+                    "id": 7769,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6853,
+                    "id": 7770,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3725,35 +3725,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5987,
+                    "id": 6821,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 5988,
+                    "id": 6822,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 5989,
+                    "id": 6823,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 5990,
+                    "id": 6824,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 5991,
+                    "id": 6825,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3785,25 +3785,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 6854,
+                    "id": 7771,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 6855,
+                    "id": 7772,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6856,
+                    "id": 7773,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6857,
+                    "id": 7774,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -3820,21 +3820,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5992,
+                    "id": 6826,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5993,
+                    "id": 6827,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5994,
+                    "id": 6828,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3863,25 +3863,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6858,
+                    "id": 7775,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6859,
+                    "id": 7776,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6860,
+                    "id": 7777,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6861,
+                    "id": 7778,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -3898,21 +3898,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5995,
+                    "id": 6829,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5996,
+                    "id": 6830,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 5997,
+                    "id": 6831,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -3941,19 +3941,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6862,
+                    "id": 7779,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6863,
+                    "id": 7780,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6864,
+                    "id": 7781,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -3970,21 +3970,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 5998,
+                    "id": 6832,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 5999,
+                    "id": 6833,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6000,
+                    "id": 6834,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4012,19 +4012,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6865,
+                    "id": 7782,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6866,
+                    "id": 7783,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6867,
+                    "id": 7784,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4041,21 +4041,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6001,
+                    "id": 6835,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6002,
+                    "id": 6836,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6003,
+                    "id": 6837,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4083,19 +4083,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6868,
+                    "id": 7785,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6869,
+                    "id": 7786,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6870,
+                    "id": 7787,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -4112,35 +4112,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6004,
+                    "id": 6838,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6005,
+                    "id": 6839,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6006,
+                    "id": 6840,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6007,
+                    "id": 6841,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6008,
+                    "id": 6842,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4172,25 +4172,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6871,
+                    "id": 7788,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6872,
+                    "id": 7789,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6873,
+                    "id": 7790,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6874,
+                    "id": 7791,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4207,35 +4207,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6009,
+                    "id": 6843,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6010,
+                    "id": 6844,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6011,
+                    "id": 6845,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6012,
+                    "id": 6846,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6013,
+                    "id": 6847,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4267,25 +4267,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6875,
+                    "id": 7792,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6876,
+                    "id": 7793,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6877,
+                    "id": 7794,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6878,
+                    "id": 7795,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4302,35 +4302,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6014,
+                    "id": 6848,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6015,
+                    "id": 6849,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6016,
+                    "id": 6850,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6017,
+                    "id": 6851,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6018,
+                    "id": 6852,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4362,25 +4362,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6879,
+                    "id": 7796,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6880,
+                    "id": 7797,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6881,
+                    "id": 7798,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6882,
+                    "id": 7799,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4397,35 +4397,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6019,
+                    "id": 6853,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6020,
+                    "id": 6854,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6021,
+                    "id": 6855,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6022,
+                    "id": 6856,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6023,
+                    "id": 6857,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 }
@@ -4456,25 +4456,25 @@
             "ship_type": 40,
             "statistics": [
                 {
-                    "id": 6883,
+                    "id": 7800,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6884,
+                    "id": 7801,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6885,
+                    "id": 7802,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 6886,
+                    "id": 7803,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4491,21 +4491,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6024,
+                    "id": 6858,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6025,
+                    "id": 6859,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6026,
+                    "id": 6860,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4538,25 +4538,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6887,
+                    "id": 7804,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6888,
+                    "id": 7805,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6889,
+                    "id": 7806,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6890,
+                    "id": 7807,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4573,21 +4573,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6027,
+                    "id": 6861,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6028,
+                    "id": 6862,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6029,
+                    "id": 6863,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4621,25 +4621,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6891,
+                    "id": 7808,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6892,
+                    "id": 7809,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6893,
+                    "id": 7810,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6894,
+                    "id": 7811,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4656,21 +4656,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6030,
+                    "id": 6864,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6031,
+                    "id": 6865,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6032,
+                    "id": 6866,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4703,25 +4703,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6895,
+                    "id": 7812,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6896,
+                    "id": 7813,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6897,
+                    "id": 7814,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6898,
+                    "id": 7815,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4738,21 +4738,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6033,
+                    "id": 6867,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6034,
+                    "id": 6868,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6035,
+                    "id": 6869,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4786,25 +4786,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6899,
+                    "id": 7816,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6900,
+                    "id": 7817,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6901,
+                    "id": 7818,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6902,
+                    "id": 7819,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4821,21 +4821,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6036,
+                    "id": 6870,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6037,
+                    "id": 6871,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6038,
+                    "id": 6872,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4868,25 +4868,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6903,
+                    "id": 7820,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6904,
+                    "id": 7821,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6905,
+                    "id": 7822,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6906,
+                    "id": 7823,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4903,21 +4903,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6039,
+                    "id": 6873,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6040,
+                    "id": 6874,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6041,
+                    "id": 6875,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -4950,25 +4950,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6907,
+                    "id": 7824,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6908,
+                    "id": 7825,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6909,
+                    "id": 7826,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6910,
+                    "id": 7827,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -4985,21 +4985,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6042,
+                    "id": 6876,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6043,
+                    "id": 6877,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6044,
+                    "id": 6878,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5031,25 +5031,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6911,
+                    "id": 7828,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6912,
+                    "id": 7829,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6913,
+                    "id": 7830,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6914,
+                    "id": 7831,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5066,21 +5066,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6045,
+                    "id": 6879,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6046,
+                    "id": 6880,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6047,
+                    "id": 6881,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5113,25 +5113,25 @@
             "ship_type": 15,
             "statistics": [
                 {
-                    "id": 6915,
+                    "id": 7832,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6916,
+                    "id": 7833,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6917,
+                    "id": 7834,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 6918,
+                    "id": 7835,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5148,35 +5148,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6048,
+                    "id": 6882,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6049,
+                    "id": 6883,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6050,
+                    "id": 6884,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6051,
+                    "id": 6885,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6052,
+                    "id": 6886,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5211,25 +5211,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6919,
+                    "id": 7836,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6920,
+                    "id": 7837,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6921,
+                    "id": 7838,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6922,
+                    "id": 7839,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5246,35 +5246,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6053,
+                    "id": 6887,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6054,
+                    "id": 6888,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6055,
+                    "id": 6889,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6056,
+                    "id": 6890,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6057,
+                    "id": 6891,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5309,25 +5309,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6923,
+                    "id": 7840,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6924,
+                    "id": 7841,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6925,
+                    "id": 7842,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6926,
+                    "id": 7843,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5344,35 +5344,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6058,
+                    "id": 6892,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6059,
+                    "id": 6893,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6060,
+                    "id": 6894,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6061,
+                    "id": 6895,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6062,
+                    "id": 6896,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5407,25 +5407,25 @@
             "ship_type": 30,
             "statistics": [
                 {
-                    "id": 6927,
+                    "id": 7844,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 6928,
+                    "id": 7845,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6929,
+                    "id": 7846,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6930,
+                    "id": 7847,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5442,21 +5442,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6063,
+                    "id": 6897,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6064,
+                    "id": 6898,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6065,
+                    "id": 6899,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5489,31 +5489,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6931,
+                    "id": 7848,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6932,
+                    "id": 7849,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6933,
+                    "id": 7850,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6934,
+                    "id": 7851,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6935,
+                    "id": 7852,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5530,21 +5530,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6066,
+                    "id": 6900,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6067,
+                    "id": 6901,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6068,
+                    "id": 6902,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5577,31 +5577,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6936,
+                    "id": 7853,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6937,
+                    "id": 7854,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6938,
+                    "id": 7855,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6939,
+                    "id": 7856,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6940,
+                    "id": 7857,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5618,21 +5618,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6069,
+                    "id": 6903,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6070,
+                    "id": 6904,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6071,
+                    "id": 6905,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5665,31 +5665,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6941,
+                    "id": 7858,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6942,
+                    "id": 7859,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6943,
+                    "id": 7860,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6944,
+                    "id": 7861,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6945,
+                    "id": 7862,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5706,21 +5706,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6072,
+                    "id": 6906,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6073,
+                    "id": 6907,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6074,
+                    "id": 6908,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5753,31 +5753,31 @@
             "ship_type": 31,
             "statistics": [
                 {
-                    "id": 6946,
+                    "id": 7863,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 6947,
+                    "id": 7864,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 6948,
+                    "id": 7865,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6949,
+                    "id": 7866,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6950,
+                    "id": 7867,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -5794,28 +5794,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6075,
+                    "id": 6909,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6076,
+                    "id": 6910,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6077,
+                    "id": 6911,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6078,
+                    "id": 6912,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5850,25 +5850,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6951,
+                    "id": 7868,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6952,
+                    "id": 7869,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6953,
+                    "id": 7870,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6954,
+                    "id": 7871,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5885,28 +5885,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6079,
+                    "id": 6913,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6080,
+                    "id": 6914,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6081,
+                    "id": 6915,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6082,
+                    "id": 6916,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -5941,25 +5941,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6955,
+                    "id": 7872,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6956,
+                    "id": 7873,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6957,
+                    "id": 7874,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6958,
+                    "id": 7875,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -5976,28 +5976,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6083,
+                    "id": 6917,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6084,
+                    "id": 6918,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6085,
+                    "id": 6919,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6086,
+                    "id": 6920,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6032,31 +6032,31 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6959,
+                    "id": 7876,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6960,
+                    "id": 7877,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6961,
+                    "id": 7878,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6962,
+                    "id": 7879,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
                 },
                 {
-                    "id": 6963,
+                    "id": 7880,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -6073,28 +6073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6087,
+                    "id": 6921,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6088,
+                    "id": 6922,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6089,
+                    "id": 6923,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6090,
+                    "id": 6924,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6128,25 +6128,25 @@
             "ship_type": 1,
             "statistics": [
                 {
-                    "id": 6964,
+                    "id": 7881,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 6965,
+                    "id": 7882,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 6966,
+                    "id": 7883,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 6967,
+                    "id": 7884,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "5"
@@ -6163,21 +6163,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6091,
+                    "id": 6925,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6092,
+                    "id": 6926,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6093,
+                    "id": 6927,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6212,25 +6212,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6968,
+                    "id": 7885,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6969,
+                    "id": 7886,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6970,
+                    "id": 7887,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6971,
+                    "id": 7888,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6247,21 +6247,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6094,
+                    "id": 6928,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6095,
+                    "id": 6929,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6096,
+                    "id": 6930,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6296,31 +6296,31 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6972,
+                    "id": 7889,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6973,
+                    "id": 7890,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6974,
+                    "id": 7891,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6975,
+                    "id": 7892,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 6976,
+                    "id": 7893,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -6337,21 +6337,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6097,
+                    "id": 6931,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6098,
+                    "id": 6932,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6099,
+                    "id": 6933,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6385,25 +6385,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6977,
+                    "id": 7894,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6978,
+                    "id": 7895,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6979,
+                    "id": 7896,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6980,
+                    "id": 7897,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6420,21 +6420,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6100,
+                    "id": 6934,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6101,
+                    "id": 6935,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6102,
+                    "id": 6936,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6468,25 +6468,25 @@
             "ship_type": 23,
             "statistics": [
                 {
-                    "id": 6981,
+                    "id": 7898,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "4"
                 },
                 {
-                    "id": 6982,
+                    "id": 7899,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 6983,
+                    "id": 7900,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "10"
                 },
                 {
-                    "id": 6984,
+                    "id": 7901,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6503,28 +6503,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6103,
+                    "id": 6937,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6104,
+                    "id": 6938,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6105,
+                    "id": 6939,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6106,
+                    "id": 6940,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6558,25 +6558,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6985,
+                    "id": 7902,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6986,
+                    "id": 7903,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6987,
+                    "id": 7904,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6988,
+                    "id": 7905,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6593,28 +6593,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6107,
+                    "id": 6941,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6108,
+                    "id": 6942,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6109,
+                    "id": 6943,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6110,
+                    "id": 6944,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6647,25 +6647,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6989,
+                    "id": 7906,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6990,
+                    "id": 7907,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6991,
+                    "id": 7908,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6992,
+                    "id": 7909,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6682,28 +6682,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6111,
+                    "id": 6945,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6112,
+                    "id": 6946,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6113,
+                    "id": 6947,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6114,
+                    "id": 6948,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6736,25 +6736,25 @@
             "ship_type": 5,
             "statistics": [
                 {
-                    "id": 6993,
+                    "id": 7910,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "4"
                 },
                 {
-                    "id": 6994,
+                    "id": 7911,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 6995,
+                    "id": 7912,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 6996,
+                    "id": 7913,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -6771,21 +6771,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6115,
+                    "id": 6949,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6116,
+                    "id": 6950,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6117,
+                    "id": 6951,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6815,19 +6815,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 6997,
+                    "id": 7914,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 6998,
+                    "id": 7915,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 6999,
+                    "id": 7916,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6844,21 +6844,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6118,
+                    "id": 6952,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6119,
+                    "id": 6953,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6120,
+                    "id": 6954,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6888,19 +6888,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7000,
+                    "id": 7917,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7001,
+                    "id": 7918,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7002,
+                    "id": 7919,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6917,21 +6917,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6121,
+                    "id": 6955,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6122,
+                    "id": 6956,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6123,
+                    "id": 6957,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -6961,19 +6961,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7003,
+                    "id": 7920,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7004,
+                    "id": 7921,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7005,
+                    "id": 7922,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -6990,21 +6990,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6124,
+                    "id": 6958,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6125,
+                    "id": 6959,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6126,
+                    "id": 6960,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7033,25 +7033,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7006,
+                    "id": 7923,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7007,
+                    "id": 7924,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7008,
+                    "id": 7925,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7009,
+                    "id": 7926,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -7068,21 +7068,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6127,
+                    "id": 6961,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6128,
+                    "id": 6962,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6129,
+                    "id": 6963,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7111,19 +7111,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7010,
+                    "id": 7927,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7011,
+                    "id": 7928,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7012,
+                    "id": 7929,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7140,21 +7140,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6130,
+                    "id": 6964,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6131,
+                    "id": 6965,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6132,
+                    "id": 6966,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7183,19 +7183,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7013,
+                    "id": 7930,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7014,
+                    "id": 7931,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7015,
+                    "id": 7932,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7212,21 +7212,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6133,
+                    "id": 6967,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6134,
+                    "id": 6968,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6135,
+                    "id": 6969,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7255,19 +7255,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7016,
+                    "id": 7933,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7017,
+                    "id": 7934,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7018,
+                    "id": 7935,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7284,21 +7284,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6136,
+                    "id": 6970,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6137,
+                    "id": 6971,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6138,
+                    "id": 6972,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7327,19 +7327,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7019,
+                    "id": 7936,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7020,
+                    "id": 7937,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7021,
+                    "id": 7938,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7356,21 +7356,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6139,
+                    "id": 6973,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6140,
+                    "id": 6974,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6141,
+                    "id": 6975,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7398,19 +7398,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7022,
+                    "id": 7939,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7023,
+                    "id": 7940,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7024,
+                    "id": 7941,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7427,21 +7427,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6142,
+                    "id": 6976,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6143,
+                    "id": 6977,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6144,
+                    "id": 6978,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7470,25 +7470,25 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7025,
+                    "id": 7942,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7026,
+                    "id": 7943,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7027,
+                    "id": 7944,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7028,
+                    "id": 7945,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -7505,21 +7505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6145,
+                    "id": 6979,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6146,
+                    "id": 6980,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6147,
+                    "id": 6981,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7550,19 +7550,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7029,
+                    "id": 7946,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7030,
+                    "id": 7947,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7031,
+                    "id": 7948,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7579,21 +7579,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6148,
+                    "id": 6982,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6149,
+                    "id": 6983,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6150,
+                    "id": 6984,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7623,19 +7623,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7032,
+                    "id": 7949,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7033,
+                    "id": 7950,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7034,
+                    "id": 7951,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7652,21 +7652,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6151,
+                    "id": 6985,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6152,
+                    "id": 6986,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6153,
+                    "id": 6987,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7696,19 +7696,19 @@
             "ship_type": 11,
             "statistics": [
                 {
-                    "id": 7035,
+                    "id": 7952,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7036,
+                    "id": 7953,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7037,
+                    "id": 7954,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -7725,21 +7725,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6154,
+                    "id": 6988,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6155,
+                    "id": 6989,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6156,
+                    "id": 6990,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7771,31 +7771,31 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7038,
+                    "id": 7955,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7039,
+                    "id": 7956,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7040,
+                    "id": 7957,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7041,
+                    "id": 7958,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7042,
+                    "id": 7959,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "3"
@@ -7812,21 +7812,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6157,
+                    "id": 6991,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6158,
+                    "id": 6992,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6159,
+                    "id": 6993,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7858,25 +7858,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7043,
+                    "id": 7960,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7044,
+                    "id": 7961,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7045,
+                    "id": 7962,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7046,
+                    "id": 7963,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7893,21 +7893,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6160,
+                    "id": 6994,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6161,
+                    "id": 6995,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6162,
+                    "id": 6996,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -7938,25 +7938,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7047,
+                    "id": 7964,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7048,
+                    "id": 7965,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7049,
+                    "id": 7966,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7050,
+                    "id": 7967,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -7973,21 +7973,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6163,
+                    "id": 6997,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6164,
+                    "id": 6998,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6165,
+                    "id": 6999,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8018,25 +8018,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7051,
+                    "id": 7968,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7052,
+                    "id": 7969,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7053,
+                    "id": 7970,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7054,
+                    "id": 7971,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8053,21 +8053,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6166,
+                    "id": 7000,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6167,
+                    "id": 7001,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6168,
+                    "id": 7002,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8099,25 +8099,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7055,
+                    "id": 7972,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7056,
+                    "id": 7973,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7057,
+                    "id": 7974,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7058,
+                    "id": 7975,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8134,21 +8134,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6169,
+                    "id": 7003,
                     "related_action_id": 5,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6170,
+                    "id": 7004,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6171,
+                    "id": 7005,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8179,25 +8179,25 @@
             "ship_type": 13,
             "statistics": [
                 {
-                    "id": 7059,
+                    "id": 7976,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7060,
+                    "id": 7977,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7061,
+                    "id": 7978,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7062,
+                    "id": 7979,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8214,35 +8214,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6172,
+                    "id": 7006,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6173,
+                    "id": 7007,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6174,
+                    "id": 7008,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6175,
+                    "id": 7009,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6176,
+                    "id": 7010,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8272,31 +8272,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7063,
+                    "id": 7980,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7064,
+                    "id": 7981,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7065,
+                    "id": 7982,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7066,
+                    "id": 7983,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7067,
+                    "id": 7984,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8313,35 +8313,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6177,
+                    "id": 7011,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6178,
+                    "id": 7012,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6179,
+                    "id": 7013,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6180,
+                    "id": 7014,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6181,
+                    "id": 7015,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8371,31 +8371,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7068,
+                    "id": 7985,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7069,
+                    "id": 7986,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7070,
+                    "id": 7987,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7071,
+                    "id": 7988,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7072,
+                    "id": 7989,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -8412,35 +8412,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6182,
+                    "id": 7016,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6183,
+                    "id": 7017,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6184,
+                    "id": 7018,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6185,
+                    "id": 7019,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6186,
+                    "id": 7020,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8470,25 +8470,25 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7073,
+                    "id": 7990,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7074,
+                    "id": 7991,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7075,
+                    "id": 7992,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7076,
+                    "id": 7993,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -8505,35 +8505,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6187,
+                    "id": 7021,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6188,
+                    "id": 7022,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6189,
+                    "id": 7023,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6190,
+                    "id": 7024,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6191,
+                    "id": 7025,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -8563,31 +8563,31 @@
             "ship_type": 25,
             "statistics": [
                 {
-                    "id": 7077,
+                    "id": 7994,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7078,
+                    "id": 7995,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7079,
+                    "id": 7996,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7080,
+                    "id": 7997,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7081,
+                    "id": 7998,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "1"
@@ -8604,28 +8604,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6192,
+                    "id": 7026,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6193,
+                    "id": 7027,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6194,
+                    "id": 7028,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6195,
+                    "id": 7029,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8655,19 +8655,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7082,
+                    "id": 7999,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7083,
+                    "id": 8000,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7084,
+                    "id": 8001,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8684,28 +8684,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6196,
+                    "id": 7030,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6197,
+                    "id": 7031,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6198,
+                    "id": 7032,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6199,
+                    "id": 7033,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8735,19 +8735,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7085,
+                    "id": 8002,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7086,
+                    "id": 8003,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7087,
+                    "id": 8004,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8764,28 +8764,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6200,
+                    "id": 7034,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6201,
+                    "id": 7035,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6202,
+                    "id": 7036,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6203,
+                    "id": 7037,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8815,19 +8815,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7088,
+                    "id": 8005,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7089,
+                    "id": 8006,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7090,
+                    "id": 8007,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8844,28 +8844,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6204,
+                    "id": 7038,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6205,
+                    "id": 7039,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6206,
+                    "id": 7040,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6207,
+                    "id": 7041,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8894,19 +8894,19 @@
             "ship_type": 41,
             "statistics": [
                 {
-                    "id": 7091,
+                    "id": 8008,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7092,
+                    "id": 8009,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7093,
+                    "id": 8010,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
@@ -8923,28 +8923,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6208,
+                    "id": 7042,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6209,
+                    "id": 7043,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6210,
+                    "id": 7044,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6211,
+                    "id": 7045,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -8979,19 +8979,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7094,
+                    "id": 8011,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7095,
+                    "id": 8012,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7096,
+                    "id": 8013,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9008,28 +9008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6212,
+                    "id": 7046,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6213,
+                    "id": 7047,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6214,
+                    "id": 7048,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6215,
+                    "id": 7049,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9064,19 +9064,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7097,
+                    "id": 8014,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7098,
+                    "id": 8015,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7099,
+                    "id": 8016,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9093,28 +9093,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6216,
+                    "id": 7050,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6217,
+                    "id": 7051,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6218,
+                    "id": 7052,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6219,
+                    "id": 7053,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9149,19 +9149,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7100,
+                    "id": 8017,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7101,
+                    "id": 8018,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7102,
+                    "id": 8019,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9178,28 +9178,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6220,
+                    "id": 7054,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6221,
+                    "id": 7055,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6222,
+                    "id": 7056,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6223,
+                    "id": 7057,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9233,19 +9233,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7103,
+                    "id": 8020,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7104,
+                    "id": 8021,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7105,
+                    "id": 8022,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9262,28 +9262,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6224,
+                    "id": 7058,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6225,
+                    "id": 7059,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6226,
+                    "id": 7060,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6227,
+                    "id": 7061,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9318,19 +9318,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7106,
+                    "id": 8023,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7107,
+                    "id": 8024,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7108,
+                    "id": 8025,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9347,28 +9347,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6228,
+                    "id": 7062,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6229,
+                    "id": 7063,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6230,
+                    "id": 7064,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6231,
+                    "id": 7065,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9402,19 +9402,19 @@
             "ship_type": 19,
             "statistics": [
                 {
-                    "id": 7109,
+                    "id": 8026,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7110,
+                    "id": 8027,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7111,
+                    "id": 8028,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
@@ -9431,28 +9431,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6232,
+                    "id": 7066,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6233,
+                    "id": 7067,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6234,
+                    "id": 7068,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6235,
+                    "id": 7069,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9483,25 +9483,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7112,
+                    "id": 8029,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7113,
+                    "id": 8030,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7114,
+                    "id": 8031,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7115,
+                    "id": 8032,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9518,28 +9518,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6236,
+                    "id": 7070,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6237,
+                    "id": 7071,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6238,
+                    "id": 7072,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6239,
+                    "id": 7073,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9570,25 +9570,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7116,
+                    "id": 8033,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7117,
+                    "id": 8034,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7118,
+                    "id": 8035,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7119,
+                    "id": 8036,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9605,28 +9605,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6240,
+                    "id": 7074,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6241,
+                    "id": 7075,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6242,
+                    "id": 7076,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6243,
+                    "id": 7077,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9656,25 +9656,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7120,
+                    "id": 8037,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7121,
+                    "id": 8038,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7122,
+                    "id": 8039,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7123,
+                    "id": 8040,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9691,28 +9691,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6244,
+                    "id": 7078,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6245,
+                    "id": 7079,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6246,
+                    "id": 7080,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6247,
+                    "id": 7081,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9742,25 +9742,25 @@
             "ship_type": 43,
             "statistics": [
                 {
-                    "id": 7124,
+                    "id": 8041,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7125,
+                    "id": 8042,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7126,
+                    "id": 8043,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7127,
+                    "id": 8044,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -9777,21 +9777,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6248,
+                    "id": 7082,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6249,
+                    "id": 7083,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6250,
+                    "id": 7084,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9822,19 +9822,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7128,
+                    "id": 8045,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7129,
+                    "id": 8046,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7130,
+                    "id": 8047,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9851,21 +9851,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6251,
+                    "id": 7085,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6252,
+                    "id": 7086,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6253,
+                    "id": 7087,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9896,19 +9896,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7131,
+                    "id": 8048,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7132,
+                    "id": 8049,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7133,
+                    "id": 8050,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9925,21 +9925,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6254,
+                    "id": 7088,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6255,
+                    "id": 7089,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6256,
+                    "id": 7090,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -9970,19 +9970,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7134,
+                    "id": 8051,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7135,
+                    "id": 8052,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7136,
+                    "id": 8053,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -9999,21 +9999,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6257,
+                    "id": 7091,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6258,
+                    "id": 7092,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6259,
+                    "id": 7093,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10044,19 +10044,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7137,
+                    "id": 8054,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7138,
+                    "id": 8055,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7139,
+                    "id": 8056,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10073,21 +10073,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6260,
+                    "id": 7094,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6261,
+                    "id": 7095,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6262,
+                    "id": 7096,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10117,19 +10117,19 @@
             "ship_type": 16,
             "statistics": [
                 {
-                    "id": 7140,
+                    "id": 8057,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7141,
+                    "id": 8058,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7142,
+                    "id": 8059,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -10146,35 +10146,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6263,
+                    "id": 7097,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6264,
+                    "id": 7098,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6265,
+                    "id": 7099,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6266,
+                    "id": 7100,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6267,
+                    "id": 7101,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10205,25 +10205,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7143,
+                    "id": 8060,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7144,
+                    "id": 8061,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7145,
+                    "id": 8062,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7146,
+                    "id": 8063,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10240,35 +10240,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6268,
+                    "id": 7102,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6269,
+                    "id": 7103,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6270,
+                    "id": 7104,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6271,
+                    "id": 7105,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6272,
+                    "id": 7106,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10299,25 +10299,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7147,
+                    "id": 8064,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7148,
+                    "id": 8065,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7149,
+                    "id": 8066,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7150,
+                    "id": 8067,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10334,35 +10334,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6273,
+                    "id": 7107,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6274,
+                    "id": 7108,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6275,
+                    "id": 7109,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6276,
+                    "id": 7110,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6277,
+                    "id": 7111,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10393,25 +10393,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7151,
+                    "id": 8068,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7152,
+                    "id": 8069,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7153,
+                    "id": 8070,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7154,
+                    "id": 8071,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10428,35 +10428,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6278,
+                    "id": 7112,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6279,
+                    "id": 7113,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6280,
+                    "id": 7114,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6281,
+                    "id": 7115,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6282,
+                    "id": 7116,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10487,25 +10487,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7155,
+                    "id": 8072,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7156,
+                    "id": 8073,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7157,
+                    "id": 8074,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7158,
+                    "id": 8075,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10522,35 +10522,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6283,
+                    "id": 7117,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6284,
+                    "id": 7118,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6285,
+                    "id": 7119,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6286,
+                    "id": 7120,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6287,
+                    "id": 7121,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10580,25 +10580,25 @@
             "ship_type": 18,
             "statistics": [
                 {
-                    "id": 7159,
+                    "id": 8076,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7160,
+                    "id": 8077,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7161,
+                    "id": 8078,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7162,
+                    "id": 8079,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -10615,21 +10615,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6288,
+                    "id": 7122,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6289,
+                    "id": 7123,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6290,
+                    "id": 7124,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10662,25 +10662,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7163,
+                    "id": 8080,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7164,
+                    "id": 8081,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7165,
+                    "id": 8082,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7166,
+                    "id": 8083,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10697,21 +10697,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6291,
+                    "id": 7125,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6292,
+                    "id": 7126,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6293,
+                    "id": 7127,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10744,25 +10744,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7167,
+                    "id": 8084,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7168,
+                    "id": 8085,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7169,
+                    "id": 8086,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7170,
+                    "id": 8087,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10779,21 +10779,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6294,
+                    "id": 7128,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6295,
+                    "id": 7129,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6296,
+                    "id": 7130,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10826,25 +10826,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7171,
+                    "id": 8088,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7172,
+                    "id": 8089,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7173,
+                    "id": 8090,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7174,
+                    "id": 8091,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10861,21 +10861,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6297,
+                    "id": 7131,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6298,
+                    "id": 7132,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6299,
+                    "id": 7133,
                     "related_action_id": 3,
                     "related_action_side_effect": "stress"
                 }
@@ -10907,25 +10907,25 @@
             "ship_type": 29,
             "statistics": [
                 {
-                    "id": 7175,
+                    "id": 8092,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7176,
+                    "id": 8093,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7177,
+                    "id": 8094,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7178,
+                    "id": 8095,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -10942,28 +10942,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6300,
+                    "id": 7134,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6301,
+                    "id": 7135,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6302,
+                    "id": 7136,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6303,
+                    "id": 7137,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -10994,25 +10994,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7179,
+                    "id": 8096,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7180,
+                    "id": 8097,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7181,
+                    "id": 8098,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7182,
+                    "id": 8099,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11029,28 +11029,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6304,
+                    "id": 7138,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6305,
+                    "id": 7139,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6306,
+                    "id": 7140,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6307,
+                    "id": 7141,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11081,25 +11081,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7183,
+                    "id": 8100,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7184,
+                    "id": 8101,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7185,
+                    "id": 8102,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7186,
+                    "id": 8103,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11116,28 +11116,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6308,
+                    "id": 7142,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6309,
+                    "id": 7143,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6310,
+                    "id": 7144,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6311,
+                    "id": 7145,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11168,25 +11168,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7187,
+                    "id": 8104,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7188,
+                    "id": 8105,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7189,
+                    "id": 8106,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7190,
+                    "id": 8107,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11203,28 +11203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6312,
+                    "id": 7146,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6313,
+                    "id": 7147,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6314,
+                    "id": 7148,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 7,
                     "base_action_side_effect": null,
-                    "id": 6315,
+                    "id": 7149,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11254,25 +11254,25 @@
             "ship_type": 27,
             "statistics": [
                 {
-                    "id": 7191,
+                    "id": 8108,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7192,
+                    "id": 8109,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7193,
+                    "id": 8110,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7194,
+                    "id": 8111,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -11289,28 +11289,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6316,
+                    "id": 7150,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6317,
+                    "id": 7151,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6318,
+                    "id": 7152,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6319,
+                    "id": 7153,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11343,25 +11343,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7195,
+                    "id": 8112,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7196,
+                    "id": 8113,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7197,
+                    "id": 8114,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7198,
+                    "id": 8115,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11378,28 +11378,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6320,
+                    "id": 7154,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6321,
+                    "id": 7155,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6322,
+                    "id": 7156,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6323,
+                    "id": 7157,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11432,25 +11432,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7199,
+                    "id": 8116,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7200,
+                    "id": 8117,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7201,
+                    "id": 8118,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7202,
+                    "id": 8119,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11467,28 +11467,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6324,
+                    "id": 7158,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6325,
+                    "id": 7159,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6326,
+                    "id": 7160,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6327,
+                    "id": 7161,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11521,25 +11521,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7203,
+                    "id": 8120,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7204,
+                    "id": 8121,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7205,
+                    "id": 8122,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7206,
+                    "id": 8123,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11556,28 +11556,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6328,
+                    "id": 7162,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6329,
+                    "id": 7163,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 13,
                     "base_action_side_effect": null,
-                    "id": 6330,
+                    "id": 7164,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6331,
+                    "id": 7165,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11609,25 +11609,25 @@
             "ship_type": 14,
             "statistics": [
                 {
-                    "id": 7207,
+                    "id": 8124,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7208,
+                    "id": 8125,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7209,
+                    "id": 8126,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7210,
+                    "id": 8127,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11644,35 +11644,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6332,
+                    "id": 7166,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6333,
+                    "id": 7167,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6334,
+                    "id": 7168,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6335,
+                    "id": 7169,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6336,
+                    "id": 7170,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11707,25 +11707,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7211,
+                    "id": 8128,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7212,
+                    "id": 8129,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7213,
+                    "id": 8130,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7214,
+                    "id": 8131,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11742,35 +11742,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6337,
+                    "id": 7171,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6338,
+                    "id": 7172,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6339,
+                    "id": 7173,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6340,
+                    "id": 7174,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6341,
+                    "id": 7175,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11805,25 +11805,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7215,
+                    "id": 8132,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7216,
+                    "id": 8133,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7217,
+                    "id": 8134,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7218,
+                    "id": 8135,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11840,35 +11840,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6342,
+                    "id": 7176,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6343,
+                    "id": 7177,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6344,
+                    "id": 7178,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6345,
+                    "id": 7179,
                     "related_action_id": 4,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6346,
+                    "id": 7180,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11903,25 +11903,25 @@
             "ship_type": 20,
             "statistics": [
                 {
-                    "id": 7219,
+                    "id": 8136,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7220,
+                    "id": 8137,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7221,
+                    "id": 8138,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7222,
+                    "id": 8139,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -11938,28 +11938,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6347,
+                    "id": 7181,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6348,
+                    "id": 7182,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6349,
+                    "id": 7183,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6350,
+                    "id": 7184,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -11992,31 +11992,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7223,
+                    "id": 8140,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7224,
+                    "id": 8141,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7225,
+                    "id": 8142,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7226,
+                    "id": 8143,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7227,
+                    "id": 8144,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12033,28 +12033,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6351,
+                    "id": 7185,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6352,
+                    "id": 7186,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6353,
+                    "id": 7187,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6354,
+                    "id": 7188,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12087,37 +12087,37 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7228,
+                    "id": 8145,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7229,
+                    "id": 8146,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7230,
+                    "id": 8147,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7231,
+                    "id": 8148,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7232,
+                    "id": 8149,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7233,
+                    "id": 8150,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -12134,28 +12134,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6355,
+                    "id": 7189,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6356,
+                    "id": 7190,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6357,
+                    "id": 7191,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6358,
+                    "id": 7192,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12188,31 +12188,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7234,
+                    "id": 8151,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7235,
+                    "id": 8152,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7236,
+                    "id": 8153,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7237,
+                    "id": 8154,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7238,
+                    "id": 8155,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12229,28 +12229,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6359,
+                    "id": 7193,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6360,
+                    "id": 7194,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": null,
-                    "id": 6361,
+                    "id": 7195,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6362,
+                    "id": 7196,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12283,31 +12283,31 @@
             "ship_type": 26,
             "statistics": [
                 {
-                    "id": 7239,
+                    "id": 8156,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7240,
+                    "id": 8157,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "2"
                 },
                 {
-                    "id": 7241,
+                    "id": 8158,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7242,
+                    "id": 8159,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7243,
+                    "id": 8160,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12324,35 +12324,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6363,
+                    "id": 7197,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6364,
+                    "id": 7198,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6365,
+                    "id": 7199,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6366,
+                    "id": 7200,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6367,
+                    "id": 7201,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12387,25 +12387,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7244,
+                    "id": 8161,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7245,
+                    "id": 8162,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7246,
+                    "id": 8163,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7247,
+                    "id": 8164,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12422,35 +12422,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6368,
+                    "id": 7202,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6369,
+                    "id": 7203,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6370,
+                    "id": 7204,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6371,
+                    "id": 7205,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6372,
+                    "id": 7206,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12485,25 +12485,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7248,
+                    "id": 8165,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7249,
+                    "id": 8166,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7250,
+                    "id": 8167,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7251,
+                    "id": 8168,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12520,35 +12520,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6373,
+                    "id": 7207,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6374,
+                    "id": 7208,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6375,
+                    "id": 7209,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6376,
+                    "id": 7210,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6377,
+                    "id": 7211,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12582,25 +12582,25 @@
             "ship_type": 28,
             "statistics": [
                 {
-                    "id": 7252,
+                    "id": 8169,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "3"
                 },
                 {
-                    "id": 7253,
+                    "id": 8170,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "0"
                 },
                 {
-                    "id": 7254,
+                    "id": 8171,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "12"
                 },
                 {
-                    "id": 7255,
+                    "id": 8172,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12617,28 +12617,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6378,
+                    "id": 7212,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6379,
+                    "id": 7213,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6380,
+                    "id": 7214,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6381,
+                    "id": 7215,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12674,31 +12674,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7256,
+                    "id": 8173,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7257,
+                    "id": 8174,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7258,
+                    "id": 8175,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7259,
+                    "id": 8176,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7260,
+                    "id": 8177,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12715,28 +12715,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6382,
+                    "id": 7216,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6383,
+                    "id": 7217,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6384,
+                    "id": 7218,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6385,
+                    "id": 7219,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12772,31 +12772,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7261,
+                    "id": 8178,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7262,
+                    "id": 8179,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7263,
+                    "id": 8180,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7264,
+                    "id": 8181,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7265,
+                    "id": 8182,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12813,28 +12813,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6386,
+                    "id": 7220,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6387,
+                    "id": 7221,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6388,
+                    "id": 7222,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6389,
+                    "id": 7223,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12870,31 +12870,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7266,
+                    "id": 8183,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7267,
+                    "id": 8184,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7268,
+                    "id": 8185,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7269,
+                    "id": 8186,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7270,
+                    "id": 8187,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -12911,28 +12911,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6390,
+                    "id": 7224,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6391,
+                    "id": 7225,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6392,
+                    "id": 7226,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6393,
+                    "id": 7227,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -12967,31 +12967,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7271,
+                    "id": 8188,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7272,
+                    "id": 8189,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7273,
+                    "id": 8190,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7274,
+                    "id": 8191,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7275,
+                    "id": 8192,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13008,28 +13008,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6394,
+                    "id": 7228,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6395,
+                    "id": 7229,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6396,
+                    "id": 7230,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6397,
+                    "id": 7231,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13065,31 +13065,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7276,
+                    "id": 8193,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7277,
+                    "id": 8194,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7278,
+                    "id": 8195,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7279,
+                    "id": 8196,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7280,
+                    "id": 8197,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13106,28 +13106,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6398,
+                    "id": 7232,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6399,
+                    "id": 7233,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": "stress",
-                    "id": 6400,
+                    "id": 7234,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6401,
+                    "id": 7235,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13162,31 +13162,31 @@
             "ship_type": 10,
             "statistics": [
                 {
-                    "id": 7281,
+                    "id": 8198,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7282,
+                    "id": 8199,
                     "recurring": false,
                     "statistic_id": 14,
                     "value": "3"
                 },
                 {
-                    "id": 7283,
+                    "id": 8200,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7284,
+                    "id": 8201,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7285,
+                    "id": 8202,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -13203,28 +13203,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6402,
+                    "id": 7236,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6403,
+                    "id": 7237,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6404,
+                    "id": 7238,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6405,
+                    "id": 7239,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13254,19 +13254,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7286,
+                    "id": 8203,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7287,
+                    "id": 8204,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7288,
+                    "id": 8205,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13283,28 +13283,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6406,
+                    "id": 7240,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6407,
+                    "id": 7241,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6408,
+                    "id": 7242,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6409,
+                    "id": 7243,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13334,19 +13334,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7289,
+                    "id": 8206,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7290,
+                    "id": 8207,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7291,
+                    "id": 8208,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13363,28 +13363,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6410,
+                    "id": 7244,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6411,
+                    "id": 7245,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6412,
+                    "id": 7246,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6413,
+                    "id": 7247,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13413,19 +13413,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7292,
+                    "id": 8209,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7293,
+                    "id": 8210,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7294,
+                    "id": 8211,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13442,28 +13442,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6414,
+                    "id": 7248,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6415,
+                    "id": 7249,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6416,
+                    "id": 7250,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6417,
+                    "id": 7251,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13493,19 +13493,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7295,
+                    "id": 8212,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7296,
+                    "id": 8213,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7297,
+                    "id": 8214,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13522,28 +13522,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6418,
+                    "id": 7252,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6419,
+                    "id": 7253,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6420,
+                    "id": 7254,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6421,
+                    "id": 7255,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13573,19 +13573,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7298,
+                    "id": 8215,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7299,
+                    "id": 8216,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7300,
+                    "id": 8217,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13602,28 +13602,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6422,
+                    "id": 7256,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6423,
+                    "id": 7257,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6424,
+                    "id": 7258,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6425,
+                    "id": 7259,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -13652,19 +13652,19 @@
             "ship_type": 36,
             "statistics": [
                 {
-                    "id": 7301,
+                    "id": 8218,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7302,
+                    "id": 8219,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7303,
+                    "id": 8220,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
@@ -13681,21 +13681,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6426,
+                    "id": 7260,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6427,
+                    "id": 7261,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6428,
+                    "id": 7262,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13728,19 +13728,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7304,
+                    "id": 8221,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7305,
+                    "id": 8222,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7306,
+                    "id": 8223,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13757,21 +13757,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6429,
+                    "id": 7263,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6430,
+                    "id": 7264,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6431,
+                    "id": 7265,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13803,19 +13803,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7307,
+                    "id": 8224,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7308,
+                    "id": 8225,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7309,
+                    "id": 8226,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13832,21 +13832,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6432,
+                    "id": 7266,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6433,
+                    "id": 7267,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6434,
+                    "id": 7268,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13878,19 +13878,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7310,
+                    "id": 8227,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7311,
+                    "id": 8228,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7312,
+                    "id": 8229,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13907,21 +13907,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6435,
+                    "id": 7269,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": "stress",
-                    "id": 6436,
+                    "id": 7270,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6437,
+                    "id": 7271,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -13953,19 +13953,19 @@
             "ship_type": 9,
             "statistics": [
                 {
-                    "id": 7313,
+                    "id": 8230,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7314,
+                    "id": 8231,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7315,
+                    "id": 8232,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
@@ -13982,28 +13982,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6438,
+                    "id": 7272,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6439,
+                    "id": 7273,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6440,
+                    "id": 7274,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6441,
+                    "id": 7275,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14038,25 +14038,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7316,
+                    "id": 8233,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7317,
+                    "id": 8234,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7318,
+                    "id": 8235,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7319,
+                    "id": 8236,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14073,28 +14073,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6442,
+                    "id": 7276,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6443,
+                    "id": 7277,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6444,
+                    "id": 7278,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6445,
+                    "id": 7279,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14129,25 +14129,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7320,
+                    "id": 8237,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7321,
+                    "id": 8238,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7322,
+                    "id": 8239,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7323,
+                    "id": 8240,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14164,28 +14164,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6446,
+                    "id": 7280,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6447,
+                    "id": 7281,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6448,
+                    "id": 7282,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6449,
+                    "id": 7283,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14220,25 +14220,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7324,
+                    "id": 8241,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7325,
+                    "id": 8242,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7326,
+                    "id": 8243,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7327,
+                    "id": 8244,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14255,28 +14255,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6450,
+                    "id": 7284,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6451,
+                    "id": 7285,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6452,
+                    "id": 7286,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": "stress",
-                    "id": 6453,
+                    "id": 7287,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14310,25 +14310,25 @@
             "ship_type": 12,
             "statistics": [
                 {
-                    "id": 7328,
+                    "id": 8245,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7329,
+                    "id": 8246,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7330,
+                    "id": 8247,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7331,
+                    "id": 8248,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14345,21 +14345,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6454,
+                    "id": 7288,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6455,
+                    "id": 7289,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6456,
+                    "id": 7290,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14390,25 +14390,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7332,
+                    "id": 8249,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7333,
+                    "id": 8250,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7334,
+                    "id": 8251,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7335,
+                    "id": 8252,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14425,21 +14425,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6457,
+                    "id": 7291,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6458,
+                    "id": 7292,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6459,
+                    "id": 7293,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14470,25 +14470,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7336,
+                    "id": 8253,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7337,
+                    "id": 8254,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7338,
+                    "id": 8255,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7339,
+                    "id": 8256,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14505,21 +14505,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6460,
+                    "id": 7294,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6461,
+                    "id": 7295,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6462,
+                    "id": 7296,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14549,25 +14549,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7340,
+                    "id": 8257,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7341,
+                    "id": 8258,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7342,
+                    "id": 8259,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7343,
+                    "id": 8260,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14584,21 +14584,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6463,
+                    "id": 7297,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6464,
+                    "id": 7298,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6465,
+                    "id": 7299,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14629,25 +14629,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7344,
+                    "id": 8261,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7345,
+                    "id": 8262,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7346,
+                    "id": 8263,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7347,
+                    "id": 8264,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14664,21 +14664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6466,
+                    "id": 7300,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6467,
+                    "id": 7301,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6468,
+                    "id": 7302,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14708,25 +14708,25 @@
             "ship_type": 38,
             "statistics": [
                 {
-                    "id": 7348,
+                    "id": 8265,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7349,
+                    "id": 8266,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7350,
+                    "id": 8267,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7351,
+                    "id": 8268,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14743,35 +14743,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6469,
+                    "id": 7303,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6470,
+                    "id": 7304,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6471,
+                    "id": 7305,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6472,
+                    "id": 7306,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6473,
+                    "id": 7307,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14804,31 +14804,31 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7352,
+                    "id": 8269,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7353,
+                    "id": 8270,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7354,
+                    "id": 8271,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7355,
+                    "id": 8272,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7356,
+                    "id": 8273,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "3"
@@ -14845,35 +14845,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6474,
+                    "id": 7308,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6475,
+                    "id": 7309,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6476,
+                    "id": 7310,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6477,
+                    "id": 7311,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6478,
+                    "id": 7312,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -14906,25 +14906,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7357,
+                    "id": 8274,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7358,
+                    "id": 8275,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7359,
+                    "id": 8276,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7360,
+                    "id": 8277,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -14941,35 +14941,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6479,
+                    "id": 7313,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6480,
+                    "id": 7314,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6481,
+                    "id": 7315,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6482,
+                    "id": 7316,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6483,
+                    "id": 7317,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15001,25 +15001,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7361,
+                    "id": 8278,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7362,
+                    "id": 8279,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7363,
+                    "id": 8280,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7364,
+                    "id": 8281,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15036,35 +15036,35 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6484,
+                    "id": 7318,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6485,
+                    "id": 7319,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6486,
+                    "id": 7320,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6487,
+                    "id": 7321,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": "stress",
-                    "id": 6488,
+                    "id": 7322,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15096,25 +15096,25 @@
             "ship_type": 34,
             "statistics": [
                 {
-                    "id": 7365,
+                    "id": 8282,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7366,
+                    "id": 8283,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7367,
+                    "id": 8284,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7368,
+                    "id": 8285,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -15131,28 +15131,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6489,
+                    "id": 7323,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6490,
+                    "id": 7324,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6491,
+                    "id": 7325,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6492,
+                    "id": 7326,
                     "related_action_id": 9,
                     "related_action_side_effect": "stress"
                 }
@@ -15184,25 +15184,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7369,
+                    "id": 8286,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7370,
+                    "id": 8287,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7371,
+                    "id": 8288,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7372,
+                    "id": 8289,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15219,28 +15219,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6493,
+                    "id": 7327,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6494,
+                    "id": 7328,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6495,
+                    "id": 7329,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6496,
+                    "id": 7330,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15272,25 +15272,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7373,
+                    "id": 8290,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7374,
+                    "id": 8291,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7375,
+                    "id": 8292,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7376,
+                    "id": 8293,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15307,28 +15307,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6497,
+                    "id": 7331,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6498,
+                    "id": 7332,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6499,
+                    "id": 7333,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6500,
+                    "id": 7334,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15360,25 +15360,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7377,
+                    "id": 8294,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7378,
+                    "id": 8295,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7379,
+                    "id": 8296,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7380,
+                    "id": 8297,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15395,28 +15395,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6501,
+                    "id": 7335,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6502,
+                    "id": 7336,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6503,
+                    "id": 7337,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6504,
+                    "id": 7338,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15448,25 +15448,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7381,
+                    "id": 8298,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7382,
+                    "id": 8299,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7383,
+                    "id": 8300,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7384,
+                    "id": 8301,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15483,28 +15483,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6505,
+                    "id": 7339,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6506,
+                    "id": 7340,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6507,
+                    "id": 7341,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6508,
+                    "id": 7342,
                     "related_action_id": 2,
                     "related_action_side_effect": "stress"
                 }
@@ -15535,25 +15535,25 @@
             "ship_type": 3,
             "statistics": [
                 {
-                    "id": 7385,
+                    "id": 8302,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7386,
+                    "id": 8303,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7387,
+                    "id": 8304,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "4"
                 },
                 {
-                    "id": 7388,
+                    "id": 8305,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15570,28 +15570,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6509,
+                    "id": 7343,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6510,
+                    "id": 7344,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6511,
+                    "id": 7345,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6512,
+                    "id": 7346,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15621,25 +15621,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7389,
+                    "id": 8306,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7390,
+                    "id": 8307,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7391,
+                    "id": 8308,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7392,
+                    "id": 8309,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15656,28 +15656,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6513,
+                    "id": 7347,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6514,
+                    "id": 7348,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6515,
+                    "id": 7349,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6516,
+                    "id": 7350,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15707,25 +15707,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7393,
+                    "id": 8310,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7394,
+                    "id": 8311,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7395,
+                    "id": 8312,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7396,
+                    "id": 8313,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15742,28 +15742,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6517,
+                    "id": 7351,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6518,
+                    "id": 7352,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6519,
+                    "id": 7353,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6520,
+                    "id": 7354,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15793,25 +15793,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7397,
+                    "id": 8314,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7398,
+                    "id": 8315,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7399,
+                    "id": 8316,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7400,
+                    "id": 8317,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15828,28 +15828,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6521,
+                    "id": 7355,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6522,
+                    "id": 7356,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6523,
+                    "id": 7357,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6524,
+                    "id": 7358,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15879,25 +15879,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7401,
+                    "id": 8318,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7402,
+                    "id": 8319,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7403,
+                    "id": 8320,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7404,
+                    "id": 8321,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15914,28 +15914,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6525,
+                    "id": 7359,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6526,
+                    "id": 7360,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6527,
+                    "id": 7361,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6528,
+                    "id": 7362,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -15964,25 +15964,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7405,
+                    "id": 8322,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7406,
+                    "id": 8323,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7407,
+                    "id": 8324,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7408,
+                    "id": 8325,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -15999,28 +15999,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6529,
+                    "id": 7363,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6530,
+                    "id": 7364,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6531,
+                    "id": 7365,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6532,
+                    "id": 7366,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16049,25 +16049,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7409,
+                    "id": 8326,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7410,
+                    "id": 8327,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7411,
+                    "id": 8328,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7412,
+                    "id": 8329,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16084,28 +16084,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6533,
+                    "id": 7367,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6534,
+                    "id": 7368,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6535,
+                    "id": 7369,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6536,
+                    "id": 7370,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16135,25 +16135,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7413,
+                    "id": 8330,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7414,
+                    "id": 8331,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7415,
+                    "id": 8332,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7416,
+                    "id": 8333,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16170,28 +16170,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6537,
+                    "id": 7371,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6538,
+                    "id": 7372,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6539,
+                    "id": 7373,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6540,
+                    "id": 7374,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16220,25 +16220,25 @@
             "ship_type": 44,
             "statistics": [
                 {
-                    "id": 7417,
+                    "id": 8334,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7418,
+                    "id": 8335,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7419,
+                    "id": 8336,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "3"
                 },
                 {
-                    "id": 7420,
+                    "id": 8337,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16255,21 +16255,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6541,
+                    "id": 7375,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6542,
+                    "id": 7376,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6543,
+                    "id": 7377,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16302,25 +16302,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7421,
+                    "id": 8338,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7422,
+                    "id": 8339,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7423,
+                    "id": 8340,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7424,
+                    "id": 8341,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16337,21 +16337,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6544,
+                    "id": 7378,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6545,
+                    "id": 7379,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6546,
+                    "id": 7380,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16384,25 +16384,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7425,
+                    "id": 8342,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7426,
+                    "id": 8343,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7427,
+                    "id": 8344,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7428,
+                    "id": 8345,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16419,21 +16419,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6547,
+                    "id": 7381,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6548,
+                    "id": 7382,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6549,
+                    "id": 7383,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16466,25 +16466,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7429,
+                    "id": 8346,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7430,
+                    "id": 8347,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7431,
+                    "id": 8348,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7432,
+                    "id": 8349,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16501,21 +16501,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6550,
+                    "id": 7384,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6551,
+                    "id": 7385,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6552,
+                    "id": 7386,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16547,25 +16547,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7433,
+                    "id": 8350,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7434,
+                    "id": 8351,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7435,
+                    "id": 8352,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7436,
+                    "id": 8353,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16582,21 +16582,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6553,
+                    "id": 7387,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6554,
+                    "id": 7388,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6555,
+                    "id": 7389,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16629,25 +16629,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7437,
+                    "id": 8354,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7438,
+                    "id": 8355,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7439,
+                    "id": 8356,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7440,
+                    "id": 8357,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16664,21 +16664,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6556,
+                    "id": 7390,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6557,
+                    "id": 7391,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6558,
+                    "id": 7392,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16710,25 +16710,25 @@
             "ship_type": 7,
             "statistics": [
                 {
-                    "id": 7441,
+                    "id": 8358,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7442,
+                    "id": 8359,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7443,
+                    "id": 8360,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7444,
+                    "id": 8361,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "1"
@@ -16745,28 +16745,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6559,
+                    "id": 7393,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6560,
+                    "id": 7394,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6561,
+                    "id": 7395,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6562,
+                    "id": 7396,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16801,25 +16801,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7445,
+                    "id": 8362,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7446,
+                    "id": 8363,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7447,
+                    "id": 8364,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7448,
+                    "id": 8365,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16836,28 +16836,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6563,
+                    "id": 7397,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6564,
+                    "id": 7398,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6565,
+                    "id": 7399,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6566,
+                    "id": 7400,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16892,25 +16892,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7449,
+                    "id": 8366,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7450,
+                    "id": 8367,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7451,
+                    "id": 8368,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7452,
+                    "id": 8369,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -16927,28 +16927,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6567,
+                    "id": 7401,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6568,
+                    "id": 7402,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6569,
+                    "id": 7403,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6570,
+                    "id": 7404,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -16983,25 +16983,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7453,
+                    "id": 8370,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7454,
+                    "id": 8371,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7455,
+                    "id": 8372,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7456,
+                    "id": 8373,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17018,28 +17018,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6571,
+                    "id": 7405,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6572,
+                    "id": 7406,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6573,
+                    "id": 7407,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": null,
-                    "id": 6574,
+                    "id": 7408,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17074,25 +17074,25 @@
             "ship_type": 21,
             "statistics": [
                 {
-                    "id": 7457,
+                    "id": 8374,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7458,
+                    "id": 8375,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "3"
                 },
                 {
-                    "id": 7459,
+                    "id": 8376,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7460,
+                    "id": 8377,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17109,21 +17109,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6575,
+                    "id": 7409,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6576,
+                    "id": 7410,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6577,
+                    "id": 7411,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17156,25 +17156,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7461,
+                    "id": 8378,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7462,
+                    "id": 8379,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7463,
+                    "id": 8380,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7464,
+                    "id": 8381,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17191,21 +17191,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6578,
+                    "id": 7412,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6579,
+                    "id": 7413,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6580,
+                    "id": 7414,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17238,25 +17238,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7465,
+                    "id": 8382,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7466,
+                    "id": 8383,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7467,
+                    "id": 8384,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7468,
+                    "id": 8385,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17273,21 +17273,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6581,
+                    "id": 7415,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6582,
+                    "id": 7416,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 10,
                     "base_action_side_effect": null,
-                    "id": 6583,
+                    "id": 7417,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17319,25 +17319,25 @@
             "ship_type": 22,
             "statistics": [
                 {
-                    "id": 7469,
+                    "id": 8386,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7470,
+                    "id": 8387,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7471,
+                    "id": 8388,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "5"
                 },
                 {
-                    "id": 7472,
+                    "id": 8389,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17354,21 +17354,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6584,
+                    "id": 7418,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6585,
+                    "id": 7419,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6586,
+                    "id": 7420,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17402,31 +17402,31 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7473,
+                    "id": 8390,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7474,
+                    "id": 8391,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7475,
+                    "id": 8392,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7476,
+                    "id": 8393,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
                 },
                 {
-                    "id": 7477,
+                    "id": 8394,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -17443,21 +17443,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6587,
+                    "id": 7421,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6588,
+                    "id": 7422,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6589,
+                    "id": 7423,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17491,25 +17491,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7478,
+                    "id": 8395,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7479,
+                    "id": 8396,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7480,
+                    "id": 8397,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7481,
+                    "id": 8398,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17526,21 +17526,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6590,
+                    "id": 7424,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6591,
+                    "id": 7425,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6592,
+                    "id": 7426,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17573,25 +17573,25 @@
             "ship_type": 4,
             "statistics": [
                 {
-                    "id": 7482,
+                    "id": 8399,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7483,
+                    "id": 8400,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7484,
+                    "id": 8401,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7485,
+                    "id": 8402,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "4"
@@ -17608,28 +17608,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6593,
+                    "id": 7427,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6594,
+                    "id": 7428,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6595,
+                    "id": 7429,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6596,
+                    "id": 7430,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17662,25 +17662,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7486,
+                    "id": 8403,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7487,
+                    "id": 8404,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7488,
+                    "id": 8405,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7489,
+                    "id": 8406,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17697,28 +17697,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6597,
+                    "id": 7431,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6598,
+                    "id": 7432,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6599,
+                    "id": 7433,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6600,
+                    "id": 7434,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17751,31 +17751,31 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7490,
+                    "id": 8407,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7491,
+                    "id": 8408,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7492,
+                    "id": 8409,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7493,
+                    "id": 8410,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7494,
+                    "id": 8411,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -17792,28 +17792,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6601,
+                    "id": 7435,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6602,
+                    "id": 7436,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6603,
+                    "id": 7437,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 12,
                     "base_action_side_effect": null,
-                    "id": 6604,
+                    "id": 7438,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17846,25 +17846,25 @@
             "ship_type": 39,
             "statistics": [
                 {
-                    "id": 7495,
+                    "id": 8412,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7496,
+                    "id": 8413,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7497,
+                    "id": 8414,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "7"
                 },
                 {
-                    "id": 7498,
+                    "id": 8415,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -17881,21 +17881,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6605,
+                    "id": 7439,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6606,
+                    "id": 7440,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6607,
+                    "id": 7441,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -17931,25 +17931,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7499,
+                    "id": 8416,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7500,
+                    "id": 8417,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7501,
+                    "id": 8418,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7502,
+                    "id": 8419,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -17966,21 +17966,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6608,
+                    "id": 7442,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6609,
+                    "id": 7443,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6610,
+                    "id": 7444,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18016,31 +18016,31 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7503,
+                    "id": 8420,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7504,
+                    "id": 8421,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7505,
+                    "id": 8422,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7506,
+                    "id": 8423,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7507,
+                    "id": 8424,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "2"
@@ -18057,21 +18057,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6611,
+                    "id": 7445,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6612,
+                    "id": 7446,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6613,
+                    "id": 7447,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18107,25 +18107,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7508,
+                    "id": 8425,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7509,
+                    "id": 8426,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7510,
+                    "id": 8427,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7511,
+                    "id": 8428,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18142,21 +18142,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6614,
+                    "id": 7448,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 6,
                     "base_action_side_effect": null,
-                    "id": 6615,
+                    "id": 7449,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6616,
+                    "id": 7450,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18191,25 +18191,25 @@
             "ship_type": 24,
             "statistics": [
                 {
-                    "id": 7512,
+                    "id": 8429,
                     "recurring": false,
                     "statistic_id": 9,
                     "value": "3"
                 },
                 {
-                    "id": 7513,
+                    "id": 8430,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7514,
+                    "id": 8431,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "9"
                 },
                 {
-                    "id": 7515,
+                    "id": 8432,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18226,21 +18226,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6617,
+                    "id": 7451,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6618,
+                    "id": 7452,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6619,
+                    "id": 7453,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18273,31 +18273,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7516,
+                    "id": 8433,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7517,
+                    "id": 8434,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7518,
+                    "id": 8435,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7519,
+                    "id": 8436,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7520,
+                    "id": 8437,
                     "recurring": true,
                     "statistic_id": 7,
                     "value": "1"
@@ -18314,21 +18314,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6620,
+                    "id": 7454,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6621,
+                    "id": 7455,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6622,
+                    "id": 7456,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18346,7 +18346,7 @@
                 6
             ],
             "card_type_id": 1,
-            "cost": "54",
+            "cost": "56",
             "faction_id": 3,
             "ffg_id": "XW_P_215",
             "force_side": null,
@@ -18356,30 +18356,30 @@
             "is_unique": true,
             "name": "•Manaroo",
             "restrictions": [],
-            "ship_ability_text": null,
+            "ship_ability_text": "",
             "ship_size": 3,
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7521,
+                    "id": 8438,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7522,
+                    "id": 8439,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7523,
+                    "id": 8440,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7524,
+                    "id": 8441,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18396,21 +18396,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6623,
+                    "id": 7457,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6624,
+                    "id": 7458,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6625,
+                    "id": 7459,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18443,31 +18443,31 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7525,
+                    "id": 8442,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7526,
+                    "id": 8443,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7527,
+                    "id": 8444,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7528,
+                    "id": 8445,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
                 },
                 {
-                    "id": 7529,
+                    "id": 8446,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "1"
@@ -18484,21 +18484,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6626,
+                    "id": 7460,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6627,
+                    "id": 7461,
                     "related_action_id": 14,
                     "related_action_side_effect": "stress"
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": "stress",
-                    "id": 6628,
+                    "id": 7462,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18530,25 +18530,25 @@
             "ship_type": 45,
             "statistics": [
                 {
-                    "id": 7530,
+                    "id": 8447,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7531,
+                    "id": 8448,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7532,
+                    "id": 8449,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "6"
                 },
                 {
-                    "id": 7533,
+                    "id": 8450,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -18565,28 +18565,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6629,
+                    "id": 7463,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6630,
+                    "id": 7464,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6631,
+                    "id": 7465,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6632,
+                    "id": 7466,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18619,31 +18619,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7534,
+                    "id": 8451,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7535,
+                    "id": 8452,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7536,
+                    "id": 8453,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7537,
+                    "id": 8454,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7538,
+                    "id": 8455,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18660,28 +18660,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6633,
+                    "id": 7467,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6634,
+                    "id": 7468,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6635,
+                    "id": 7469,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6636,
+                    "id": 7470,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18714,37 +18714,37 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7539,
+                    "id": 8456,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7540,
+                    "id": 8457,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7541,
+                    "id": 8458,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7542,
+                    "id": 8459,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7543,
+                    "id": 8460,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7544,
+                    "id": 8461,
                     "recurring": true,
                     "statistic_id": 4,
                     "value": "2"
@@ -18761,28 +18761,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6637,
+                    "id": 7471,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6638,
+                    "id": 7472,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6639,
+                    "id": 7473,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6640,
+                    "id": 7474,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18815,31 +18815,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7545,
+                    "id": 8462,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7546,
+                    "id": 8463,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7547,
+                    "id": 8464,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7548,
+                    "id": 8465,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7549,
+                    "id": 8466,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18856,28 +18856,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6641,
+                    "id": 7475,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 3,
                     "base_action_side_effect": null,
-                    "id": 6642,
+                    "id": 7476,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6643,
+                    "id": 7477,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6644,
+                    "id": 7478,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -18909,31 +18909,31 @@
             "ship_type": 42,
             "statistics": [
                 {
-                    "id": 7550,
+                    "id": 8467,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "3"
                 },
                 {
-                    "id": 7551,
+                    "id": 8468,
                     "recurring": false,
                     "statistic_id": 12,
                     "value": "2"
                 },
                 {
-                    "id": 7552,
+                    "id": 8469,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7553,
+                    "id": 8470,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7554,
+                    "id": 8471,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -18950,28 +18950,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6645,
+                    "id": 7479,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6646,
+                    "id": 7480,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6647,
+                    "id": 7481,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6648,
+                    "id": 7482,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19006,25 +19006,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7555,
+                    "id": 8472,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7556,
+                    "id": 8473,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7557,
+                    "id": 8474,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7558,
+                    "id": 8475,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19041,28 +19041,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6649,
+                    "id": 7483,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6650,
+                    "id": 7484,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6651,
+                    "id": 7485,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6652,
+                    "id": 7486,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19097,25 +19097,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7559,
+                    "id": 8476,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7560,
+                    "id": 8477,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7561,
+                    "id": 8478,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7562,
+                    "id": 8479,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19132,28 +19132,28 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6653,
+                    "id": 7487,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6654,
+                    "id": 7488,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6655,
+                    "id": 7489,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6656,
+                    "id": 7490,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19187,25 +19187,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7563,
+                    "id": 8480,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7564,
+                    "id": 8481,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7565,
+                    "id": 8482,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7566,
+                    "id": 8483,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19222,28 +19222,28 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6657,
+                    "id": 7491,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 4,
                     "base_action_side_effect": null,
-                    "id": 6658,
+                    "id": 7492,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 1,
                     "base_action_side_effect": "stress",
-                    "id": 6659,
+                    "id": 7493,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 14,
                     "base_action_side_effect": null,
-                    "id": 6660,
+                    "id": 7494,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19277,25 +19277,25 @@
             "ship_type": 47,
             "statistics": [
                 {
-                    "id": 7567,
+                    "id": 8484,
                     "recurring": false,
                     "statistic_id": 8,
                     "value": "2"
                 },
                 {
-                    "id": 7568,
+                    "id": 8485,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "1"
                 },
                 {
-                    "id": 7569,
+                    "id": 8486,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "8"
                 },
                 {
-                    "id": 7570,
+                    "id": 8487,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "3"
@@ -19312,21 +19312,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6661,
+                    "id": 7495,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6662,
+                    "id": 7496,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6663,
+                    "id": 7497,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19356,25 +19356,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7571,
+                    "id": 8488,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7572,
+                    "id": 8489,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7573,
+                    "id": 8490,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7574,
+                    "id": 8491,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19391,21 +19391,21 @@
                 {
                     "base_action_id": 2,
                     "base_action_side_effect": null,
-                    "id": 6664,
+                    "id": 7498,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6665,
+                    "id": 7499,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6666,
+                    "id": 7500,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19435,25 +19435,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7575,
+                    "id": 8492,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7576,
+                    "id": 8493,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7577,
+                    "id": 8494,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7578,
+                    "id": 8495,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19470,21 +19470,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6667,
+                    "id": 7501,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6668,
+                    "id": 7502,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6669,
+                    "id": 7503,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19514,25 +19514,25 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7579,
+                    "id": 8496,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7580,
+                    "id": 8497,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7581,
+                    "id": 8498,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7582,
+                    "id": 8499,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
@@ -19549,21 +19549,21 @@
                 {
                     "base_action_id": 9,
                     "base_action_side_effect": null,
-                    "id": 6670,
+                    "id": 7504,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 5,
                     "base_action_side_effect": null,
-                    "id": 6671,
+                    "id": 7505,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 },
                 {
                     "base_action_id": 8,
                     "base_action_side_effect": "stress",
-                    "id": 6672,
+                    "id": 7506,
                     "related_action_id": null,
                     "related_action_side_effect": null
                 }
@@ -19589,31 +19589,31 @@
             "ship_type": 48,
             "statistics": [
                 {
-                    "id": 7583,
+                    "id": 8500,
                     "recurring": false,
                     "statistic_id": 10,
                     "value": "2"
                 },
                 {
-                    "id": 7584,
+                    "id": 8501,
                     "recurring": false,
                     "statistic_id": 1,
                     "value": "2"
                 },
                 {
-                    "id": 7585,
+                    "id": 8502,
                     "recurring": false,
                     "statistic_id": 2,
                     "value": "2"
                 },
                 {
-                    "id": 7586,
+                    "id": 8503,
                     "recurring": false,
                     "statistic_id": 3,
                     "value": "2"
                 },
                 {
-                    "id": 7587,
+                    "id": 8504,
                     "recurring": false,
                     "statistic_id": 7,
                     "value": "3"
@@ -20685,7 +20685,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
@@ -20724,7 +20724,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, todos os resultados <hit>/<crit> atribuem fichasde interferência em vez de causarem dano.",
@@ -20763,7 +20763,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Se esteataque acertar, todosos resultados <hit>/<crit> atribuem fichas de traçãoem vez de causarem dano.",
@@ -20802,7 +20802,7 @@
                 3
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 3"
+            "weapon_range": "1 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque</smallcaps>",
@@ -20849,7 +20849,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque:</smallcaps> Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
@@ -20897,7 +20897,7 @@
                 4
             ],
             "weapon_no_bonus": false,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste1<nonbreak><standardcharge>. Mude 1 resultado<hit> para um resultado <crit>.",
@@ -20989,7 +20989,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>. Mude 1 resultado<nonbreak><hit> para um resultado <crit>.",
@@ -21036,7 +21036,7 @@
                 5
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><focus><smallcaps>):</smallcaps> Gaste1<nonbreak><standardcharge>. Se o defensorestiver em seu <bullseye>, você pode gastar 1 ou mais <standardcharge> para rerrolar essa mesma quantidade em dados de ataque.",
@@ -21080,7 +21080,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>. Após este ataque, vocêpode realizá-lo novamente como ataque bônus contraum alvo diferente em alcance 0-1 do defensor, ignorandoo requisito <targetlock>.",
@@ -21126,7 +21126,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>. Após este ataque acertar, cada nave em alcance 0-1do defensor expõe 1 desuas cartas de dano.",
@@ -21172,7 +21172,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>. Após você declarar o defensor, ele pode sofrer1 dano<nonbreak><hit>. Se ele fizer isso, pule as etapas de Dadosde Ataque e de Defesae considere oataque um acerto.",
@@ -21217,7 +21217,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><targetlock><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>.Se este ataque acertar, gaste 1 resultado <hit> ou <crit> para fazer com que o defensor sofra 1 dano <hit>. Todos os resultados <hit>/<crit> restantes atribuem fichas de íon em vez de causarem dano.",
@@ -21262,7 +21262,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "2 - 3"
+            "weapon_range": "2 – 3"
         },
         {
             "ability_text": "<smallcaps>Ataque (</smallcaps><focus><smallcaps>):</smallcaps> Gaste 1<nonbreak><standardcharge>.",
@@ -21307,7 +21307,7 @@
                 6
             ],
             "weapon_no_bonus": true,
-            "weapon_range": "1 - 2"
+            "weapon_range": "1 – 2"
         },
         {
             "ability_text": "Quando defender, antes que osdados de ataque sejam rolados, você pode gastar uma mira sua travada no atacante para rolar 1 dado de ataque. Se você fizer isso, o atacante recebe 1 ficha de interferência. Então, em um resultado <hit> ou <crit>, receba 1 ficha de interferência.",

--- a/translation_helper/jsonDownloader.py
+++ b/translation_helper/jsonDownloader.py
@@ -43,8 +43,11 @@ for lang in languages:
     # Download the file from `url` and save it locally under `file_name`:
     with requests.get(url, headers=headers) as response, io.open(filename, 'w', encoding='utf8') as outfile:
         print('Processing JSON file...')
-
-        # We make the file more readable before saving it.
         obj = response.json()
+
+        # Sort the cards array by id to make it better comparable
+        sorted_cards = sorted(obj["cards"], key=lambda k: k["id"])
+        obj = {"cards": sorted_cards}
+        # Save the JSON to an easily readable file.
         json.dump(obj, outfile, sort_keys=True, indent=4, ensure_ascii=False)
         print("Wrote to " + filename + ".")


### PR DESCRIPTION
Since the order keeps changing the "cards" list is now sorted by the card IDs.
This makes the comparison (via "diff" or similar) far more easy when a new version is out.

Also already updated the version and noted the changes in the commit message.